### PR TITLE
Add workshop: distributing KBs built on commonplace

### DIFF
--- a/kb/work/README.md
+++ b/kb/work/README.md
@@ -27,4 +27,5 @@ Each workshop is a directory exploring a specific workflow end-to-end: from ques
 - [review-revise-gated](./review-revise-gated/README.md) — finding review/revise arrangements that reliably produce the manual-edit quality bar, then codifying as reusable instructions
 - [auditable-llm-editing](./auditable-llm-editing/README.md) — testing whether sparse, anchored writing state prevents accidental claim drift across repeated LLM editing passes
 - [shipping-model](./shipping-model/README.md) — deciding how commonplace ships its content so user collections stay theirs while our library sits alongside as a read-only dependency
+- [distributing-built-kbs](./distributing-built-kbs/README.md) — the downstream counterpart to shipping-model: most hassle-free way to distribute a domain KB someone built, by separating the lightweight consumer path from the authoring machinery
 - [lifecycle-management](./lifecycle-management/README.md) — mapping the full artifact life-cycle (intake, promotion, maturation, retirement); the `agent-memory-design` test case landed as a `note + synthesis` trait in `kb/notes/designing-agent-memory-systems.md`

--- a/kb/work/distributing-built-kbs/README.md
+++ b/kb/work/distributing-built-kbs/README.md
@@ -8,87 +8,94 @@ This is the **downstream** distribution problem — getting a *domain* KB to its
 
 ## The core reframe: consumer path ≠ author path
 
-A commonplace KB bundles two things that ship together today but have very different distribution needs:
+This reframe underpins both parts below. A commonplace KB bundles two things that ship together today but have very different distribution needs:
 
 - **The knowledge** — plain markdown in `kb/notes|reference|instructions`, their `COLLECTION.md`s, `kb/types/`, and the committed `dir-index.md` / curated indexes. Static text.
 - **The authoring/maintenance machinery** — the `llm-commonplace` package, the `cp-skill-*` family (write / connect / validate / ingest / revise), and the review system (SQLite). Tools for *building* a KB.
 
-A consumer solving a problem only needs to **read and navigate**. Per [navigation.md](../../reference/navigation.md), navigation is a progressive-disclosure stack: control-plane file → `rg` → committed indexes → descriptions → links. None of that requires the Python package or the skills. The minimal consumption runtime is **an agent + `ripgrep` + `git`**.
+A consumer solving a problem only needs to **read and navigate**. Per [navigation.md](../../reference/navigation.md), navigation is a progressive-disclosure stack: control-plane file → `rg` → committed indexes → descriptions → links. None of that requires the Python package or the skills. The minimal consumption runtime is **an agent + `ripgrep` + `git`**. This rests on the "files, not database" principle: authored markdown is the source of truth and indexes are rebuildable navigation artifacts ([storage-architecture](../../reference/storage-architecture.md)), so distribution inherits portability for free.
 
-This is the lever:
+---
 
-> **The single biggest hassle-reduction move is to commit fresh indexes at release time and keep the consumer off the package entirely.** The moment navigation depends on running `commonplace-refresh-indexes`, the install step and a runtime dependency come back — to deliver what is fundamentally static text. Pre-build the indexes, ship them, and the consumer needs nothing but an agent with ripgrep.
+# Part 1 — The current situation: what you can do today
 
-This rests on the "files, not database" design principle: authored knowledge is file-backed and indexes are rebuildable navigation artifacts, not the source of truth ([storage-architecture](../../reference/storage-architecture.md)). Distribution inherits that property for free.
+With nothing added to commonplace, a built KB is already distributable, because it is just markdown in git.
 
-## Distribution modes, ordered by hassle
+## What a consumer needs at read time
 
-### 1. Standalone git repo — "clone and point" (default, lowest hassle)
+An agent + `ripgrep` + `git`. No `llm-commonplace` install, no skills, no daemon — **provided the indexes are committed**. The committed `dir-index.md` / curated indexes plus descriptions and authored links are the whole navigation surface. This is the decisive property: ship pre-built indexes and the reader needs nothing else.
 
-The KB is its own repository with a consumption-oriented control-plane file at the root. The consumer runs `git clone`, points their agent at the directory, and starts. Updates are `git pull`. This is essentially the README's "Direct use" mode and is the most hassle-free when there is a dedicated agent or person whose job *is* that problem.
+## Modes that work now
 
-- **Pro:** zero install, free versioning, diffable, offline-capable; the control-plane file travels with the content.
-- **Con:** it is a separate checkout — if the knowledge must live *inside* another project, you need mode 2.
+1. **Standalone git repo — "clone and point" (lowest hassle).** The KB is its own repo; the consumer runs `git clone`, points their agent at the directory, and starts. Updates are `git pull`. This is the README's "Direct use" mode. Best when there is a dedicated agent or person whose job *is* that problem.
 
-### 2. Embedded read-only namespace inside a consuming project (`kb/<domain>/`)
+2. **Embedded via plain git — submodule, subtree, or copy.** When the knowledge must live inside another project, ordinary git already supports it: add the KB as a submodule (version-pinnable, some init friction), a subtree (no submodule friction, messier history), or a plain copy. No commonplace feature is required to *place* the tree. **Limitation today:** the consuming project's skills won't treat the embedded KB as a known library root — skill-root resolution presence-checks `kb/commonplace/` specifically (per ADR-021), not an arbitrary `kb/<domain>/`. So a manually embedded domain KB is readable by `rg` and links but is not first-class to the `cp-skill-*` family.
 
-When the knowledge must live *inside* another project, this is the **exact problem ADR-021 already solved** for commonplace's own library: a namespace directory, a `.commonplace`-style marker, presence-check skill-root resolution, and a drift check on re-run. A domain KB is just another instance of "ship a read-only library into a consuming tree," so that machinery generalizes from `kb/commonplace/` to `kb/<domain>/`.
+3. **Release tarball (`git archive`).** A versioned snapshot the consumer downloads, unzips, and points at. No history weight, no submodule friction. Works today with stock git.
 
-Delivery options for the embedded tree:
+## Rough edges you hit doing this manually today
 
-| Mechanism | Re-sync | Tradeoff |
-|---|---|---|
-| Git submodule | `git pull` in submodule; version-pinnable | Submodule UX friction; consumers must init it |
-| Git subtree | Re-pull subtree | No submodule friction; messier history |
-| Plain copy + marker | Re-copy / re-run an export | Simplest; weakest version story |
+Everything above works, but preparing a *clean* bundle is currently a manual checklist:
 
-### 3. Release tarball (`git archive` of the consumption subset)
+- **Indexes must be regenerated before release.** If content changed, the author runs `commonplace-refresh-indexes` (the package) so committed indexes are fresh. Authors have the package, so this is fine — but it is a manual step, easy to forget, and a stale index silently degrades the consumer's navigation.
+- **Sources need hand-trimming.** `kb/sources/` raw captures are often the bulk of a problem KB and may be copyrighted. Today you manually omit them and fix `../sources/...` links to external URLs (the shipping-model workshop already locked this decision as a rule, but nothing applies it for you).
+- **No consumer control-plane exists.** Only the authoring-heavy `AGENTS.md` ships (skills, review, fix, write conventions). To hand a consumer a clean entry point you trim it by hand down to Goals → Key indexes → Navigation conventions.
+- **Author-only trees travel unless excluded.** `kb/work/`, `kb/tasks/`, the review SQLite state, and `.venv/` are all author-side and add weight/noise unless you exclude them yourself.
+- **No single export command.** The above is a checklist a human runs each release, not one reproducible command.
 
-For pinned or offline consumers: a release artifact they download, unzip, and point at. Versioned, no git-history weight, no submodule friction. Good for "give me exactly v3 of the payments-KB and never move."
+Net: **distribution works today, but "hassle-free" requires manual discipline** — refresh indexes, strip sources and author trees, trim a consumer control-plane, then clone/submodule/tar.
 
-### Avoid for pure knowledge: the pip-package + init path
+---
 
-Packaging the content into `_data/` and shipping an `init`-style installer is what commonplace does for its *methodology* library — justified because it ships executable tooling. For a read-only **domain** KB it drags in packaging, an install step, and a runtime dependency to deliver static text. Only justify it if the KB ships its own *executable* tooling (custom validators, generators, or skills) alongside the knowledge.
+# Part 2 — Brainstorm: what we could add to make it easier
 
-### MkDocs is a human surface, not the agent path
+Each item below removes one of the manual rough edges. Ordered roughly by leverage.
 
-`mkdocs.yml` already exists and renders the KB for human browsing. That is a **discovery / marketing** complement, not the agent-consumption mechanism — agents consume the markdown and indexes directly.
+## A. A `commonplace-bundle` export command (highest leverage)
 
-## What to strip from a consumption bundle
-
-- `kb/sources/` raw captures → **cite external URLs** instead. Sources are often a problem-KB's bulk and may be copyrighted; the shipping-model workshop already locked the "convert source links to external URLs, omit raw sources" decision.
-- `kb/work/`, `kb/tasks/`, the review SQLite state, `.venv/` — all author-side, none of it consumed.
-- The control-plane file needs a **consumer variant**. The current `AGENTS.md` is authoring-heavy (skills, review, fix, write conventions). A consumer control-plane foregrounds Goals → Key indexes → Navigation conventions and drops the authoring workflow. This is what makes a cold-start agent productive in one read.
-
-## The missing piece: an export command
-
-No command today produces this consumption bundle. `commonplace-init` goes the *opposite* direction — it sets up authoring and installs the methodology library. The shipping-model workshop already flagged a `commonplace-ship-preview` as a needed mitigation; that is the same machinery pointed downstream.
-
-Sketch of `commonplace-bundle` (name TBD):
+One command that produces a consumption bundle, turning the Part 1 checklist into a reproducible build. Sketch:
 
 1. **Select** the consumption subset: `kb/notes`, `kb/reference`, `kb/instructions`, their `COLLECTION.md`s, `kb/types`. Exclude `sources`, `work`, `tasks`, reports, review state, `.venv`.
 2. **Rewrite** `../sources/...` links to their external URLs (reuse the shipping-model source-link migration rule).
-3. **Regenerate** all indexes fresh (`commonplace-refresh-indexes`) so the bundle is navigable without the package.
-4. **Swap in** the consumer control-plane file (a stripped `AGENTS.md`).
-5. **Emit** either a standalone repo layout (mode 1), an embeddable `kb/<domain>/` tree with a marker (mode 2), or a tarball (mode 3) — same subset, three packagings.
+3. **Regenerate** all indexes fresh so the bundle is navigable without the package.
+4. **Swap in** the consumer control-plane file (item B).
+5. **Emit** as a standalone repo layout (mode 1), an embeddable `kb/<domain>/` tree with a marker (mode 2), or a tarball (mode 3) — same subset, three packagings.
 
-Building this turns "hassle-free distribution" from a manual checklist into one command, and it shares most of its logic with the already-planned `ship-preview`.
+This shares most of its logic with the `commonplace-ship-preview` tool the shipping-model workshop already flagged; building one likely gets the other cheaply.
+
+## B. A consumer control-plane template
+
+A stripped `AGENTS.md` variant that foregrounds Goals → Key indexes → Navigation conventions and drops the authoring workflow (skills, review, fix, write conventions). This is what makes a cold-start consumer agent productive in a single read. `commonplace-init` could grow a `--consumer` control-plane template, or the bundle command could emit it.
+
+## C. Generalize the read-only namespace beyond `kb/commonplace/`
+
+Today ADR-021's read-only-library machinery — namespace directory, `.commonplace` marker, presence-check skill-root resolution, drift check — is hardwired to commonplace's *own* library. Generalizing it so any embedded domain KB at `kb/<domain>/` is recognized as a read-only library root would make mode 2 first-class: the consuming project's skills would scan the embedded KB as link targets and load its `COLLECTION.md` register. The shipping-model design-space already gestured at this ("scales to multi-source libraries") and left it as an open question. This is the difference between "an agent can grep the embedded KB" and "the embedded KB is a known, navigable library in the project."
+
+## D. Versioning / re-sync metadata
+
+A version tag + manifest in the bundle (generalizing the `.commonplace` marker) so a consumer can tell which release they have and re-sync cleanly. Pairs with mode 2: a submodule pinned to a release tag, or a copy whose marker records the source version, both enable "update to the latest payments-KB" without guesswork.
+
+## E. (Conditional) a stronger search layer for large bundles
+
+If distributed KBs grow past the size where `rg` + indexes stay scannable, [navigation.md](../../reference/navigation.md) already anticipates ranked lexical (BM25) and later semantic/hybrid search. Only worth adding when a distributed KB is large enough that flat lexical search gets noisy — not needed for the small problem-scoped KBs this workshop is mostly about.
 
 ## Recommendation
 
-Default to **mode 1 (standalone git repo, clone-and-point)** for a problem-scoped KB consumed by an agent: it is the lowest-friction path and needs no install. Reach for **mode 2 (embedded read-only `kb/<domain>/`)** when the knowledge must live inside a consuming project, reusing the ADR-021 namespace + marker + presence-check pattern. Use **mode 3 (tarball)** for pinned/offline delivery. In all three, the decisive lever is the same: **ship pre-built indexes and a consumer control-plane so the reader never needs the `llm-commonplace` package or the authoring skills.**
+**Today:** default to mode 1 (standalone repo, clone-and-point); use mode 2 (embed via submodule/subtree/copy) when it must live inside a consuming project; tarball for pinned/offline. In all cases the decisive lever is shipping **pre-built indexes + a hand-trimmed consumer control-plane** so the reader never needs the package or the skills.
+
+**To add, in priority order:** (A) the `commonplace-bundle` export command, (B) the consumer control-plane template, then (C) the generalized read-only namespace for first-class embedding. (A) and (B) remove most of the manual hassle; (C) makes embedded domain KBs first-class to the skill family.
 
 ## What would close this workshop
 
 - A decision on whether to build `commonplace-bundle` (and whether it merges with `ship-preview`).
 - A specification of the consumer control-plane template.
-- A confirmed mode-2 mechanism (submodule vs. subtree vs. copy+marker) for embedding a domain KB.
-- Promotable durable conclusions: most likely a note on "distributing a KB for consumption is a strictly lighter problem than installing it for authoring," and a reference doc on the bundle format.
+- A decision on whether to generalize the ADR-021 read-only namespace to arbitrary `kb/<domain>/` libraries.
+- Promotable durable conclusions: a note on "distributing a KB for consumption is a strictly lighter problem than installing it for authoring," and a reference doc on the bundle format.
 
 ## Grounding
 
 - [Shipping-model workshop](../shipping-model/README.md) — derived-from: the upstream counterpart; its namespace, marker, drift-check, and source-link decisions are reused here.
-- [ADR-021: ship library content under kb/commonplace/](../../reference/adr/021-ship-library-content-under-kb-commonplace.md) — grounds: the read-only-namespace mechanism this workshop generalizes.
-- [Navigation](../../reference/navigation.md) — grounds: the consumer only needs control-plane + rg + indexes + descriptions + links; no daemon, no package.
+- [ADR-021: ship library content under kb/commonplace/](../../reference/adr/021-ship-library-content-under-kb-commonplace.md) — grounds: the read-only-namespace mechanism Part 2 item C would generalize.
+- [Navigation](../../reference/navigation.md) — grounds: the consumer only needs control-plane + rg + indexes + descriptions + links; also the source for the item-E search-layer roadmap.
 - [Storage architecture](../../reference/storage-architecture.md) — grounds: authored markdown is the source of truth; indexes are rebuildable, so the bundle can ship them pre-built.
 - [An agentic KB maximizes contextual competence through discoverable, composable, trusted knowledge](../../notes/an-agentic-kb-maximizes-contextual-competence-through-discoverable.md) — rationale: why a clean consumer boundary preserves trust in the shipped knowledge.

--- a/kb/work/distributing-built-kbs/README.md
+++ b/kb/work/distributing-built-kbs/README.md
@@ -1,0 +1,94 @@
+# Workshop: Distributing KBs built on commonplace
+
+## Question
+
+If someone builds a commonplace KB holding the knowledge needed for a particular problem, what is the most hassle-free way to distribute it to the people and agents who need that knowledge?
+
+This is the **downstream** distribution problem — getting a *domain* KB to its consumers. It is distinct from, and orthogonal to, the [shipping-model workshop](../shipping-model/README.md), which solved the *upstream* problem: how commonplace ships its own methodology library into a project (decided in [ADR-021](../../reference/adr/021-ship-library-content-under-kb-commonplace.md), now live as `kb/commonplace/`). The mechanisms rhyme, but the consumer and the payload differ.
+
+## The core reframe: consumer path ≠ author path
+
+A commonplace KB bundles two things that ship together today but have very different distribution needs:
+
+- **The knowledge** — plain markdown in `kb/notes|reference|instructions`, their `COLLECTION.md`s, `kb/types/`, and the committed `dir-index.md` / curated indexes. Static text.
+- **The authoring/maintenance machinery** — the `llm-commonplace` package, the `cp-skill-*` family (write / connect / validate / ingest / revise), and the review system (SQLite). Tools for *building* a KB.
+
+A consumer solving a problem only needs to **read and navigate**. Per [navigation.md](../../reference/navigation.md), navigation is a progressive-disclosure stack: control-plane file → `rg` → committed indexes → descriptions → links. None of that requires the Python package or the skills. The minimal consumption runtime is **an agent + `ripgrep` + `git`**.
+
+This is the lever:
+
+> **The single biggest hassle-reduction move is to commit fresh indexes at release time and keep the consumer off the package entirely.** The moment navigation depends on running `commonplace-refresh-indexes`, the install step and a runtime dependency come back — to deliver what is fundamentally static text. Pre-build the indexes, ship them, and the consumer needs nothing but an agent with ripgrep.
+
+This rests on the "files, not database" design principle: authored knowledge is file-backed and indexes are rebuildable navigation artifacts, not the source of truth ([storage-architecture](../../reference/storage-architecture.md)). Distribution inherits that property for free.
+
+## Distribution modes, ordered by hassle
+
+### 1. Standalone git repo — "clone and point" (default, lowest hassle)
+
+The KB is its own repository with a consumption-oriented control-plane file at the root. The consumer runs `git clone`, points their agent at the directory, and starts. Updates are `git pull`. This is essentially the README's "Direct use" mode and is the most hassle-free when there is a dedicated agent or person whose job *is* that problem.
+
+- **Pro:** zero install, free versioning, diffable, offline-capable; the control-plane file travels with the content.
+- **Con:** it is a separate checkout — if the knowledge must live *inside* another project, you need mode 2.
+
+### 2. Embedded read-only namespace inside a consuming project (`kb/<domain>/`)
+
+When the knowledge must live *inside* another project, this is the **exact problem ADR-021 already solved** for commonplace's own library: a namespace directory, a `.commonplace`-style marker, presence-check skill-root resolution, and a drift check on re-run. A domain KB is just another instance of "ship a read-only library into a consuming tree," so that machinery generalizes from `kb/commonplace/` to `kb/<domain>/`.
+
+Delivery options for the embedded tree:
+
+| Mechanism | Re-sync | Tradeoff |
+|---|---|---|
+| Git submodule | `git pull` in submodule; version-pinnable | Submodule UX friction; consumers must init it |
+| Git subtree | Re-pull subtree | No submodule friction; messier history |
+| Plain copy + marker | Re-copy / re-run an export | Simplest; weakest version story |
+
+### 3. Release tarball (`git archive` of the consumption subset)
+
+For pinned or offline consumers: a release artifact they download, unzip, and point at. Versioned, no git-history weight, no submodule friction. Good for "give me exactly v3 of the payments-KB and never move."
+
+### Avoid for pure knowledge: the pip-package + init path
+
+Packaging the content into `_data/` and shipping an `init`-style installer is what commonplace does for its *methodology* library — justified because it ships executable tooling. For a read-only **domain** KB it drags in packaging, an install step, and a runtime dependency to deliver static text. Only justify it if the KB ships its own *executable* tooling (custom validators, generators, or skills) alongside the knowledge.
+
+### MkDocs is a human surface, not the agent path
+
+`mkdocs.yml` already exists and renders the KB for human browsing. That is a **discovery / marketing** complement, not the agent-consumption mechanism — agents consume the markdown and indexes directly.
+
+## What to strip from a consumption bundle
+
+- `kb/sources/` raw captures → **cite external URLs** instead. Sources are often a problem-KB's bulk and may be copyrighted; the shipping-model workshop already locked the "convert source links to external URLs, omit raw sources" decision.
+- `kb/work/`, `kb/tasks/`, the review SQLite state, `.venv/` — all author-side, none of it consumed.
+- The control-plane file needs a **consumer variant**. The current `AGENTS.md` is authoring-heavy (skills, review, fix, write conventions). A consumer control-plane foregrounds Goals → Key indexes → Navigation conventions and drops the authoring workflow. This is what makes a cold-start agent productive in one read.
+
+## The missing piece: an export command
+
+No command today produces this consumption bundle. `commonplace-init` goes the *opposite* direction — it sets up authoring and installs the methodology library. The shipping-model workshop already flagged a `commonplace-ship-preview` as a needed mitigation; that is the same machinery pointed downstream.
+
+Sketch of `commonplace-bundle` (name TBD):
+
+1. **Select** the consumption subset: `kb/notes`, `kb/reference`, `kb/instructions`, their `COLLECTION.md`s, `kb/types`. Exclude `sources`, `work`, `tasks`, reports, review state, `.venv`.
+2. **Rewrite** `../sources/...` links to their external URLs (reuse the shipping-model source-link migration rule).
+3. **Regenerate** all indexes fresh (`commonplace-refresh-indexes`) so the bundle is navigable without the package.
+4. **Swap in** the consumer control-plane file (a stripped `AGENTS.md`).
+5. **Emit** either a standalone repo layout (mode 1), an embeddable `kb/<domain>/` tree with a marker (mode 2), or a tarball (mode 3) — same subset, three packagings.
+
+Building this turns "hassle-free distribution" from a manual checklist into one command, and it shares most of its logic with the already-planned `ship-preview`.
+
+## Recommendation
+
+Default to **mode 1 (standalone git repo, clone-and-point)** for a problem-scoped KB consumed by an agent: it is the lowest-friction path and needs no install. Reach for **mode 2 (embedded read-only `kb/<domain>/`)** when the knowledge must live inside a consuming project, reusing the ADR-021 namespace + marker + presence-check pattern. Use **mode 3 (tarball)** for pinned/offline delivery. In all three, the decisive lever is the same: **ship pre-built indexes and a consumer control-plane so the reader never needs the `llm-commonplace` package or the authoring skills.**
+
+## What would close this workshop
+
+- A decision on whether to build `commonplace-bundle` (and whether it merges with `ship-preview`).
+- A specification of the consumer control-plane template.
+- A confirmed mode-2 mechanism (submodule vs. subtree vs. copy+marker) for embedding a domain KB.
+- Promotable durable conclusions: most likely a note on "distributing a KB for consumption is a strictly lighter problem than installing it for authoring," and a reference doc on the bundle format.
+
+## Grounding
+
+- [Shipping-model workshop](../shipping-model/README.md) — derived-from: the upstream counterpart; its namespace, marker, drift-check, and source-link decisions are reused here.
+- [ADR-021: ship library content under kb/commonplace/](../../reference/adr/021-ship-library-content-under-kb-commonplace.md) — grounds: the read-only-namespace mechanism this workshop generalizes.
+- [Navigation](../../reference/navigation.md) — grounds: the consumer only needs control-plane + rg + indexes + descriptions + links; no daemon, no package.
+- [Storage architecture](../../reference/storage-architecture.md) — grounds: authored markdown is the source of truth; indexes are rebuildable, so the bundle can ship them pre-built.
+- [An agentic KB maximizes contextual competence through discoverable, composable, trusted knowledge](../../notes/an-agentic-kb-maximizes-contextual-competence-through-discoverable.md) — rationale: why a clean consumer boundary preserves trust in the shipped knowledge.


### PR DESCRIPTION
Capture the downstream distribution analysis as a workshop sibling to
shipping-model. Separates the lightweight consumer path (markdown +
committed indexes + rg) from the authoring machinery (package, skills,
review), and sketches a commonplace-bundle export command.

https://claude.ai/code/session_01E6aTwotW6XZtcH3sdBYWhN