### PR TITLE
Replace skill projection symlinks with copies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -138,7 +138,7 @@ This creates:
 - **Commonplace library content** — shipped notes, reference docs, instructions, review gates, and skills under `kb/commonplace/notes/`, `kb/commonplace/reference/`, and `kb/commonplace/instructions/`
 - **Type definitions** — shared types under `kb/types/`, plus source/report type scaffolds
 - **Canonical skills** — `kb/commonplace/instructions/cp-skill-write/`, plus the matching `cp-skill-validate/`, `cp-skill-connect/`, etc. The `cp-skill-` prefix avoids collisions with your project's own skills and with the `commonplace-*` CLI commands.
-- **Known runtime skill projections** — `.agents/skills/cp-skill-*/` and `.claude/skills/cp-skill-*/` links for two common layouts (step 5 covers other runtimes). On Linux/macOS these are relative symlinks; on Windows, where symlinks need admin rights or Developer Mode, init automatically falls back to a directory junction, which needs neither.
+- **Known runtime skill projections** — `.agents/skills/cp-skill-*/` and `.claude/skills/cp-skill-*/` copies of the canonical skill directories for two common layouts (step 5 covers other runtimes). These are regular directories, not symlinks or junctions, so they work the same on every platform — including Windows without admin rights or Developer Mode.
 - **`.envrc`** — project-scoped environment (`PATH`, `UV_CACHE_DIR`) for the optional direnv setup (see the [direnv appendix](#appendix-direnv-linuxmacos)); harmless if you don't use direnv
 - **`AGENTS.md.template`** — control-plane template with the project name filled in
 
@@ -182,15 +182,15 @@ Then review the merged file and fill in the per-project parts. The template's HT
 
 ## 5. Install skills for every agent that will work on the project
 
-**For most agent setups, nothing needs to be done here.** `commonplace-init` already projected the skills into the two common layouts — `.agents/skills/cp-skill-*/` (Codex and others) and `.claude/skills/cp-skill-*/` (Claude Code) — by linking each `cp-skill-*` directory to its source under `kb/commonplace/instructions/`. On Linux/macOS these are relative symlinks; on Windows they are directory junctions when symlinks are unavailable (no admin rights or Developer Mode). If every agent that will work on the project reads one of those two directories, skip to step 6.
+**For most agent setups, nothing needs to be done here.** `commonplace-init` already projected the skills into the two common layouts — `.agents/skills/cp-skill-*/` (Codex and others) and `.claude/skills/cp-skill-*/` (Claude Code) — by copying each `cp-skill-*` directory from its source under `kb/commonplace/instructions/`. The copies are regular directories, so no platform-specific link support is needed. If every agent that will work on the project reads one of those two directories, skip to step 6.
 
-You only need to do something here if an agent uses a **different** skill-discovery convention, or runs on a platform where even the junction fallback was skipped (sandboxed filesystems, network volumes). In that case, expose the same source directories where that runtime expects them:
+You only need to do something here if an agent uses a **different** skill-discovery convention. In that case, expose the same source directories where that runtime expects them:
 
 ```text
 kb/commonplace/instructions/cp-skill-*/
 ```
 
-Inspect your runtime's skill-discovery rules and project every `cp-skill-*` directory into that surface — symlink, junction, copy, plugin registration, or IDE-specific import. Prefer links or runtime registration over copies, so that rerunning `commonplace-init` after an upgrade stays visible.
+Inspect your runtime's skill-discovery rules and project every `cp-skill-*` directory into that surface — copy, plugin registration, or IDE-specific import. The canonical content stays under `kb/commonplace/instructions/`; rerunning `commonplace-init` after an upgrade reports projected copies that drifted from that source without overwriting them.
 
 ## 6. Start the runtime
 

--- a/kb/instructions/cp-skill-health-check/SKILL.md
+++ b/kb/instructions/cp-skill-health-check/SKILL.md
@@ -49,10 +49,11 @@ Interpretation:
 Run:
 
 ```bash
-# Use find -L so it follows symlinked skill directories. The known
-# .claude/.agents projections are usually symlinks into the canonical skill
-# source tree, and plain `find` (without -L) will not descend into them,
-# returning a misleading empty result.
+# Use find -L so it also follows symlinked skill directories. In an installed
+# KB the known .claude/.agents projections are real copied directories, but in
+# the Commonplace source repo (and installs from older versions) they are
+# symlinks into the canonical skill source tree, and plain `find` (without -L)
+# will not descend into those, returning a misleading empty result.
 find -L .claude/skills .agents/skills -maxdepth 2 -name SKILL.md -print 2>/dev/null | sort
 # Derive the expected promoted set from the live skill source tree
 # (kb/commonplace/instructions/ in an installed KB, kb/instructions/ in the

--- a/kb/reference/README.md
+++ b/kb/reference/README.md
@@ -205,6 +205,7 @@ Imperative how-to procedures live in [kb/instructions/](../instructions/) rather
 
 - [ADR-021: ship library content under kb/commonplace](./adr/021-ship-library-content-under-kb-commonplace.md) — the library/user boundary, path invariance rules, and scaffold layout behind the current installed surface
 - [ADR-027: package scaffold assets without source-tree symlinks](./adr/027-package-scaffold-assets-without-source-tree-symlinks.md) — the current packaging mechanism for scaffold assets in source checkouts, sdists, and wheels
+- [ADR-037: promote skills into runtime surfaces by copying](./adr/037-promote-skills-into-runtime-surfaces-by-copying.md) — why `commonplace-init` copies skill directories instead of symlinking or junctioning them
 - [ADR-014: scripts as python package, one-tree model](./adr/014-scripts-as-python-package-one-tree-model.md) — the packaging and install decision ADR-021 refines
 - [ADR-012: types for structure, traits for review](./adr/012-types-for-structure-traits-for-review.md) — why structural types and semantic-review traits are separate axes
 - [ADR-015: standardize authored type definitions on JSON schema](./adr/015-standardize-authored-type-definitions-on-json-schema.md) — the authored type-definition format

--- a/kb/reference/adr/037-promote-skills-into-runtime-surfaces-by-copying.md
+++ b/kb/reference/adr/037-promote-skills-into-runtime-surfaces-by-copying.md
@@ -1,0 +1,49 @@
+---
+description: Replaces symlink and Windows-junction skill projections with real copied directories in commonplace-init, migrating legacy links to copies on re-init
+type: ../types/adr.md
+tags: []
+status: accepted
+---
+
+# 037-Promote skills into runtime surfaces by copying
+
+**Status:** accepted
+**Date:** 2026-07-03
+
+## Context
+
+Since ADR 006, `commonplace-init` promoted shipped skills into the known runtime discovery surfaces (`.claude/skills/`, `.agents/skills/`) as symlinks into the canonical `kb/commonplace/instructions/<name>/` directories, keeping one authoritative copy of each skill. On Windows, where real symlinks require admin rights or Developer Mode, the installer fell back to directory junctions created through the stdlib `_winapi.CreateJunction`.
+
+The link-based projection kept producing Windows problems. Symlink creation fails without elevated privileges; junctions require an absolute target on a local volume, so they break when a project moves and are skipped entirely on network volumes and sandboxed filesystems; and tools vary in how they treat reparse points, so a projection that exists on disk still may not resolve for a given runtime. The projection step was the one part of install that could partially fail, which forced a skip-and-report path in the installer, extra Windows warnings, and manual recovery instructions in INSTALL.md.
+
+ADR 027 already removed symlinks from the packaging side for the same reason: Unix filesystem affordances are the wrong dependency for install correctness once Windows matters.
+
+## Decision
+
+`commonplace-init` copies each promoted skill directory from `kb/commonplace/instructions/<name>/` into every runtime skills directory as regular files. Projected files go through the same per-file `_record_existing` classification as the rest of the scaffold: missing files are created, identical files are preserved silently, and differing files are preserved and reported.
+
+A symlink or junction found at a projection destination — left by an install from an earlier version — is removed and replaced with a copy on re-init. The junction fallback and the skipped-projection reporting are deleted; copying works on every platform, so there is no partial-failure path left.
+
+The canonical contract stays the source directory under `kb/commonplace/instructions/`. The Commonplace source repo keeps its committed relative symlinks under `.claude/skills/` and `.agents/skills/` — those are repo-local development conveniences on platforms that support them, not installer output.
+
+## Consequences
+
+Easier:
+- Install behaves identically on every platform and filesystem; no privilege, Developer Mode, volume, or reparse-point conditions to document or diagnose.
+- The installer loses its only partial-failure path (skipped projections), along with the Windows-specific warning about them.
+- Runtime surfaces contain plain directories that every tool reads without following links.
+
+Harder:
+- Skill content is duplicated: one canonical copy plus one copy per runtime surface. Edits made to a projected copy drift silently until a re-init reports them.
+- Upgrades no longer propagate through a link. Re-running `commonplace-init` reports projected copies that differ from the canonical source but never overwrites them; reconciling is a manual diff-and-merge, consistent with the scaffold-wide "never clobber a practitioner edit" rule.
+
+Risks:
+- Users may edit a runtime copy instead of the canonical source and lose the edit's authority; the re-init drift report is the only signal.
+
+## Links
+
+- [006-two-tree-installation-layout](./006-two-tree-installation-layout.md) — refines: replaces the symlinked skill promotion that layout introduced
+- [014-scripts-as-python-package-one-tree-model](./014-scripts-as-python-package-one-tree-model.md) — refines: keeps the package-and-init model while changing the projection mechanism
+- [021-ship-library-content-under-kb-commonplace](./021-ship-library-content-under-kb-commonplace.md) — implements: projects from the `kb/commonplace/instructions/` source path that decision fixed
+- [027-package-scaffold-assets-without-source-tree-symlinks](./027-package-scaffold-assets-without-source-tree-symlinks.md) — extends: removes the remaining install-time symlink dependency after packaging-time symlinks were removed
+- [instruction-generation](../instruction-generation.md) — implemented-by: skill projection section describing the copy behavior

--- a/kb/reference/architecture.md
+++ b/kb/reference/architecture.md
@@ -70,7 +70,7 @@ The Python package carries the scaffold inputs as packaged data in built wheels.
 | `kb/tasks/` | User's task lifecycle artifacts |
 | `kb/work/` | User's temporal workshop material |
 | `kb/reports/` | User's generated operational artifacts |
-| `.claude/skills/`, `.agents/skills/` | Optional known runtime skill projections into `kb/commonplace/instructions/`; other runtimes may need their own projection |
+| `.claude/skills/`, `.agents/skills/` | Known runtime skill projections — copies of the `kb/commonplace/instructions/` skill directories; other runtimes may need their own projection |
 
 ## How the shipped surface is produced
 
@@ -79,7 +79,7 @@ The Python package carries the scaffold inputs as packaged data in built wheels.
 1. Creates the directory shell under `kb/` — the user's collections, the user-space directories, and the `kb/commonplace/` hierarchy.
 2. Copies shipped library trees into `kb/commonplace/{notes,reference,instructions}/`. Shared `kb/types/` and user-space type scaffolds (`kb/sources/types/`, `kb/reports/types/`) land at their conventional top-level locations.
 3. Scaffolds minimal `COLLECTION.md` templates into the user's empty collections so that write skills have a starter register and conventions stub to fill in.
-4. Attempts to promote selected skills into known `.claude/skills/cp-skill-*/` and `.agents/skills/cp-skill-*/` runtime surfaces — as symlinks into `kb/commonplace/instructions/<name>/`, or, on Windows where symlinks need admin rights or Developer Mode, as directory junctions (via the stdlib `_winapi.CreateJunction`) — and resolves project-specific templates such as `AGENTS.md` and `.envrc`. If neither a symlink nor a junction can be created, the canonical skill directories remain installed under `kb/commonplace/instructions/`; other agent runtimes may need to link, copy, register, or import those directories into their own discovery surface.
+4. Promotes selected skills into known `.claude/skills/cp-skill-*/` and `.agents/skills/cp-skill-*/` runtime surfaces as real copied directories of `kb/commonplace/instructions/<name>/` (legacy symlink or junction projections from earlier versions are replaced with copies on re-init), and resolves project-specific templates such as `AGENTS.md` and `.envrc`. The canonical skill directories stay installed under `kb/commonplace/instructions/`; agent runtimes with a different discovery surface may need to copy, register, or import those directories themselves.
 
 The result is that the agent's hot path stays inside the project tree. It reads `AGENTS.md`, the target collection's `COLLECTION.md`, and the relevant type files directly from the installed KB rather than jumping out to a separate framework checkout.
 

--- a/kb/reference/commands.md
+++ b/kb/reference/commands.md
@@ -13,7 +13,7 @@ All commands are installed by `pip install llm-commonplace` and available as `co
 
 ### commonplace-init
 
-Initialize or update a Commonplace project. Creates KB directories, seeds instructions and type definitions, attempts known `.claude/skills/` and `.agents/skills/` projections for shipped skills, and resolves templates. If those optional projections cannot be created, other runtimes can still expose the canonical `kb/commonplace/instructions/cp-skill-*` directories through their own skill mechanism.
+Initialize or update a Commonplace project. Creates KB directories, seeds instructions and type definitions, copies shipped skills into the known `.claude/skills/` and `.agents/skills/` runtime layouts, and resolves templates. Runtimes with a different skill-discovery surface can expose the canonical `kb/commonplace/instructions/cp-skill-*` directories through their own skill mechanism.
 
 ```bash
 commonplace-init --name <project-name>

--- a/kb/reference/instruction-generation.md
+++ b/kb/reference/instruction-generation.md
@@ -80,9 +80,9 @@ In addition to copying the instructions tree under `kb/commonplace/instructions/
 - `.claude/skills/cp-skill-<skill>/`
 - `.agents/skills/cp-skill-<skill>/`
 
-Each generated projection is normally a **symlink** pointing at `kb/commonplace/instructions/cp-skill-<skill>/`, keeping skill discovery working for those runtimes while the canonical skill content stays in one place inside the shipped library. On Windows, where symlinks require admin rights or Developer Mode, `init_project` falls back to a **directory junction** (via the stdlib `_winapi.CreateJunction`, which creates the link directory itself and needs neither privilege). Only if both the symlink and the junction fail does initialization preserve the canonical skill directories and report the optional runtime projections as skipped.
+Each generated projection is a **real copied directory** of `kb/commonplace/instructions/cp-skill-<skill>/`. Earlier versions projected symlinks with a Windows directory-junction fallback, but both link forms kept failing or misbehaving on Windows (ADR-037); `init_project` now copies unconditionally and replaces a legacy symlink or junction found at the destination with a copy on re-init. Projected files are classified per file by the same `_record_existing` rules as the rest of the scaffold, so a re-run reports copies that drifted from the canonical source without overwriting them.
 
-The canonical contract is the source directory, not the two generated layouts. Agent runtimes and IDEs that use another skill surface must link, copy, register, or import the same `kb/commonplace/instructions/cp-skill-*` directories according to their own rules.
+The canonical contract is the source directory, not the two generated layouts. Agent runtimes and IDEs that use another skill surface must copy, register, or import the same `kb/commonplace/instructions/cp-skill-*` directories according to their own rules.
 
 ## Re-running init
 

--- a/kb/reference/scenario-architecture.md
+++ b/kb/reference/scenario-architecture.md
@@ -19,7 +19,7 @@ An installed project has one `kb/` root containing two coexisting surfaces:
 Plus two supporting runtime surfaces:
 
 - `commonplace-*` commands provided by the installed Python package
-- promoted framework skills under `.claude/skills/` and `.agents/skills/` (symlinks, or directory junctions on Windows, into `kb/commonplace/instructions/`)
+- promoted framework skills under `.claude/skills/` and `.agents/skills/` (copies of the `kb/commonplace/instructions/` skill directories)
 
 There is no separate vendored `commonplace/` framework tree. The agent's normal path stays inside the project:
 

--- a/src/commonplace/cli/init_project.py
+++ b/src/commonplace/cli/init_project.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import stat
 import sys
 from dataclasses import dataclass, field
 from importlib.resources import as_file, files
@@ -18,7 +19,6 @@ class InitReport:
     created: list[Path] = field(default_factory=list)
     preserved_identical: list[Path] = field(default_factory=list)
     preserved_different: list[Path] = field(default_factory=list)
-    skipped: list[tuple[Path, str]] = field(default_factory=list)
 
 
 def _record_existing(
@@ -36,15 +36,13 @@ def _record_existing(
     report.preserved_different.append(rel_path)
 
 
-def _copy_scaffold_tree(
-    scaffold_root: Path,
-    src_rel: str,
+def _copy_tree_files(
+    src_dir: Path,
     dest_root: Path,
-    target_rel: str,
+    target_rel: str | Path,
     report: InitReport,
 ) -> None:
-    """Recursively copy a scaffold subtree, classifying existing files."""
-    src_dir = _resolve_scaffold_source(scaffold_root, src_rel)
+    """Recursively copy a directory tree, classifying existing files."""
     for src_file in sorted(src_dir.rglob("*")):
         if not src_file.is_file():
             continue
@@ -58,6 +56,18 @@ def _copy_scaffold_tree(
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src_file, target)
         report.created.append(rel_path)
+
+
+def _copy_scaffold_tree(
+    scaffold_root: Path,
+    src_rel: str,
+    dest_root: Path,
+    target_rel: str,
+    report: InitReport,
+) -> None:
+    """Recursively copy a scaffold subtree, classifying existing files."""
+    src_dir = _resolve_scaffold_source(scaffold_root, src_rel)
+    _copy_tree_files(src_dir, dest_root, target_rel, report)
 
 
 def _copy_scaffold_file(
@@ -125,26 +135,30 @@ def _resolve_scaffold_source(scaffold_root: Path, src_rel: str) -> Path:
     raise FileNotFoundError(f"Scaffold source is missing: {src_rel}")
 
 
-def _create_junction(target: Path, link: Path) -> bool:
-    """Create a Windows directory junction at ``link`` pointing to ``target``.
+def _is_filesystem_link(path: Path) -> bool:
+    """True for a symlink or a Windows reparse point (junction).
 
-    Junctions need neither admin rights nor Developer Mode, unlike real symlinks.
-    Uses the stdlib ``_winapi.CreateJunction`` (Windows-only, undocumented but
-    stable). Returns ``True`` on success, ``False`` if the call is unavailable
-    or fails. The target is resolved to an absolute path, as junctions require.
-
-    ``CreateJunction`` creates the ``link`` directory itself (via
-    ``CreateDirectoryW``) and then sets its reparse point, so ``link`` must not
-    already exist — the caller guarantees this by only falling back here after
-    the ``symlink_to`` attempt on an absent path.
+    Earlier versions projected skills as symlinks with a junction fallback;
+    re-init replaces those with real copies. ``Path.is_junction`` only exists
+    on Python 3.12+, so junctions are detected through ``st_file_attributes``
+    (present only on Windows stat results).
     """
+    if path.is_symlink():
+        return True
     try:
-        import _winapi
-
-        _winapi.CreateJunction(str(target.resolve()), str(link))
-    except (OSError, AttributeError, ImportError):
+        attributes = os.lstat(path).st_file_attributes  # type: ignore[attr-defined]
+    except (OSError, AttributeError):
         return False
-    return True
+    return bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _remove_filesystem_link(path: Path) -> None:
+    """Remove a symlink or junction without touching its target's contents."""
+    try:
+        path.unlink()
+    except OSError:
+        # On Windows, directory symlinks and junctions are removed with rmdir.
+        os.rmdir(path)
 
 
 def init_project(root: Path, name: str | None = None) -> InitReport:
@@ -190,9 +204,11 @@ def init_project(root: Path, name: str | None = None) -> InitReport:
             _write_template(src, target, Path(target_rel), replacements, report)
 
     # Promote selected instruction directories into runtime skills directories
-    # via symlinks. The source is the local kb/commonplace/instructions/<name>
+    # by copying. The source is the local kb/commonplace/instructions/<name>
     # directory (scaffolded above from the shipped library), not the scaffold
-    # package itself.
+    # package itself. Copies work on every platform; the symlinks (and Windows
+    # junction fallback) earlier versions used kept breaking on Windows, so a
+    # legacy link found at the destination is replaced with a real copy.
     for skill_name in MANIFEST.promoted_skills:
         skill_src = root / "kb" / "commonplace" / "instructions" / skill_name
         if not skill_src.is_dir():
@@ -200,36 +216,10 @@ def init_project(root: Path, name: str | None = None) -> InitReport:
                 f"Promoted skill source is missing: kb/commonplace/instructions/{skill_name}"
             )
         for skills_dest in MANIFEST.skills_dirs:
-            link = root / skills_dest / skill_name
-            link.parent.mkdir(parents=True, exist_ok=True)
-            # Compute relative path from the link's parent to the source.
-            target = Path(os.path.relpath(skill_src, link.parent))
-            if link.is_symlink():
-                if link.resolve() == skill_src.resolve():
-                    report.preserved_identical.append(skills_dest / skill_name)
-                    continue
-                link.unlink()
-            elif link.exists():
-                # A real directory or file may be an intentional runtime-specific
-                # skill projection on platforms that cannot follow symlinks.
-                report.preserved_different.append(skills_dest / skill_name)
-                continue
-            try:
-                link.symlink_to(target, target_is_directory=True)
-            except OSError as exc:
-                # On Windows, real symlinks need admin rights or Developer Mode.
-                # A directory junction needs neither and is followed transparently
-                # by tools reading the directory, so fall back to one. Junctions
-                # require an absolute target on the same local volume, so they do
-                # not survive a project move the way the relative symlink does.
-                # `_create_junction` returns False off Windows (no `_winapi`), so
-                # this path is a no-op there and the projection stays skipped.
-                if _create_junction(skill_src, link):
-                    report.created.append(skills_dest / skill_name)
-                    continue
-                report.skipped.append((skills_dest / skill_name, str(exc)))
-                continue
-            report.created.append(skills_dest / skill_name)
+            target = root / skills_dest / skill_name
+            if _is_filesystem_link(target):
+                _remove_filesystem_link(target)
+            _copy_tree_files(skill_src, root, skills_dest / skill_name, report)
 
     return report
 
@@ -260,12 +250,6 @@ def direnv_warnings(root: Path) -> list[str]:
         lines.append(
             "PowerShell activation: '.\\.venv\\Scripts\\Activate.ps1'. cmd "
             "activation: '.venv\\Scripts\\activate.bat'."
-        )
-        lines.append(
-            "Skill projection uses a directory junction on Windows (no admin "
-            "rights or Developer Mode needed). If even that is skipped (network "
-            "volume, sandboxed filesystem), install the cp-skill-* directories "
-            "into your agent runtime's skill surface manually."
         )
         lines.append(
             "See INSTALL.md step 2 (Install the library and make the commands "
@@ -342,19 +326,10 @@ def main(argv: list[str] | None = None) -> int:
         print("Preserved existing files differing from current scaffold output:")
         for path in report.preserved_different:
             print(f"- {path.as_posix()}")
-    if report.skipped:
-        print("Skipped optional runtime skill projections:")
-        for path, reason in report.skipped:
-            print(f"- {path.as_posix()}: {reason}")
-        print(
-            "Install the matching kb/commonplace/instructions/cp-skill-* directories "
-            "through your agent runtime's own skill mechanism if needed."
-        )
     if (
         not report.created
         and not report.preserved_identical
         and not report.preserved_different
-        and not report.skipped
     ):
         print("No changes needed.")
 

--- a/src/commonplace/scaffold_manifest.py
+++ b/src/commonplace/scaffold_manifest.py
@@ -73,7 +73,7 @@ MANIFEST = ScaffoldManifest(
         ("AGENTS.md.template", "AGENTS.md.template"),
         (".envrc.template", ".envrc"),
     ),
-    # Skill directories for supported runtimes; promoted skills are symlinked
+    # Skill directories for supported runtimes; promoted skills are copied
     # into each from kb/commonplace/instructions/<name>.
     skills_dirs=(
         Path(".claude/skills"),

--- a/test/commonplace/cli/test_init_project.py
+++ b/test/commonplace/cli/test_init_project.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -12,7 +14,6 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from commonplace.cli import init_project as init_project_module  # noqa: E402
-from commonplace.scaffold_manifest import MANIFEST  # noqa: E402
 from commonplace.cli.init_project import (  # noqa: E402
     direnv_warnings,
     init_project,
@@ -89,7 +90,7 @@ def test_init_project_seeds_scaffold_files(tmp_path: Path) -> None:
     assert (tmp_path / "AGENTS.md.template").is_file()
 
 
-def test_init_project_installs_skills_as_symlinks(tmp_path: Path) -> None:
+def test_init_project_installs_skills_as_copies(tmp_path: Path) -> None:
     init_project(tmp_path)
 
     for skills_dir in (
@@ -104,72 +105,38 @@ def test_init_project_installs_skills_as_symlinks(tmp_path: Path) -> None:
             "cp-skill-connect",
             "cp-skill-health-check",
         ):
-            link = skills_dir / skill_name
-            assert link.is_symlink(), f"{link} should be a symlink"
-            assert (link / "SKILL.md").is_file()
-            # Symlink points back into the shipped library.
-            assert link.resolve() == (tmp_path / "kb" / "commonplace" / "instructions" / skill_name).resolve()
+            dest = skills_dir / skill_name
+            assert dest.is_dir()
+            assert not dest.is_symlink(), f"{dest} should be a real directory"
+            source = tmp_path / "kb" / "commonplace" / "instructions" / skill_name
+            assert (dest / "SKILL.md").read_bytes() == (source / "SKILL.md").read_bytes()
 
 
-def test_init_project_skips_skill_projection_when_symlinks_are_unavailable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    def fail_symlink(
-        self: Path,
-        target: str | Path,
-        target_is_directory: bool = False,
-    ) -> None:
-        raise OSError("symbolic link privilege not held")
-
-    monkeypatch.setattr(Path, "symlink_to", fail_symlink)
-
-    report = init_project(tmp_path)
-
-    assert (tmp_path / "kb" / "commonplace" / "instructions" / "cp-skill-write" / "SKILL.md").is_file()
-    assert not (tmp_path / ".claude" / "skills" / "cp-skill-write").exists()
-    assert len(report.skipped) == (
-        len(MANIFEST.promoted_skills) * len(MANIFEST.skills_dirs)
+def test_init_project_replaces_legacy_symlink_projection_with_copy(tmp_path: Path) -> None:
+    init_project(tmp_path)
+    source = tmp_path / "kb" / "commonplace" / "instructions" / "cp-skill-write"
+    link = tmp_path / ".claude" / "skills" / "cp-skill-write"
+    shutil.rmtree(link)
+    link.symlink_to(
+        Path(os.path.relpath(source, link.parent)), target_is_directory=True
     )
-    assert any("symbolic link privilege not held" in reason for _, reason in report.skipped)
-
-
-def test_init_project_falls_back_to_junction_when_symlink_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    def fail_symlink(
-        self: Path,
-        target: str | Path,
-        target_is_directory: bool = False,
-    ) -> None:
-        raise OSError("symbolic link privilege not held")
-
-    created: list[tuple[Path, Path]] = []
-
-    def fake_junction(target: Path, link: Path) -> bool:
-        link.mkdir(parents=True, exist_ok=True)
-        created.append((target, link))
-        return True
-
-    monkeypatch.setattr(Path, "symlink_to", fail_symlink)
-    monkeypatch.setattr(init_project_module, "_create_junction", fake_junction)
 
     report = init_project(tmp_path)
 
-    assert Path(".claude/skills/cp-skill-write") in report.created
-    assert not report.skipped
-    assert len(created) == len(MANIFEST.promoted_skills) * len(MANIFEST.skills_dirs)
+    assert not link.is_symlink()
+    assert Path(".claude/skills/cp-skill-write/SKILL.md") in report.created
+    assert (link / "SKILL.md").read_bytes() == (source / "SKILL.md").read_bytes()
 
 
 def test_init_project_preserves_existing_real_skill_projection(tmp_path: Path) -> None:
-    link = tmp_path / ".claude" / "skills" / "cp-skill-write"
-    link.mkdir(parents=True)
-    (link / "SKILL.md").write_text("runtime-specific copy", encoding="utf-8")
+    dest = tmp_path / ".claude" / "skills" / "cp-skill-write"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text("runtime-specific copy", encoding="utf-8")
 
     report = init_project(tmp_path)
 
-    assert Path(".claude/skills/cp-skill-write") in report.preserved_different
-    assert not link.is_symlink()
-    assert (link / "SKILL.md").read_text(encoding="utf-8") == "runtime-specific copy"
+    assert Path(".claude/skills/cp-skill-write/SKILL.md") in report.preserved_different
+    assert (dest / "SKILL.md").read_text(encoding="utf-8") == "runtime-specific copy"
 
 
 def test_init_project_resolves_templates(tmp_path: Path) -> None:

--- a/test/commonplace/cli/test_init_project.py
+++ b/test/commonplace/cli/test_init_project.py
@@ -117,9 +117,12 @@ def test_init_project_replaces_legacy_symlink_projection_with_copy(tmp_path: Pat
     source = tmp_path / "kb" / "commonplace" / "instructions" / "cp-skill-write"
     link = tmp_path / ".claude" / "skills" / "cp-skill-write"
     shutil.rmtree(link)
-    link.symlink_to(
-        Path(os.path.relpath(source, link.parent)), target_is_directory=True
-    )
+    try:
+        link.symlink_to(
+            Path(os.path.relpath(source, link.parent)), target_is_directory=True
+        )
+    except OSError:
+        pytest.skip("cannot create the legacy symlink this test simulates")
 
     report = init_project(tmp_path)
 

--- a/test/commonplace/lib/extraction/test_frontmatter_aggregate.py
+++ b/test/commonplace/lib/extraction/test_frontmatter_aggregate.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 
 SRC_ROOT = Path(__file__).resolve().parents[5] / "src"
 if str(SRC_ROOT) not in sys.path:
@@ -71,7 +73,10 @@ def test_list_values_group_by_string_item(tmp_path: Path) -> None:
 def test_skips_symlinks(tmp_path: Path) -> None:
     real = write(tmp_path / "real.md", "---\nstatus: real\n---\n# R\n")
     link = tmp_path / "link.md"
-    link.symlink_to(real)
+    try:
+        link.symlink_to(real)
+    except OSError:
+        pytest.skip("cannot create symlinks on this platform")
 
     result = frontmatter_aggregate.aggregate_field("status", roots=[tmp_path])
 

--- a/test/commonplace/lib/extraction/test_link_audit.py
+++ b/test/commonplace/lib/extraction/test_link_audit.py
@@ -85,7 +85,10 @@ def test_recurses_subdirectories(tmp_path: Path) -> None:
 def test_skips_symlinks(tmp_path: Path) -> None:
     real = write(tmp_path / "real.md", "[real](./r.md)")
     link = tmp_path / "link.md"
-    link.symlink_to(real)
+    try:
+        link.symlink_to(real)
+    except OSError:
+        pytest.skip("cannot create symlinks on this platform")
 
     found = link_audit.find_links(roots=[tmp_path])
 


### PR DESCRIPTION
## Summary

Changes skill promotion from symlink/junction-based projection to real directory copies. This eliminates platform-specific failures on Windows and simplifies the install process by removing the only partial-failure path in `commonplace-init`.

## Key Changes

- **Refactor tree-copy logic**: Extract `_copy_tree_files()` as a reusable function for copying directory trees with per-file classification (created/preserved identical/preserved different). `_copy_scaffold_tree()` now delegates to it.

- **Replace symlink projection with copying**: Promoted skills are now copied from `kb/commonplace/instructions/<name>/` into runtime surfaces (`.claude/skills/`, `.agents/skills/`) as regular directories instead of symlinks or Windows junctions.

- **Handle legacy links on re-init**: Add `_is_filesystem_link()` to detect symlinks and Windows reparse points (junctions), and `_remove_filesystem_link()` to safely remove them. When re-running init, any legacy link at a projection destination is removed and replaced with a copy.

- **Remove junction fallback**: Delete `_create_junction()` and the `_winapi.CreateJunction` Windows-specific code path. Copying works identically on all platforms.

- **Simplify reporting**: Remove the `skipped` field from `InitReport` — there is no longer a partial-failure path. All projections either succeed or are preserved if they already exist and differ from the source.

- **Update documentation**: Revise INSTALL.md, architecture.md, instruction-generation.md, and other references to describe projections as copies rather than symlinks/junctions. Remove Windows-specific warnings about privilege requirements and junction limitations.

- **Update tests**: Replace symlink-specific tests with copy-based tests. Add test for legacy symlink replacement. Remove tests for junction fallback and skipped projections.

- **Add ADR 037**: Documents the decision to use copies instead of links, rationale (platform consistency, no partial failures), and consequences (duplication, manual reconciliation on upgrades).

## Implementation Details

- `_copy_tree_files()` uses the same per-file `_record_existing()` classification as scaffold copying, so projected files follow the "never clobber a practitioner edit" rule.
- Legacy link detection uses `Path.is_symlink()` for symlinks and `st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT` for Windows junctions (since `Path.is_junction()` is Python 3.12+ only).
- Link removal handles both symlinks (`unlink()`) and directory junctions (`rmdir()` on Windows OSError fallback).
- The canonical skill source remains `kb/commonplace/instructions/`; the Commonplace repo's own `.claude/skills/` and `.agents/skills/` symlinks are development conveniences, not installer output.

https://claude.ai/code/session_01H6pSP5mGyZ9wfBM9C4rJFc