### PR TITLE
Revise agent-memory-design workshop with role axis

### DIFF
--- a/kb/work/agent-memory-design/explore-boundary-and-graduation.md
+++ b/kb/work/agent-memory-design/explore-boundary-and-graduation.md
@@ -20,7 +20,7 @@ Quick map of the main project artifacts by class and role:
 | Changelogs | Prose | Knowledge |
 | Issue threads | Prose | Mostly knowledge |
 
-Memory system artifacts (session logs, observations, cues, notes) span both roles. The pattern: memory fills in the prose-role cells that project artifacts under-serve, and provides the signal for which symbolic system-definition artifacts (tests, lint rules) are worth codifying.
+Memory system artifacts (session logs, observations, cues, notes) span both roles. The pattern: memory fills in the prose cells that project artifacts under-serve, and provides the signal for which symbolic system-definition artifacts (tests, lint rules) are worth codifying.
 
 ### Code
 

--- a/kb/work/agent-memory-design/explore-boundary-and-graduation.md
+++ b/kb/work/agent-memory-design/explore-boundary-and-graduation.md
@@ -4,7 +4,23 @@ Workshop: [agent-memory-design](./framing.md)
 
 ## 1. The boundary, artifact by artifact
 
-The framing proposes: "the memory system stores what project artifacts don't preserve." Let's stress-test this against every artifact type in a typical software project.
+The framing proposes: "the memory system stores what project artifacts don't preserve." Let's stress-test this against every artifact type in a typical software project. The [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md) gives us a grid — class (opaque/prose/symbolic), backend (where it lives), role (knowledge vs system-definition) — that lets us place each artifact precisely. The boundary isn't a single line; it's a pattern of which cells project artifacts occupy and which cells the memory system fills in.
+
+Quick map of the main project artifacts by class and role:
+
+| Artifact | Class | Role |
+|---|---|---|
+| Code | Symbolic | System-definition |
+| Tests | Symbolic | System-definition |
+| Lint rules / CI checks | Symbolic | System-definition |
+| Docs / README | Prose | Knowledge |
+| ADRs | Prose | Knowledge |
+| Code comments | Prose | Mixed (usually knowledge, sometimes system-definition warnings) |
+| CLAUDE.md | Prose | System-definition |
+| Changelogs | Prose | Knowledge |
+| Issue threads | Prose | Mostly knowledge |
+
+Memory system artifacts (session logs, observations, cues, notes) span both roles. The pattern: memory fills in the prose-role cells that project artifacts under-serve, and provides the signal for which symbolic system-definition artifacts (tests, lint rules) are worth codifying.
 
 ### Code
 
@@ -24,11 +40,11 @@ CI config preserves *what checks run*. It doesn't preserve: why a check was adde
 
 ### CLAUDE.md / agent instructions
 
-This is the interesting edge case. CLAUDE.md is *already* a memory artifact — it stores routing knowledge the agent needs every session. The boundary question: what belongs in CLAUDE.md vs. the broader memory system?
+This is the interesting edge case. CLAUDE.md is *already* a memory artifact in prose-class, system-definition role — it is the always-load policy file. The boundary question: what belongs in CLAUDE.md vs. the broader memory system?
 
-Proposed distinction: **CLAUDE.md is compiled routing; the memory system is the source.** CLAUDE.md holds the distilled, always-load instructions. The memory system holds the session experiences that revealed what CLAUDE.md needs to say. When a user corrects the agent three times for the same mistake, the correction pattern lives in session logs (memory system) and eventually graduates to a CLAUDE.md entry (project artifact). CLAUDE.md is the deployment artifact; the memory system is the learning substrate.
+Proposed distinction: **CLAUDE.md is compiled system-definition; the memory system is the source.** CLAUDE.md holds the distilled, always-load instructions — the most context-expensive system-definition slot in the whole architecture, because every token in it costs every session. The memory system holds the session experiences that revealed what CLAUDE.md needs to say, plus the larger body of system-definition cues that are cheap enough (because they fire on demand) not to need always-load promotion. When a user corrects the agent three times for the same mistake, the correction pattern lives in session logs (memory system) and either graduates to a typed cue (system-definition, fires on trigger) or further to a CLAUDE.md entry (system-definition, always loaded) depending on how often the trigger would fire anyway.
 
-This means CLAUDE.md and the memory system have a producer-consumer relationship, not a boundary. The memory system feeds CLAUDE.md; CLAUDE.md is one of several graduation destinations.
+This means CLAUDE.md and the memory system have a producer-consumer relationship, not a boundary. The memory system feeds CLAUDE.md; CLAUDE.md is one of several graduation destinations within the system-definition role.
 
 ### ADRs
 
@@ -54,7 +70,9 @@ Proposed heuristic: **if the knowledge is load-bearing for understanding the adj
 
 ### Summary: where the framing breaks down
 
-The "stores what project artifacts don't preserve" principle is *necessary but not sufficient*. Two problems:
+The class/role grid gives the first-pass answer: the memory system mostly fills prose cells that project artifacts can't fill, in both roles, while preserving the provenance that makes graduation possible. Code occupies the symbolic system-definition cell; the memory system adds the knowledge cell alongside (the reasoning that code can't carry). Docs occupy the prose knowledge cell; the memory system adds the system-definition cell alongside (cues that fire when the agent would repeat a documented mistake).
+
+But "stores what project artifacts don't preserve" as a single principle is *necessary but not sufficient*. Two problems:
 
 1. **Overlap zone.** Some knowledge legitimately belongs in both places. An ADR is a project artifact *and* a memory artifact. A CLAUDE.md entry is a project artifact *and* routing knowledge derived from memory. The boundary isn't a line — it's a gradient with artifacts that have a foot in both worlds.
 
@@ -68,9 +86,9 @@ A better formulation: **The memory system is the substrate from which project ar
 
 ## 2. Graduation pathways
 
-When does a pattern in session logs become a durable artifact?
+When does a pattern in session logs become a durable artifact? The destination depends on role first, then on class. System-definition patterns graduate toward CLAUDE.md, conventions, lint rules, tests, scripts — moving along the codification gradient as the pattern stabilizes. Knowledge patterns graduate toward ADRs, notes, documentation. The same source pattern sometimes produces graduates in both roles: a recurring correction may yield a lint rule (symbolic system-definition) and an ADR (prose knowledge) that explains why the rule exists.
 
-### Session log -> ADR
+### Session log -> ADR (knowledge role)
 
 **Trigger:** A decision was debated across multiple sessions, or a past decision was questioned and the answer required reconstructing context that wasn't documented.
 
@@ -84,7 +102,7 @@ When does a pattern in session logs become a durable artifact?
 
 **Example:** Sessions 12, 15, and 23 all touch on whether to use a monorepo or multi-repo. Session 23 finally commits to monorepo. An ADR captures the conclusion; the sessions preserve the full deliberation.
 
-### Session log -> Documented procedure
+### Session log -> Documented procedure (system-definition role)
 
 **Trigger:** The same workflow appears in 3+ sessions, possibly with slight variations that converge over time.
 
@@ -98,7 +116,7 @@ When does a pattern in session logs become a durable artifact?
 
 **Example:** In sessions 8, 14, 22, and 31, the user asks the agent to "do the release process." Each time, the agent figures out the steps from scratch (or loads the same context). After the fourth occurrence, the pattern graduates to a documented release procedure.
 
-### Session log -> Linting rule or test
+### Session log -> Linting rule or test (system-definition role, symbolic class)
 
 **Trigger:** A constraint was violated repeatedly, and each violation was caught and corrected manually.
 
@@ -114,7 +132,7 @@ When does a pattern in session logs become a durable artifact?
 
 This is the constraining gradient in action: observation -> documented convention -> automated check -> deterministic enforcement.
 
-### Session log -> CLAUDE.md entry
+### Session log -> CLAUDE.md entry (system-definition role, always-loaded)
 
 **Trigger:** The agent repeatedly needs the same routing or context knowledge at session start, and it's not currently in the always-loaded context.
 
@@ -128,7 +146,7 @@ This is the constraining gradient in action: observation -> documented conventio
 
 **Example:** In five consecutive sessions, the user reminds the agent that this project uses pnpm, not npm. The correction graduates from session-level to CLAUDE.md: "This project uses pnpm. Do not use npm."
 
-### Session log -> Code comment
+### Session log -> Code comment (usually knowledge role)
 
 **Trigger:** A piece of context was needed to understand or modify a specific code location, and it wasn't obvious from the code itself.
 
@@ -149,11 +167,12 @@ A useful way to model the shared structure:
 1. **Observation** — something happens in a session (a decision, a correction, a recurring pattern)
 2. **Accumulation** — the memory system records it
 3. **Recognition** — the pattern is noticed (by repetition count, by search cost, by correction frequency)
-4. **Distillation** — the raw observations are compressed into a durable artifact
-5. **Placement** — the artifact goes to its proper home (ADR, procedure, test, CLAUDE.md, comment)
-6. **Provenance** — the session logs remain as source material, linked from the graduated artifact
+4. **Role assignment** — decide whether the graduated artifact is consumed as fact (knowledge) or as policy (system-definition), or both. Some source patterns naturally commit to one role (corrections → system-definition); others produce paired artifacts (a debated decision → ADR + cue).
+5. **Distillation** — the raw observations are compressed into a durable artifact in the assigned role
+6. **Placement** — the artifact goes to its proper home (ADR, procedure, test, CLAUDE.md, comment), selected by role and by how tightly the pattern can be constrained
+7. **Provenance** — the session logs remain as source material, linked from the graduated artifact
 
-Recognition is the bottleneck. Automated recognition is possible for some signals (repetition count, correction frequency) but hard for others (when a decision becomes "load-bearing enough" to warrant an ADR). This maps directly to the agency trilemma from the comparative review: high-quality graduation decisions require context that costs reasoning budget.
+Recognition is the bottleneck. Automated recognition is possible for some signals (repetition count, correction frequency) but hard for others (when a decision becomes "load-bearing enough" to warrant an ADR). This maps directly to the agency trilemma from the comparative review: high-quality graduation decisions require context that costs reasoning budget. Role assignment is a second, related judgment — automatable for clear cases (a repeated correction is always system-definition) but requiring taste for ambiguous ones (a discovery with unclear operational implications).
 
 ## 3. Relationship to existing manual distillation processes
 
@@ -188,6 +207,8 @@ The KB's reach concept (from Deutsch via the ephemerality note) maps cleanly ont
 **High-reach knowledge wants to be in the library layer.** "Systems that optimize for normal-load efficiency sacrifice overload resilience" applies to many contexts. It belongs in a permanent note, not in session logs.
 
 **Low-reach knowledge can stay in session logs.** "The bug in PR #247 was caused by a race condition in the connection pool" is specific to that PR. It doesn't need to graduate — the PR itself and the fix commit carry the essential information.
+
+Reach behaves differently across roles. For knowledge-role artifacts, reach means how widely the claim applies — a generalizable principle covers many future questions. For system-definition-role artifacts, reach is narrower and stranger: a cue is valuable when it fires accurately in the situations it covers, not when it fires in many unrelated ones. A broad cue that over-fires wastes context; a narrow cue that fires accurately earns its budget. Graduating to CLAUDE.md moves a cue from on-demand to always-loaded — the reach increases in a different sense (fires every session) but so does the context cost. The system-definition graduation question is "does this fire enough to earn its slot?" not "does it apply widely?"
 
 **But here's the tension: you often can't tell the reach of an observation when you first make it.** The connection pool race condition might be a one-off (low reach), or it might be the third instance of a pattern where async resource pools need explicit shutdown ordering (high reach). You only discover the reach by accumulating instances.
 

--- a/kb/work/agent-memory-design/explore-layered-architecture.md
+++ b/kb/work/agent-memory-design/explore-layered-architecture.md
@@ -38,9 +38,10 @@ Concrete examples from the framing's taxonomy:
 
 Each observation is:
 - **Typed** (decision, correction, preference, discovery, question, procedure-fragment). This list is illustrative, not exhaustive — plausible additional types include affective/engagement signals (frustration, satisfaction, disengagement patterns) and meta-operational observations (observations about the memory system's own behavior, such as "retrieval missed a relevant note" or "extraction pipeline misclassified X").
+- **Role-tagged** — knowledge (consumed as fact) or system-definition (consumed as policy), following the [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md). Some types have a natural role (corrections are system-definition; negative results are knowledge). Others are role-ambiguous at extraction and produce paired artifacts (a decision observation yields both a knowledge record "why we chose A" and a system-definition cue keyed on the rejected alternative).
 - **Timestamped** and linked to source session(s)
 - **Scored** — confidence (how certain is the extraction?) and importance (how likely to matter later?)
-- **Indexed** for retrieval — keywords, tags, embeddings, whatever the retrieval layer needs
+- **Indexed** for retrieval — keywords, tags, embeddings, whatever the retrieval layer needs; the role tag selects which index the observation populates (search+navigation indexes for knowledge, trigger indexes for system-definition)
 
 The observation layer is where [ClawVault](../../agent-memory-systems/reviews/clawvault.md), a scored-observation memory system with session lifecycle management and promotion pipelines (see the [comparative review](../../agent-memory-systems/agentic-memory-systems-comparative-review.md)), is most instructive: scored observations with explicit types and promotion pathways. The difference from ClawVault: we derive observations from stored traces rather than extracting them at interaction time. This decouples capture speed from extraction quality — the extraction pipeline can be rerun, improved, and backfilled.
 
@@ -124,11 +125,13 @@ This is the less obvious direction but equally important. Library notes should g
 
 Concretely: a library note about "prefer staging specific files over `git add -A`" should generate observation-layer entries that activate when a session involves git staging. The activation cue is: "when the agent is about to run git add, check if the user has a preference about staging strategy."
 
-## How does "store everything" interact with lifecycle separation?
+## How does "store everything" interact with lifecycle and role?
 
-The framing identifies three memory spaces with different metabolic rates: knowledge (steady growth), self (slow evolution), operational (high churn). If you store everything, the separation moves from storage to retrieval — you tag/index differently rather than storing differently.
+The framing identifies three memory spaces with different metabolic rates: knowledge (steady growth), self (slow evolution), operational (high churn). If you store everything, the separation moves from storage to retrieval — you tag/index differently rather than storing differently. The role axis adds a second orthogonal tag: knowledge vs system-definition. A single observation carries both a lifecycle tag (how fast does it churn?) and a role tag (how is it consumed?).
 
-This is mostly right, but with a nuance: **the layers interact with the lifecycle separation, not orthogonally to it.**
+Note a terminology collision: the three-space model uses "knowledge" as one of three lifecycle spaces (the one with long-lived factual accumulation), while the role axis uses "knowledge" as one of two consumption roles (consumed as fact). The two senses overlap but do not coincide. An operational-space observation about a debugging procedure is typically system-definition in role (fire it when the situation recurs). A self-space observation about preferences is also system-definition. Lifecycle and role answer different questions — *when does this expire?* vs *how is this consumed?* — and both matter for retrieval.
+
+With that said, the layers interact with the lifecycle separation, not orthogonally to it.
 
 | Layer | Knowledge content | Self content | Operational content |
 |-------|------------------|-------------|-------------------|
@@ -142,7 +145,7 @@ The metabolic rate applies within each layer:
 - Self observations evolve slowly — a preference observed 5 times is likely stable
 - Knowledge observations accumulate — a factual discovery doesn't expire (though it may be superseded)
 
-So the practical implication is: **tag observations by lifecycle space, and use the tag in promotion heuristics.** A knowledge observation with high recurrence should promote to a library note. An operational observation with high recurrence should promote to a procedure. A self observation that recurs across many sessions should promote to CLAUDE.md. Different promotion thresholds, different target artifacts, same pipeline.
+So the practical implication is: **tag observations by lifecycle space *and* role, and use both tags in promotion heuristics.** A knowledge-space + knowledge-role observation with high recurrence should promote to a library note. An operational-space + system-definition-role observation with high recurrence should promote to a procedure (prose) or script (symbolic). A self-space + system-definition-role observation that recurs across many sessions should promote to CLAUDE.md. Different promotion thresholds, different target artifacts, same pipeline. The role tag determines *what kind of artifact* to produce; the lifecycle tag determines *how aggressively to promote and expire*.
 
 This is more useful than storing them separately. Separate storage creates boundaries that inhibit cross-space connections (a debugging procedure might reveal a knowledge insight; a self-preference might have implications for operational workflow). Unified storage with lifecycle tags preserves those connections while still allowing lifecycle-appropriate retrieval.
 

--- a/kb/work/agent-memory-design/explore-learning-from-logs.md
+++ b/kb/work/agent-memory-design/explore-learning-from-logs.md
@@ -4,11 +4,17 @@ Workshop exploration for questions 7-9 from the [framing](./framing.md).
 
 ## The extraction taxonomy
 
-Session logs contain at least four distinct signal types. They differ in oracle clarity, extraction difficulty, and promotion pathway.
+Session logs contain at least four distinct signal types. They differ in oracle clarity, extraction difficulty, promotion pathway, and — following the [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md) — the role the extracted artifact plays when consumed.
 
-### 1. Correction consolidation
+Role sorts the four types cleanly. Corrections, preferences, and procedures are **system-definition**: the extracted artifact is consumed as policy that changes what the agent does. Decision provenance and negative results (covered in the framing and synthesis) are **knowledge**: they are consumed as reference to answer "why" questions. Discoveries start as knowledge candidates and may graduate into either role — or both, if the insight both deserves a note (knowledge) and implies a cue (system-definition).
+
+The role affects how the graduated artifact is used, how retrieval finds it, and what destination makes sense. A correction that graduates as a CLAUDE.md entry (system-definition, prose) serves a different consumer than the ADR that documents *why* the correction exists (knowledge, prose). Both can come from the same underlying pattern.
+
+### 1. Correction consolidation (system-definition)
 
 **What it is.** The user says "no, do X instead," "that's wrong," or rejects a tool call and provides a different instruction. The session log records the wrong output, the rejection signal, and the corrected direction.
+
+**Role.** System-definition. The graduated artifact's job is to prevent the wrong action next time. A correction may also seed a companion knowledge artifact ("why do we prefer approach B?") but the primary product is a constraint on future behavior.
 
 **Example extracted artifact:**
 
@@ -26,9 +32,11 @@ occurrences: 3
 
 **Graduated artifact:** A rule in CLAUDE.md, a convention in WRITING.md, a preference in a memory file, or (at the far end of codification) a linting check or validation script.
 
-### 2. Preference mining
+### 2. Preference mining (system-definition)
 
 **What it is.** The user consistently accepts certain patterns and rejects others, but never explicitly articulates a rule. The signal is distributed across many sessions — no single session contains enough evidence.
+
+**Role.** System-definition. A preference steers future choices; it is not primarily consumed to answer questions.
 
 **Example extracted artifact:**
 
@@ -53,9 +61,11 @@ confidence: 0.8  # 6 accepts, 2 rejects matching pattern
 
 **Graduated artifact:** A style guide entry, a CLAUDE.md instruction, a configuration setting. The hardest preferences to graduate are taste-based ones ("I prefer shorter function names") that resist codification into deterministic rules.
 
-### 3. Procedure extraction
+### 3. Procedure extraction (system-definition)
 
 **What it is.** The same workflow recurs across sessions: "search for related notes, read the type template, write the note, connect it, validate." The session log records each step; across sessions, the recurring sequence becomes visible.
+
+**Role.** System-definition. A procedure is consumed to steer how a task is performed. The codification gradient (instruction → skill → script) stays within the system-definition role while shifting class (prose → prose with formal shape → symbolic).
 
 **Example extracted artifact:**
 
@@ -82,9 +92,11 @@ variations:
 
 **Graduated artifact:** An instruction file (if human judgment is needed at steps), a skill (if it can be automated with parameters), or a script (if it is fully deterministic). The graduation pathway mirrors the codification spectrum from the KB's theory.
 
-### 4. Discovery flagging
+### 4. Discovery flagging (knowledge, sometimes system-definition)
 
 **What it is.** During work, an insight emerges — a connection between ideas, a design principle, an abstraction that unifies several observations. These are the highest-value extractions and the hardest to detect automatically.
+
+**Role.** Discoveries enter as knowledge: claims that grow the agent's reach when retrieved for reference. Some develop a system-definition companion after the fact — a discovery about async resource cleanup may produce both a note (knowledge) and a cue that fires when the agent writes async cleanup code (system-definition). Role is assigned at graduation, not extraction, because the operational implications are visible only with use.
 
 **Example extracted artifact:**
 
@@ -145,23 +157,23 @@ Runs periodically (daily? weekly? on explicit trigger?). Reviews accumulated can
 
 These thresholds are untested starting points for discussion, not empirically validated numbers. They should be calibrated against real session data before any implementation.
 
-| Type | Promotion signal | Threshold sketch |
-|------|-----------------|-----------------|
-| Correction | Same mistake corrected N times | N >= 2, different sessions |
-| Preference | Consistent accept/reject pattern | 5+ instances, 80%+ consistency, 3+ sessions |
-| Procedure | Same tool-call subsequence recurs | 3+ sessions with aligned subsequence |
-| Discovery | Referenced or re-derived in later sessions | 2+ later references, or explicit user flag |
+| Type | Promotion signal | Threshold sketch | Role |
+|------|-----------------|-----------------|------|
+| Correction | Same mistake corrected N times | N >= 2, different sessions | System-definition |
+| Preference | Consistent accept/reject pattern | 5+ instances, 80%+ consistency, 3+ sessions | System-definition |
+| Procedure | Same tool-call subsequence recurs | 3+ sessions with aligned subsequence | System-definition |
+| Discovery | Referenced or re-derived in later sessions | 2+ later references, or explicit user flag | Knowledge (may add system-definition companion) |
 
 The promotion filter is itself a judgment-heavy operation. It sits on the inspectability-learnability spectrum from the memory-management-policy note. Starting with inspectable heuristic rules (threshold-based, like the table above) makes sense. Whether to learn the promotion policy from data (like AgeMem's RL-trained policy) depends on having enough volume — and on having an oracle for "was this promotion good?", which loops back to the core problem.
 
 ### Stage 4: Graduation
 
-A promoted candidate becomes a library artifact. The specific form depends on the type:
+A promoted candidate becomes a library artifact. The specific form depends on both the source type and the role the graduated artifact will play:
 
-- **Correction -> rule/convention.** Codifiable corrections become CLAUDE.md entries or validation checks. Judgment-dependent corrections become documented conventions.
-- **Preference -> style guide / configuration.** Preferences with high consistency become explicit instructions. Preferences with lower consistency become documented tendencies with exceptions noted.
-- **Procedure -> instruction / skill / script.** Along the codification spectrum: instructions (human-in-the-loop), skills (agent-automated with parameters), scripts (fully deterministic).
-- **Discovery -> note.** The hardest graduation because the artifact needs to be well-written, well-connected, and situated within the existing KB structure. This is the only graduation type that cannot be fully automated — it requires the authorial judgment the KB's writing methodology demands.
+- **Correction -> rule/convention (system-definition).** Codifiable corrections become CLAUDE.md entries or validation checks. Judgment-dependent corrections become documented conventions. Optionally produces a companion knowledge artifact (an ADR or note) explaining *why* the convention exists.
+- **Preference -> style guide / configuration (system-definition).** Preferences with high consistency become explicit instructions. Preferences with lower consistency become documented tendencies with exceptions noted.
+- **Procedure -> instruction / skill / script (system-definition).** Along the codification spectrum: instructions (prose), skills (prose with formal shape), scripts (symbolic). Role stays constant; class tightens.
+- **Discovery -> note (knowledge), possibly plus cue (system-definition).** The primary graduation is a knowledge artifact: a note, structured claim, or new index entry. If the discovery has clear operational implications, it also produces a system-definition cue. This is the hardest graduation because the knowledge artifact needs authorial judgment — the only graduation type that cannot be fully automated.
 
 ## Session logs as oracle substrate
 
@@ -218,7 +230,7 @@ A practical system should start at the easy end and work up. Correction consolid
 
 ## Open threads
 
-**Deduplication across extraction types.** A correction ("don't sort imports alphabetically") may also be a preference observation ("prefers grouped imports") and eventually a procedure fragment ("import ordering step in code review"). The same underlying knowledge can appear in multiple extraction schemas. Does the system merge them? Keep them separate and let the promotion filter sort it out? The answer probably depends on whether the graduated artifacts differ — if a correction becomes a rule and a preference becomes a style guide entry, they are different artifacts serving different functions even if derived from the same underlying pattern.
+**Deduplication across extraction types.** A correction ("don't sort imports alphabetically") may also be a preference observation ("prefers grouped imports") and eventually a procedure fragment ("import ordering step in code review"). The same underlying knowledge can appear in multiple extraction schemas. Does the system merge them? Keep them separate and let the promotion filter sort it out? The answer probably depends on whether the graduated artifacts differ — if a correction becomes a rule and a preference becomes a style guide entry, they are different artifacts serving different functions even if derived from the same underlying pattern. The role axis adds a further distinction: a single source may legitimately produce both a system-definition cue (the lint rule) and a knowledge note (the explanation of why the convention exists). These are not duplicates; they serve different consumers.
 
 **Extraction timing.** Pi Self-Learning extracts at session end. ClawVault extracts incrementally during the session. Napkin extracts on a timer. The right timing depends on the signal type: corrections are best extracted immediately (the context is fresh), preferences need cross-session accumulation (no single session has enough data), procedures need enough sessions to detect recurrence. A system with multiple extraction types probably needs multiple extraction clocks.
 

--- a/kb/work/agent-memory-design/explore-retrieval-activation.md
+++ b/kb/work/agent-memory-design/explore-retrieval-activation.md
@@ -158,7 +158,7 @@ The comparative review identifies a deep split: Mem0/Graphiti/Cognee treat knowl
 |---|---|---|---|---|
 | Raw session logs | Complete interaction transcripts | "Find the session where we discussed X" | Full-text search + temporal filtering | Substrate (ambiguous) |
 | Extracted cues | Typed trigger-lesson pairs | "What corrections apply to this action?" | Action-type index + embedding match | System-definition |
-| Synthesized artifacts | Consolidated preferences, procedures, precedents | "What are our conventions for X?" | Navigable links from domain indexes | Mixed (preferences/procedures are system-definition; precedents are knowledge) |
+| Synthesized artifacts | Consolidated preferences, procedures, precedents | "What are our conventions for X?" | Navigable links from domain indexes | Mixed (preferences/procedures are system-definition; precedents span both roles) |
 | Library notes | Curated knowledge with articulated relationships | "How does X relate to Y?" | Link traversal + semantic navigation | Knowledge |
 
 **Search works for the lower layers** (raw logs and extracted cues) because the access pattern is retrieval: you have a query and you want matching items. The items are numerous, weakly structured, and connected only by temporal co-occurrence or semantic similarity. Extracted cues, although stored like search-retrievable records, are activated differently — the trigger is the agent's proposed action, not a query.

--- a/kb/work/agent-memory-design/explore-retrieval-activation.md
+++ b/kb/work/agent-memory-design/explore-retrieval-activation.md
@@ -1,6 +1,15 @@
 # Exploration: How does the memory system find and activate the right information?
 
-This explores the retrieval and activation layer of a store-everything agent memory system. The framing assumes storage is cheap and complete (all session logs, all artifacts). The hard problem is finding the right information at the right time under bounded context. Grounded in the KB's activation gap analysis, action-capacity framing, elicitation strategies, statelessness constraint, and the comparative review of 11 memory systems.
+This explores the retrieval and activation layer of a store-everything agent memory system. The framing assumes storage is cheap and complete (all session logs, all artifacts). The hard problem is finding the right information at the right time under bounded context. Grounded in the KB's activation gap analysis, action-capacity framing, elicitation strategies, statelessness constraint, the comparative review of 11 memory systems, and the [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md) role distinction.
+
+## Retrieval divides by role, not by content
+
+The central organizing move is to split retrieval by the role the retrieved artifact will play. A single store can serve both roles, but the access patterns differ:
+
+- **Knowledge-role retrieval** answers questions at consumption time. The consumer is the agent or user looking up a fact or navigating to understand a decision. Standard RAG plus articulated links cover this.
+- **System-definition-role activation** injects policy when a situation matches. The consumer is the agent about to act. The "retrieval" is a watcher-plus-trigger, not a query.
+
+Most of the difficulty in this section is system-definition activation — the knowledge retrieval side mostly reuses patterns the KB already documents (search + navigation). The typed cue indexes, priority arbitration, and commitment mechanisms below are all machinery for the system-definition role. The knowledge-role flow sits on top as a less novel layer.
 
 ---
 
@@ -12,7 +21,7 @@ The action-capacity note reframes the problem: the memory system doesn't just an
 
 The activation gap note decomposes activation into cue match, priority arbitration, and commitment. Each stage has a different failure mode and a different design surface.
 
-**Cue match: making relevant knowledge findable.** The system must connect the current task context to stored knowledge even when the surface terms don't overlap. Approaches:
+**Cue match: making relevant system-definition knowledge fire.** The system must connect the agent's proposed action to stored cues even when the surface terms don't overlap. This is specifically the system-definition problem — for knowledge-role retrieval, cue match is just query match and the standard approach (embedding + links) suffices. Approaches:
 
 - *Semantic embedding search* over session logs and extracted artifacts. Standard RAG. Works for factual retrieval ("what did we decide about the API versioning scheme?").
 
@@ -49,13 +58,13 @@ The activation gap note decomposes activation into cue match, priority arbitrati
 
 ### Action-specific retrieval patterns
 
-| Action mode | What to retrieve | Retrieval method |
-|---|---|---|
-| Execution | Corrections for the action type; relevant procedures | Action-type index lookup + semantic match on task description |
-| Classification | Precedent decisions for similar items; active category definitions | Precedent index lookup by item features |
-| Communication | Voice/style patterns; relationship history with the recipient | Entity-keyed retrieval (by person/channel) |
-| Planning | Past plans for similar goals; outcomes of previous approaches | Goal-similarity search + outcome-weighted ranking |
-| Pattern recognition | Historical situations resembling the current one | Situation embedding search with temporal spread |
+| Action mode | What to retrieve | Retrieval method | Role |
+|---|---|---|---|
+| Execution | Corrections for the action type; relevant procedures | Action-type index lookup + semantic match on task description | System-definition |
+| Classification | Precedent decisions for similar items; active category definitions | Precedent index lookup by item features | System-definition (precedents as policy) or Knowledge (category definitions as reference) |
+| Communication | Voice/style patterns; relationship history with the recipient | Entity-keyed retrieval (by person/channel) | System-definition |
+| Planning | Past plans for similar goals; outcomes of previous approaches | Goal-similarity search + outcome-weighted ranking | Mixed — past plans are knowledge; outcome-weighted ranking generates system-definition cues |
+| Pattern recognition | Historical situations resembling the current one | Situation embedding search with temporal spread | Knowledge (providing context) |
 
 ---
 
@@ -145,25 +154,25 @@ The comparative review identifies a deep split: Mem0/Graphiti/Cognee treat knowl
 
 ### Layer map
 
-| Layer | Content | Access pattern | Method |
-|---|---|---|---|
-| Raw session logs | Complete interaction transcripts | "Find the session where we discussed X" | Full-text search + temporal filtering |
-| Extracted cues | Typed trigger-lesson pairs | "What corrections apply to this action?" | Action-type index + embedding match |
-| Synthesized artifacts | Consolidated preferences, procedures, precedents | "What are our conventions for X?" | Navigable links from domain indexes |
-| Library notes | Curated knowledge with articulated relationships | "How does X relate to Y?" | Link traversal + semantic navigation |
+| Layer | Content | Access pattern | Method | Primary role |
+|---|---|---|---|---|
+| Raw session logs | Complete interaction transcripts | "Find the session where we discussed X" | Full-text search + temporal filtering | Substrate (ambiguous) |
+| Extracted cues | Typed trigger-lesson pairs | "What corrections apply to this action?" | Action-type index + embedding match | System-definition |
+| Synthesized artifacts | Consolidated preferences, procedures, precedents | "What are our conventions for X?" | Navigable links from domain indexes | Mixed (preferences/procedures are system-definition; precedents are knowledge) |
+| Library notes | Curated knowledge with articulated relationships | "How does X relate to Y?" | Link traversal + semantic navigation | Knowledge |
 
-**Search works for the lower layers** (raw logs and extracted cues) because the access pattern is retrieval: you have a query and you want matching items. The items are numerous, weakly structured, and connected only by temporal co-occurrence or semantic similarity.
+**Search works for the lower layers** (raw logs and extracted cues) because the access pattern is retrieval: you have a query and you want matching items. The items are numerous, weakly structured, and connected only by temporal co-occurrence or semantic similarity. Extracted cues, although stored like search-retrievable records, are activated differently — the trigger is the agent's proposed action, not a query.
 
-**Navigation works for the upper layers** (synthesized artifacts and library notes) because the access pattern is reasoning: you have a starting point and you want to follow connections to build understanding. The items are fewer, richly structured, and connected by articulated relationships.
+**Navigation works for the upper layers** (synthesized artifacts and library notes) because the access pattern is reasoning: you have a starting point and you want to follow connections to build understanding. The items are fewer, richly structured, and connected by articulated relationships. Navigation is natural for knowledge-role consumption (a human or agent looking up "why" and following links); it serves system-definition consumption poorly because it assumes someone is already asking a question rather than acting.
 
-### Composition: search feeds navigation
+### Composition: activation, search, and navigation
 
-The two approaches compose vertically. A typical retrieval flow:
+Three access patterns compose, and they sort by role. A typical full retrieval flow:
 
-1. **Search** raw logs and extracted cues for items matching the current task context.
-2. **Follow links** from matched items to synthesized artifacts and library notes.
-3. **Navigate** the library layer to gather related context.
-4. **Load** the assembled context into the agent's working memory.
+1. **Activation** fires any system-definition cues whose triggers match the agent's proposed action. Correction cues load imperatively; preference and procedure cues fill their reserved slots.
+2. **Search** over the lower layers surfaces knowledge-role records related to the task (past decisions, negative results, relevant notes).
+3. **Navigate** from matched knowledge records through articulated links to library notes, assembling the connected reasoning.
+4. **Load** the assembled context into the agent's working memory, with system-definition items framed as instructions and knowledge items as reference.
 
 Example: Agent is writing a database migration.
 1. Search finds 3 correction cues related to migrations.
@@ -179,9 +188,9 @@ Possible mechanism: when a new correction cue is extracted in domain D, query fo
 
 ---
 
-## 5. Finding "why" across thousands of sessions
+## 5. Finding "why" across thousands of sessions (knowledge-role retrieval)
 
-The framing identifies a key use case: answering "why did we do it this way?" when the answer is distributed across session logs.
+The framing identifies a key use case: answering "why did we do it this way?" when the answer is distributed across session logs. This is pure knowledge-role retrieval — the consumer is a human or agent asking a question, not an agent about to act. The mechanisms below (decision extraction, backlinks, temporal clustering, negative-result preservation) build the knowledge-role index over session logs. The complementary system-definition retrieval — firing a cue when the agent proposes the already-rejected alternative — is covered by the typed cue indexes in section 1.
 
 ### The problem's structure
 

--- a/kb/work/agent-memory-design/explore-retrieval-activation.md
+++ b/kb/work/agent-memory-design/explore-retrieval-activation.md
@@ -21,7 +21,7 @@ The action-capacity note reframes the problem: the memory system doesn't just an
 
 The activation gap note decomposes activation into cue match, priority arbitration, and commitment. Each stage has a different failure mode and a different design surface.
 
-**Cue match: making relevant system-definition knowledge fire.** The system must connect the agent's proposed action to stored cues even when the surface terms don't overlap. This is specifically the system-definition problem — for knowledge-role retrieval, cue match is just query match and the standard approach (embedding + links) suffices. Approaches:
+**Cue match: making relevant system-definition cues fire.** The system must connect the agent's proposed action to stored cues even when the surface terms don't overlap. This is specifically the system-definition problem — for knowledge-role retrieval, cue match is just query match and the standard approach (embedding + links) suffices. Approaches:
 
 - *Semantic embedding search* over session logs and extracted artifacts. Standard RAG. Works for factual retrieval ("what did we decide about the API versioning scheme?").
 

--- a/kb/work/agent-memory-design/framing.md
+++ b/kb/work/agent-memory-design/framing.md
@@ -36,6 +36,8 @@ This inverts the emphasis of most memory system designs, which spend effort on w
 
 9. **Agent statelessness makes routing architectural** ([statelessness](../../notes/agent-statelessness-makes-routing-architectural-not-learned.md)). Every session is day one; routing infrastructure is permanent prosthetics.
 
+10. **Artifacts have three independent axes** ([axes-of-artifact-analysis](../../notes/axes-of-artifact-analysis.md)). Class (opaque/prose/symbolic) and backend (files, DB, weights) are structural. **Role** (knowledge vs system-definition) is relational: the same bytes are *knowledge* when consumed as fact (grow the agent's reach) and *system-definition* when consumed as policy (change the agent's disposition). The axis matters here because memory in an agent system serves both roles, and they need different extraction, retrieval, and graduation pipelines.
+
 ### What the KB identifies as missing
 
 - **Session logs** — currently not captured at all (noted in [workshop-layer](../../notes/a-functioning-kb-needs-a-workshop-layer-not-just-a-library.md))
@@ -45,18 +47,24 @@ This inverts the emphasis of most memory system designs, which spend effort on w
 
 ## The user's key addition: session logs as primary input
 
-Session interaction logs are a rich, underexploited substrate. They contain:
-- **Decisions made** — what the user chose when alternatives were presented
+Session interaction logs are a rich, underexploited substrate. They contain material that plays both roles:
+
+**System-definition signal** (changes what the agent does):
 - **Corrections** — where the agent went wrong and how it was redirected
-- **Discoveries** — insights that emerged during work
 - **Preferences** — implicit patterns in what the user accepts/rejects
 - **Procedures** — workflows that recur across sessions
-- **Questions asked** — what the user needs to know (activation cues for future sessions)
+
+**Knowledge signal** (grows the agent's reach):
+- **Decisions made** — what the user chose when alternatives were presented, and the alternatives rejected
+- **Discoveries** — insights that emerged during work
+- **Questions asked** — what the user needs to know (both a knowledge signal about gaps *and* a system-definition signal for future-session activation)
+
+The role split matters because a session log is ambiguous at capture time. The same exchange — "we chose approach A after debating approach B" — can be distilled into a knowledge artifact (an ADR answering "why A?") *or* a system-definition artifact (a cue that fires when the agent proposes B again). A useful memory system extracts both from the same raw substrate.
 
 Since storage is cheap, the system should capture all of this. The design challenge is entirely in the retrieval/activation layer:
-- How do you find the relevant precedent from 1000 sessions ago?
-- How do you surface a correction made in session 47 when the same mistake is about to recur in session 312?
-- How do you graduate a pattern observed across 5 sessions into an explicit preference?
+- How do you find the relevant precedent from 1000 sessions ago? (knowledge-role retrieval)
+- How do you surface a correction made in session 47 when the same mistake is about to recur in session 312? (system-definition activation)
+- How do you graduate a pattern observed across 5 sessions into an explicit preference? (graduation, with a choice of role — document the preference as prose for reference, or codify it as a lint rule)
 
 ## Use cases: how memory gets consumed
 
@@ -79,6 +87,8 @@ This generalizes beyond ADRs. Any "why" question — why this architecture, why 
 In a software project, not everything belongs in the memory system. Code, tests, documentation, CI configuration — these are project artifacts with their own homes. The memory system is not a replacement for standard project structure.
 
 The boundary principle: **the memory system stores what project artifacts don't preserve** — the reasoning, context, and process knowledge that produced the artifacts.
+
+Project artifacts divide across the class/role grid: code and tests are symbolic system-definition; docs are prose knowledge; ADRs are prose knowledge; CLAUDE.md is prose system-definition; lint rules are symbolic system-definition. The memory system is the substrate from which prose artifacts in both roles get distilled, and the signal for which symbolic system-definition artifacts are worth codifying (a correction recurring enough times to warrant a lint rule).
 
 | What | Where it lives | Why |
 |------|---------------|-----|
@@ -129,6 +139,8 @@ Core theory:
 - [session-history](../../notes/session-history-should-not-be-the-default-next-context.md)
 - [action-capacity](../../notes/claw-learning-loops-must-improve-action-capacity-not-just-retrieval.md)
 - [contextual competence theory](../../notes/an-agentic-kb-maximizes-contextual-competence-through-discoverable-composable-trusted-knowledge.md)
+- [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md) — class, backend, role; the role axis splits memory's dual function
+- [continual learning: behaviour is the open half](../../notes/continual-learning-open-problem-is-behaviour-not-knowledge.md) — the system-definition role is the under-addressed half
 
 Memory architecture:
 - [comparative review](../../agent-memory-systems/agentic-memory-systems-comparative-review.md)

--- a/kb/work/agent-memory-design/synthesis-ideal-memory-system.md
+++ b/kb/work/agent-memory-design/synthesis-ideal-memory-system.md
@@ -10,6 +10,21 @@ This produces a design inversion. In traditional systems, you optimize storage a
 
 "Store everything" is a bet, not an axiom. It trades storage costs for indexing overhead, search pollution risk, and potential privacy exposure. The bet is that selective retrieval can manage what aggressive storage introduces. But it shifts the hard problem to the right place: the scarce resource is attention, not disk.
 
+## Memory plays two roles
+
+A memory system for agents is not doing one thing. It is doing two things that look superficially similar but differ in how the stored content is consumed, how it is retrieved, and what a durable write changes about the system's behavior. The [axes of artifact analysis](../../notes/axes-of-artifact-analysis.md) names this as the **role** axis: artifacts are consumed in either a **knowledge role** (as fact — durable writes grow the agent's reach) or a **system-definition role** (as policy — durable writes change the agent's disposition).
+
+The distinction is relational, not structural. The same stored bytes can play either role depending on the consumer. A note documenting "we use URL-path versioning" is knowledge when retrieved to answer "how do we version APIs?" and system-definition when loaded to steer the agent's next API design.
+
+For agent memory, the two roles motivate different machinery:
+
+- **Knowledge retrieval** answers questions posed at consumption time. It fits navigation: start with a question, follow links, reason along connections. Standard RAG optimizes for this. Failure mode: the retrieval never happens because no one asked the question.
+- **System-definition activation** injects policy when a matching situation occurs. It fits triggered activation: watch for cues in the agent's proposed action, surface the constraint before commitment. This is the territory the [activation gap](../../notes/knowledge-storage-does-not-imply-contextual-activation.md) note targets. Failure mode: relevant policy is stored but never fires.
+
+Most existing agent-memory systems optimize for knowledge-role retrieval (RAG over stored facts) and underserve the system-definition role — which is [the open half of continual learning](../../notes/continual-learning-open-problem-is-behaviour-not-knowledge.md). "Adding RAG is learning" is true for the knowledge role and empty for the system-definition role.
+
+Session logs are the common substrate. A single correction in session 47 can produce **both** a knowledge artifact (an ADR that answers "why do we use approach B?") and a system-definition artifact (a cue that fires when a future session proposes approach A). The extraction pipeline must produce artifacts in both roles and the retrieval machinery must serve both consumption patterns.
+
 ## Why existing approaches fall short
 
 A comparative analysis of eleven agent memory systems -- from vector-first fact stores (Mem0) through knowledge graphs (Graphiti) to filesystem-first curated systems (Ars Contexta, commonplace) -- reveals three structural problems that no current system fully solves.
@@ -17,6 +32,8 @@ A comparative analysis of eleven agent memory systems -- from vector-first fact 
 **The agency trilemma.** Every memory system must answer: who decides what to remember? If the agent manages its own memory (as Letta does), it has full context but burns reasoning tokens on housekeeping. If an external service manages memory (Mem0, Graphiti, Cognee), extraction runs cheaply but guesses what matters without the agent's reasoning context. If humans co-manage memory (commonplace, Ars Contexta), curation quality is highest but throughput is lowest. AgeMem trains the memory policy through reinforcement learning, which approaches all three goals but requires a task-completion oracle that may not exist in open-ended domains, and the learned policy is opaque. No system combines high agency, high throughput, and high curation quality.
 
 **Navigability versus retrieval.** The systems split on how knowledge is accessed. Mem0, Graphiti, and Cognee treat knowledge as something you *search* for -- embed a query, return the top-k results. Ars Contexta and commonplace treat knowledge as something you *navigate* -- follow links with articulated relationships, reason along connections. Search-optimized systems score well on QA benchmarks. But QA accuracy does not measure whether the knowledge structure supports agent reasoning -- whether the agent can follow a chain of decisions to understand why the system works the way it does, or trace a correction back through the episodes that established it. The two approaches optimize for different things, and a memory system needs both.
+
+This split overlaps the role axis: knowledge-role consumption fits navigation (start with a question, follow links); system-definition-role consumption fits neither search nor navigation directly but requires a third pattern — **triggered activation**, where the system watches for cues in the agent's proposed action and injects relevant policy before commitment. QA benchmarks test knowledge-role retrieval. Neither search nor navigation tests system-definition activation well, which is one reason the comparative review finds no system solving the activation gap.
 
 **Everyone automates extraction; nobody automates synthesis.** Every system that processes incoming data can automatically extract structured knowledge from unstructured input. Almost none can automatically synthesize across existing knowledge to produce novel insights, recognize when two separate threads should merge, or reformulate existing entries for clarity. The boundary between extraction and synthesis remains the open frontier. This is where a "store everything" design has a structural advantage: with complete session logs retained, synthesis can be attempted retrospectively, improved over time, and rerun when techniques improve.
 
@@ -26,7 +43,7 @@ A store-everything system without structure is a haystack. Between raw session l
 
 **Layer 1: Trace.** Complete session logs -- every interaction, tool call, model output, user message. Append-only structured records with timestamps and session identifiers. The trace layer is the audit log, the ground truth, the substrate from which all higher layers derive. It answers one question well: "What exactly happened in session X?" It answers nothing else efficiently, and that is by design. Traces are for provenance and offline extraction, not for agent consumption. The agent never loads raw traces into a working context.
 
-**Layer 2: Observation.** Extracted atomic facts: decisions made, corrections given, preferences expressed, discoveries surfaced, questions asked, procedure fragments identified. Each observation is typed, timestamped, linked to its source session, and scored for confidence and importance. Observations are the first extraction from traces. They answer: "What discrete facts, decisions, and corrections exist across all sessions?"
+**Layer 2: Observation.** Extracted atomic facts: decisions made, corrections given, preferences expressed, discoveries surfaced, questions asked, procedure fragments identified. Each observation is typed, timestamped, linked to its source session, scored for confidence and importance, and **tagged with its role** — knowledge (consumed as fact) or system-definition (consumed as policy). Some observation types commit to a single role at extraction (a correction is system-definition; a negative result is knowledge); others are ambiguous and the extractor produces paired artifacts (a decision observation yields both a knowledge record for "why we chose A" and a system-definition cue for "if B is proposed, surface the reasoning for A"). Observations answer: "What discrete facts, decisions, and corrections exist across all sessions?"
 
 The observation layer is where ClawVault's design -- scored observations with explicit types and promotion pathways -- is most instructive. The difference: observations here are derived from stored traces rather than extracted at interaction time. This decouples capture speed from extraction quality. The extraction pipeline can be rerun, improved, and backfilled because traces are retained.
 
@@ -62,15 +79,27 @@ The layers matter less than the promotion pathways between them. Each transition
 
 **Library to Observation (backflow).** The less obvious direction, but equally important. Library notes should generate activation cues in the observation layer. A library note about "prefer staging specific files over `git add -A`" should produce an observation-layer entry that activates when a session involves git staging. Without this backflow, library knowledge sits inert -- stored but not activated.
 
-### Lifecycle separation through tagging, not storage
+### Lifecycle and role: orthogonal tags on the same store
 
 Knowledge, self-knowledge, and operational artifacts have different metabolic rates. Operational observations churn fast -- a debugging procedure that worked yesterday might be superseded today. Self-observations evolve slowly -- a preference observed across five sessions is likely stable. Knowledge observations accumulate -- a factual discovery does not expire, though it may be superseded.
 
 Rather than storing these in separate systems (which inhibits cross-space connections), the architecture tags observations by lifecycle space and uses the tag in promotion heuristics. A knowledge observation with high recurrence promotes to a library note. An operational observation with high recurrence promotes to a procedure. A self-observation that recurs across many sessions promotes to CLAUDE.md. Different promotion thresholds, different target artifacts, same pipeline. Unified storage with lifecycle tags preserves connections while enabling lifecycle-appropriate retrieval.
 
+The role tag is orthogonal to the lifecycle tag. A "self" observation is usually system-definition (a stable preference steers future sessions), but can also be knowledge ("I remember that we discussed how I work"). An operational observation about a debugging procedure is typically system-definition (fire it next time the situation recurs) but may also be knowledge when someone asks "how do we debug this class of bug?" The two tags answer different questions: *when does this expire?* (lifecycle) and *how is this consumed?* (role). Retrieval uses both — the lifecycle tag to weight recency, the role tag to select the activation mechanism.
+
 ## Retrieval and activation: bridging the gap between storage and context
 
 The hardest problem in the architecture is not extraction or storage. It is activation -- getting the right knowledge into the right context when it matters. The knowledge-activation gap formalizes this: a system can store relevant knowledge, prove that knowledge on demand, and still fail to surface it when it matters. Storage and activation are distinct, and most memory designs test only retrieval under direct query.
+
+### Retrieval splits by role, not by content
+
+The central design move is to build two retrieval pipelines, one for each role, sharing the same underlying store.
+
+**Knowledge-role retrieval** serves questions posed at consumption time. The canonical query is a human or agent asking "why did we do X?" or "what do we know about Y?" The retrieval interface is navigable: enter at an index, follow links, read connected notes. Embedding search over descriptions is a first-pass filter, and the library layer's articulated links do the rest. Failure mode: *the question is never asked.* Mitigation is outside this pipeline — it is the elicitation problem, which the memory system can assist but not solve.
+
+**System-definition-role activation** serves the agent's in-flight work. The canonical trigger is the agent about to take an action that matches a stored cue. The retrieval interface is not a query — it is a watcher. Cues are indexed by action signature, preference domain, or situation template, and fire when the agent's proposed action matches. This is what typed cue indexes, described below, are for. Failure mode: *the cue never fires even though it applies.* This is the activation gap proper, and it is where most of the design surface lives.
+
+The two pipelines share the observation store and cross-reference each other — a fired system-definition cue often carries a pointer into the knowledge layer for context ("this correction is part of a documented convention, see ADR 014"), and knowledge-layer navigation can reveal system-definition cues that would otherwise sit dormant ("while you're here, note that this note has an active correction attached"). But the mechanisms differ: search plus navigation for knowledge, triggered activation for system-definition.
 
 ### Three stages of activation failure
 
@@ -82,9 +111,9 @@ Activation decomposes into at least three stages, each with a different failure 
 
 **Commitment:** even when relevant knowledge is loaded into context, the agent may ignore it in favor of training-time defaults. The agent behaves like an expert witness -- giving accurate answers to whatever is asked, but not proactively raising concerns the questioner has not thought of.
 
-### Typed cue indexes
+### Typed cue indexes (system-definition activation)
 
-The central mechanism for bridging the activation gap is typed cue indexes. Instead of searching raw logs at retrieval time, the system extracts typed cues at ingestion time. Each type has a different retrieval signature:
+The central mechanism for bridging the activation gap is typed cue indexes. These are system-definition artifacts by design — the goal is to inject policy when a matching situation occurs, not to answer a question. Instead of searching raw logs at retrieval time, the system extracts typed cues at ingestion time. Each type has a different retrieval signature:
 
 A **correction cue** matches against the action the agent is about to take. It has a trigger condition and a lesson:
 
@@ -125,41 +154,47 @@ Loading relevant knowledge is not enough. The agent must actually use it. Three 
 
 *Contradiction surfacing.* When the agent's proposed action contradicts a stored correction or preference, surface the contradiction explicitly: "You are about to use approach A. In session 47, approach A failed because Z. The established alternative is approach B."
 
-### Search and navigation compose vertically
+### Search, navigation, and activation compose vertically
 
-The lower layers (traces and extracted cues) use search: you have a query and want matching items. The items are numerous, weakly structured, and connected only by temporal co-occurrence or semantic similarity.
+Three access patterns run across the layers, and a full retrieval uses all three. Search operates over the lower layers (traces and extracted items) because the items are numerous and weakly structured. Navigation operates over the upper layers (synthesized artifacts and library notes) because the items are fewer and richly linked. Activation operates over system-definition cues, regardless of layer, because the trigger is the agent's proposed action rather than a query.
 
-The upper layers (synthesized artifacts and library notes) use navigation: you have a starting point and want to follow connections to build understanding. The items are fewer, richly structured, and connected by articulated relationships.
+A typical retrieval flow for an agent about to write a database migration:
 
-A typical retrieval flow: search extracted cues for items matching the current task. Follow links from matched cues to synthesized artifacts (a correction cue links to a "migration safety checklist"). Navigate from the artifact to related library notes ("our deployment strategy requires zero-downtime migrations"). The agent receives the specific corrections, the procedure, and the architectural constraint -- assembled from three layers without loading a single raw trace.
+1. **Activation** fires any cues whose triggers match the proposed action. Correction cues load as imperative instructions; preference cues reserve a context budget; procedure cues suggest a checklist.
+2. **Search** over extracted items surfaces any knowledge-role records related to the task (past decisions about migrations, negative results, ADRs in draft).
+3. **Navigation** follows links from the surfaced records to library notes, gathering the articulated relationships that turn isolated facts into a coherent picture.
+
+The agent receives: the specific corrections (system-definition, via activation), the past decisions and alternatives (knowledge, via search + navigation), the architectural constraints (knowledge, via navigation). Three access patterns, two roles, all assembled without loading a raw trace.
 
 ## Learning from session logs: the extraction taxonomy
 
-Session logs contain at least four distinct signal types. They differ in how clear the oracle signal is, how difficult extraction is, and what they graduate into. The types, ranked from easiest to hardest:
+Session logs contain at least four distinct signal types. They differ in how clear the oracle signal is, how difficult extraction is, what role the extracted artifact plays, and what it graduates into. Role sorts the taxonomy cleanly: corrections, preferences, and procedures are system-definition (they change what the agent does); decision provenance and negative results are knowledge (they answer why-questions without changing behavior on their own); discoveries start as knowledge candidates and may graduate into either role. The types, ranked from easiest to hardest:
 
-### Corrections: the strongest signal
+### Corrections: the strongest signal (system-definition)
 
 The user says "no, do X instead" or rejects a tool call with a different instruction. The session log records the wrong output, the rejection, and the corrected direction. This is the clearest oracle in the entire system -- an explicit negative signal paired with a positive signal. Pi Self-Learning's extraction schema targets exactly this pattern: `{"mistakes": [...], "fixes": [...]}`.
 
-A correction observed twice in different sessions is not a fluke. The promotion threshold can be as low as two occurrences. The graduated artifact is a rule in CLAUDE.md, a convention in a style guide, or -- at the far end of the codification spectrum -- a linting check or validation script.
+A correction observed twice in different sessions is not a fluke. The promotion threshold can be as low as two occurrences. Corrections are natively system-definition: their value is in firing the next time the situation arises, not in answering a question. The graduated artifact sits on the codification gradient within the system-definition role: a rule in CLAUDE.md (prose), a convention in a style guide (prose), or a linting check or validation script (symbolic). A correction may also produce a companion knowledge artifact -- a note or ADR answering "why do we prefer X over Y?" -- but the primary artifact is the one that steers future behavior.
 
 Concrete example: the agent sorts Python imports alphabetically. The user corrects: "Group by stdlib / third-party / local, not alphabetical." When this correction recurs in a second session, it graduates from session-level memory to a documented preference. If it recurs a third time, the question becomes whether it should be a pre-commit hook.
 
-### Preferences: distributed signal, inferential extraction
+### Preferences: distributed signal, inferential extraction (system-definition)
 
-The user consistently accepts certain patterns and rejects others, but never articulates a rule. The signal is distributed across many sessions -- no single session contains enough evidence. Individual accept/reject signals are clear, but the pattern connecting them requires inference. The extraction step must hypothesize "short commit messages" as the latent variable from a scatter of individual approvals and rejections.
+The user consistently accepts certain patterns and rejects others, but never articulates a rule. The signal is distributed across many sessions -- no single session contains enough evidence. Individual accept/reject signals are clear, but the pattern connecting them requires inference. The extraction step must hypothesize "short commit messages" as the latent variable from a scatter of individual approvals and rejections. Like corrections, preferences are system-definition: the value is steering future choices, not answering questions.
 
 Detection works bottom-up (cluster accept/reject decisions by domain, look for feature splits that predict acceptance) or top-down (periodically prompt an LLM: "here are the last 50 decisions in domain X; what preferences explain the pattern?"). A reasonable promotion threshold: observed in five or more decisions across three or more sessions with over 80% consistency.
 
-### Procedures: sequence alignment across sessions
+### Procedures: sequence alignment across sessions (system-definition)
 
 The same workflow recurs: search for related notes, read the type template, write the note, connect it, validate. The sequence is analogous across sessions but not identical -- session 14 ingests a blog post, session 45 ingests a paper. Tool-call sequences are more reliable signals than natural-language descriptions. If four sessions all contain the subsequence `[WebFetch -> Read -> Write -> Grep -> Write -> Bash(validate)]`, that is a detectable pattern even when the surrounding conversation differs.
 
-The graduated artifact sits on the codification spectrum: an instruction document (if human judgment is needed at steps), a skill definition (if it can be automated with parameters), or a script (if fully deterministic). The graduation pathway mirrors the constraining gradient: observation, then documented convention, then automated check, then deterministic enforcement.
+Procedures are system-definition: the graduated artifact is used to steer how the agent performs the task. It sits on the codification gradient within the role: an instruction document (prose, if human judgment is needed at steps), a skill definition (prose-plus-formal-shape, if it can be automated with parameters), or a script (symbolic, if fully deterministic). The graduation pathway mirrors the constraining gradient: observation, then documented convention, then automated check, then deterministic enforcement. Role stays constant; class changes as the artifact constrains tighter.
 
-### Discoveries: the oracle problem at its purest
+### Discoveries: the oracle problem at its purest (knowledge, sometimes system-definition)
 
 An insight emerges during work -- a connection between ideas, a design principle, an abstraction that unifies several observations. These are the highest-value extractions and the hardest to detect. Unlike corrections (explicit rejection signal) or preferences (statistical pattern), a discovery is a one-off event. "Feels important" is not a verifiable signal.
+
+Discoveries usually enter as knowledge: a claim that grows the agent's reach when retrieved for reference. Some discoveries then acquire a system-definition companion — a discovery about how async resource pools fail may produce both a note (knowledge) and a cue that fires whenever the agent writes async cleanup code (system-definition). The role assignment is made at graduation, not extraction, because the insight's operational implications only become visible with use.
 
 Detection heuristics are all weak but worth trying: explicit markers ("that's interesting," "write this down"), surprise signals (claims connecting previously unlinked notes), elaboration depth (unusual number of turns spent developing a point), and post-hoc validation (the claimed discovery gets referenced in later sessions). Discoveries should enter as candidates with low confidence and promote based on reference frequency. A discovery that is never referenced again was probably not worth keeping.
 
@@ -187,7 +222,9 @@ No single signal is sufficient for all extraction types. But the combination is 
 
 ## Use cases: how memory gets consumed
 
-### Decision provenance: answering "why"
+These use cases are the canonical knowledge-role consumption patterns. Their system-definition counterparts — preventing the already-rejected approach from being proposed again — run through the typed cue index described above. Both roles draw from the same session logs; they differ in what consumer uses the extracted artifact.
+
+### Decision provenance: answering "why" (knowledge role)
 
 The recurring high-value question is: *why did we do it this way and not that way?* This is what ADRs are designed to answer, but ADRs are manually authored summaries written after the fact. Session logs contain the raw deliberation: alternatives considered, reasoning for each, constraints that were active, objections raised and addressed.
 
@@ -195,11 +232,13 @@ The memory system enables a semi-automated ADR pipeline. Detection: flag session
 
 More generally, session logs answer the "why" questions that ADRs do not anticipate. An ADR captures the decisions the author thought to document. Session logs preserve what was discarded, not just what was chosen. The memory system's job is to make those answers findable without requiring someone to write them down first.
 
-### Negative result preservation
+A well-drafted ADR often produces a system-definition companion: a cue that fires when the agent proposes one of the rejected alternatives. The ADR explains *why* (knowledge); the cue prevents repetition (system-definition). Both live in the memory system and point at each other.
+
+### Negative result preservation (knowledge role)
 
 "What was tried and abandoned" has no home in standard project structure. The code shows what was built; it does not show what was tried and discarded. When someone later proposes an approach that was already explored and rejected, only the memory system can answer "we tried that in session 34, and it failed because the proxy servers strip custom headers in our infrastructure."
 
-Negative results are extracted as structured records with the approach attempted, the failure reason, the source session, and a link to the decision that followed. They are indexed by the approach name, so a "why didn't we do X?" query finds them directly.
+Negative results are extracted as structured records with the approach attempted, the failure reason, the source session, and a link to the decision that followed. They are indexed by the approach name, so a "why didn't we do X?" query finds them directly. When a negative result is severe enough to warrant preventing recurrence, it also produces a system-definition cue keyed on the attempted approach — the knowledge record answers "why not?", the cue prevents the attempt in the first place.
 
 ## Where memory ends and the project begins
 
@@ -207,9 +246,11 @@ A memory system for a software project exists alongside code, tests, documentati
 
 ### The boundary, refined
 
-Artifact by artifact, the memory system's contribution is consistent: it adds the reasoning, context, and process knowledge that produced the artifact. Code says "retry loop with exponential backoff." The memory system says "we tried a circuit breaker in session 47 but it interacted badly with the connection pool." Tests say "this invariant holds." The memory system says "this test was written because of the bug in PR #247." Documentation says "use this API." The memory system says "three users asked the same question that the docs failed to answer."
+Project artifacts themselves split across the class/role grid, and that grid makes the boundary clearer. Code and tests are symbolic system-definition. Documentation is prose knowledge. ADRs are prose knowledge. CLAUDE.md is prose system-definition. Lint rules are symbolic system-definition. The memory system is a substrate — prose-class, file-backed — from which both knowledge-role and system-definition-role project artifacts get distilled.
 
-The interesting edge case is CLAUDE.md (or any always-loaded agent instruction file). CLAUDE.md is already a memory artifact -- it stores routing knowledge the agent needs every session. The proposed distinction: **CLAUDE.md is compiled routing; the memory system is the source.** When the user corrects the agent three times for the same mistake, the correction pattern lives in session logs and eventually graduates to a CLAUDE.md entry. CLAUDE.md is the deployment artifact; the memory system is the learning substrate.
+Artifact by artifact, the memory system's contribution is consistent: it adds the reasoning, context, and process knowledge that produced the artifact. Code (symbolic system-definition) says "retry loop with exponential backoff." The memory system adds the knowledge-role complement: "we tried a circuit breaker in session 47 but it interacted badly with the connection pool." Tests (symbolic system-definition) say "this invariant holds." The memory system adds knowledge: "this test was written because of the bug in PR #247." Documentation (prose knowledge) says "use this API." The memory system adds knowledge: "three users asked the same question that the docs failed to answer."
+
+The interesting edge case is CLAUDE.md (or any always-loaded agent instruction file). CLAUDE.md is already a memory artifact -- it is prose system-definition, loaded every session to steer the agent. The proposed distinction: **CLAUDE.md is compiled system-definition; the memory system is the source.** When the user corrects the agent three times for the same mistake, the correction pattern lives in session logs and eventually graduates to a CLAUDE.md entry (or further, to a lint rule — same role, tighter constraining). CLAUDE.md is the deployment artifact; the memory system is the learning substrate.
 
 ### Where the boundary blurs
 
@@ -223,15 +264,18 @@ A better formulation: **the memory system is the substrate from which project ar
 
 ### Graduation pathways
 
-When a pattern in session logs becomes a durable artifact, the destination depends on what was learned:
+When a pattern in session logs becomes a durable artifact, the destination depends on both what was learned and which role the artifact will play. The same source pattern can produce artifacts in both roles, serving different consumers:
 
-| Pattern | Graduation trigger | Destination |
-|---|---|---|
-| Decision debated across sessions | "Why did we decide X?" is expensive to answer | ADR linking back to source sessions |
-| Same workflow in 3+ sessions | Repetition detection | Documented procedure, skill, or script |
-| Same mistake corrected 2+ times | Correction frequency | Convention, CLAUDE.md entry, or lint rule |
-| Agent needs same orientation each session | Recurring first-message pattern | CLAUDE.md entry |
-| Context needed to understand specific code | Explanation given during session | Code comment |
+| Pattern | Graduation trigger | Destination | Role |
+|---|---|---|---|
+| Decision debated across sessions | "Why did we decide X?" is expensive to answer | ADR linking back to source sessions | Knowledge |
+| Decision with a commonly-proposed reject alternative | Agent re-proposed rejected option | Cue keyed on the rejected alternative | System-definition |
+| Same workflow in 3+ sessions | Repetition detection | Documented procedure, skill, or script | System-definition |
+| Same mistake corrected 2+ times | Correction frequency | Convention, CLAUDE.md entry, or lint rule | System-definition |
+| Same mistake, with instructive rationale | The reasoning for the correction is worth preserving | Companion note or ADR | Knowledge |
+| Agent needs same orientation each session | Recurring first-message pattern | CLAUDE.md entry | System-definition |
+| Context needed to understand specific code | Explanation given during session | Code comment | Knowledge (usually) |
+| Negative result: tried and abandoned | Approach explored and rejected | Negative-result record + "why not X?" index entry | Knowledge |
 
 The meta-pattern across all graduation types is: observation, accumulation, recognition, distillation, placement, provenance. Recognition is the bottleneck -- detecting that a pattern deserves graduation requires the kind of judgment the system is trying to automate. For signals with clear triggers (correction frequency, repetition count), recognition can be automated. For signals requiring judgment (when a decision is "load-bearing enough" to warrant an ADR), the system can only flag and assist.
 
@@ -240,6 +284,8 @@ A critical constraint on graduation: every graduated artifact creates a maintena
 ### The reach heuristic
 
 The concept of *reach* -- how broadly an insight applies across contexts -- maps onto the graduation question. High-reach knowledge ("systems that optimize for normal-load efficiency sacrifice overload resilience") wants to be in the library layer. Low-reach knowledge ("the bug in PR #247 was a race condition in the connection pool") can stay in session logs.
+
+Reach behaves asymmetrically across roles. A knowledge artifact is worth promoting when its claim applies broadly — generalization is what makes the note worth reading across many situations. A system-definition artifact is worth promoting when its trigger fires often enough *in the specific situations it covers* — a narrow cue that fires accurately is more valuable than a broad one that mostly misfires. Graduating a correction into CLAUDE.md increases reach in both directions (it fires in every session, now) but also multiplies the cost of being wrong (every session loads it). The reach heuristic for knowledge is "does this claim apply more widely?"; for system-definition it is "does this trigger fire when it should, often enough to earn its context budget?"
 
 But you often cannot tell the reach of an observation when you first make it. The connection pool race condition might be a one-off, or it might be the third instance of a pattern where async resource pools need explicit shutdown ordering. Reach is revealed by accumulation: when multiple low-reach observations cluster around the same structural pattern, the pattern has high reach and should graduate.
 


### PR DESCRIPTION
Weave the role axis (knowledge vs system-definition) from the updated
axes-of-artifact-analysis note through the workshop. The axis clarifies
several places where the workshop conflated distinct problems:

- Retrieval splits by role: knowledge consumption fits search+navigation,
  system-definition consumption needs triggered activation. The activation
  gap is primarily a system-definition problem.
- Extraction taxonomy sorts by role: corrections, preferences, and
  procedures are system-definition; decision provenance and negative
  results are knowledge; discoveries start as knowledge and may graduate
  into either role.
- Graduation destinations map to roles: ADRs/notes are knowledge;
  CLAUDE.md/conventions/lint rules are system-definition. The same source
  pattern can produce graduates in both roles.
- Project-memory boundary is clearer with the class/role grid: code and
  tests are symbolic system-definition; docs/ADRs are prose knowledge;
  CLAUDE.md is prose system-definition.
- Observations in the store carry both a lifecycle tag (when does this
  expire?) and a role tag (how is this consumed?); the tags are
  orthogonal.