### PR TITLE
Draft content-first landing page for agentic-systems builders

### DIFF
--- a/kb/work/positioning/landing-for-agentic-systems-builders.md
+++ b/kb/work/positioning/landing-for-agentic-systems-builders.md
@@ -1,7 +1,11 @@
 <!-- Draft (2026-07-04): second landing page — content-first framing for agentic-systems
 builders. Sells the KB as a ready-to-use catalogue of problems and solutions; the framework
 is the reveal, not the pitch. Complements the-knowledge-layer-for-ai-agents.md (framework-first,
-for people who want to build their own KB). Same repo, two doors. -->
+for people who want to build their own KB). Same repo, two doors.
+Updated 2026-07-04: usage section reframed as "interactive textbook that lives in your repo"
+(install = clone/submodule + one CLAUDE.md routing line); reading path split out to
+textbook-syllabus.md. Still missing: a published worked example of the point-it-at-your-code
+loop (a transcript of the KB critiquing a real design). -->
 
 # The hard problems of agentic systems, catalogued
 
@@ -18,13 +22,17 @@ The model is the part you don't control and mostly don't need to. What decides w
 
 Coverage today is deepest on the knowledge side of agentic systems: how agents get context, keep memory, learn from deployment, and fail. New areas are being added; the catalogue grows the way it was built — one reviewed claim at a time.
 
-## Three ways to use it
+## An interactive textbook that lives in your repo
 
-**Read it.** Start from a design decision you're facing. Choosing a memory architecture? The comparative review shows that the real fork isn't storage format but [who decides what to remember, and whether memory ever reaches behavior](../../notes/knowledge-storage-does-not-imply-contextual-activation.md). Wondering why your agents don't improve? [Deploy-time learning is the missing middle](../../notes/deploy-time-learning-is-the-missing-middle.md) between retraining and prompting. Betting on in-context learning? [It presupposes context engineering](../../notes/in-context-learning-presupposes-context-engineering.md) — the selection machinery is the actual system.
+A textbook's failure mode is the shelf: the knowledge exists, but it's nowhere near the context window when the design decision gets made. This one installs where the decisions happen. Clone it — or add it as a git submodule — next to your code, and put one routing line in your project's `CLAUDE.md` or `AGENTS.md`: *"for context, memory, or learning design decisions, consult the knowledge base first."* That's the whole integration. Plain markdown in git, written to be navigated by agents — claim-as-title headings, retrieval-oriented descriptions, curated indexes, typed links. No API, no service, no second runtime to trust.
 
-**Give it to your agents.** The knowledge base is plain markdown in git, written to be navigated by agents: claim-as-title headings, retrieval-oriented descriptions, curated indexes, typed links. Clone the repo, point your coding agent at it, and ask your design question — the agent finds the relevant claims, follows the links between them, and answers with citations you can check. No API, no service, no second runtime to trust.
+Then it's interactive in three ways:
 
-**Argue with it.** Every claim is stated to be contestable, carries its grounding, and marks its own confidence — seedling to current. If your production experience contradicts a note, that's not an attack on the catalogue; that's the catalogue working. Open an issue.
+**Ask it.** Start from a design decision you're facing. Choosing a memory architecture? The comparative review shows that the real fork isn't storage format but [who decides what to remember, and whether memory ever reaches behavior](../../notes/knowledge-storage-does-not-imply-contextual-activation.md). Wondering why your agents don't improve? [Deploy-time learning is the missing middle](../../notes/deploy-time-learning-is-the-missing-middle.md) between retraining and prompting. Betting on in-context learning? [It presupposes context engineering](../../notes/in-context-learning-presupposes-context-engineering.md) — the selection machinery is the actual system. New to the field? [Follow the reading path](./textbook-syllabus.md) — a curated spine through the graph, one hour end to end.
+
+**Point it at your code.** This is the move no paper textbook, course, or docs site can make: your agent holds the textbook and your codebase in the same context. "Does our memory design have [the cross-contamination failure the flat-memory note predicts](../../notes/flat-memory-predicts-specific-cross-contamination-failures-that-are.md)?" is now an answerable question about *your* system, with citations on one side and your source files on the other. The textbook reads your homework.
+
+**Argue with it.** Every claim is stated to be contestable, carries its grounding, and marks its own confidence — seedling to current. If your production experience contradicts a note, that's not an attack on the textbook; that's how it gets its next edition. Open an issue.
 
 ## Why trust a catalogue
 

--- a/kb/work/positioning/landing-for-agentic-systems-builders.md
+++ b/kb/work/positioning/landing-for-agentic-systems-builders.md
@@ -1,0 +1,45 @@
+<!-- Draft (2026-07-04): second landing page — content-first framing for agentic-systems
+builders. Sells the KB as a ready-to-use catalogue of problems and solutions; the framework
+is the reveal, not the pitch. Complements the-knowledge-layer-for-ai-agents.md (framework-first,
+for people who want to build their own KB). Same repo, two doors. -->
+
+# The hard problems of agentic systems, catalogued
+
+The model is the part you don't control and mostly don't need to. What decides whether your agentic system works is everything around it: whether the right knowledge reaches the context window at the right time, whether the system learns from its deployment or repeats its mistakes, whether its memory can be trusted, and whether it fails loudly or silently. These problems recur in every agentic system ever built — and they have general formulations, and known solutions, scattered across hundreds of codebases, papers, and threads.
+
+**This knowledge base catalogues those problems and their solutions in their most general formulations.** Not vendor takes, not framework tutorials — transferable claims about mechanisms, each stated as a sentence you can test against your own system.
+
+## What's inside
+
+- **220+ theory notes** on context engineering, agent memory, deploy-time learning, and failure modes. Each note's title is its claim; each carries a description, a reliability status, and labeled links to the claims that ground or contradict it.
+- **141 code-grounded reviews of agent memory systems** — Mem0, Graphiti, Letta, Cognee, GBrain, and 136 more — classified on shared axes (storage substrate, lineage, behavioral authority, activation), plus [a comparative analysis of what the full matrix shows](../../agent-memory-systems/agentic-memory-systems-comparative-review.md). Code-grounded means we read the source, not the README.
+- **Whole-system analyses** of agentic harnesses and orchestration layers — execution loops, control surfaces, learning loops.
+- **A worked vocabulary** — distillation, constraining, codification, activation, deploy-time learning — so design conversations stop talking past each other.
+
+Coverage today is deepest on the knowledge side of agentic systems: how agents get context, keep memory, learn from deployment, and fail. New areas are being added; the catalogue grows the way it was built — one reviewed claim at a time.
+
+## Three ways to use it
+
+**Read it.** Start from a design decision you're facing. Choosing a memory architecture? The comparative review shows that the real fork isn't storage format but [who decides what to remember, and whether memory ever reaches behavior](../../notes/knowledge-storage-does-not-imply-contextual-activation.md). Wondering why your agents don't improve? [Deploy-time learning is the missing middle](../../notes/deploy-time-learning-is-the-missing-middle.md) between retraining and prompting. Betting on in-context learning? [It presupposes context engineering](../../notes/in-context-learning-presupposes-context-engineering.md) — the selection machinery is the actual system.
+
+**Give it to your agents.** The knowledge base is plain markdown in git, written to be navigated by agents: claim-as-title headings, retrieval-oriented descriptions, curated indexes, typed links. Clone the repo, point your coding agent at it, and ask your design question — the agent finds the relevant claims, follows the links between them, and answers with citations you can check. No API, no service, no second runtime to trust.
+
+**Argue with it.** Every claim is stated to be contestable, carries its grounding, and marks its own confidence — seedling to current. If your production experience contradicts a note, that's not an attack on the catalogue; that's the catalogue working. Open an issue.
+
+## Why trust a catalogue
+
+Because you can audit it. Every artifact here passed typed validation and review before it landed, every change to it is a git diff, and every claim links to what grounds it. The system reviews are grounded in source code you can go read. Where a claim is still speculative, its status says so — you always know what's load-bearing and what's a seedling.
+
+And because the catalogue is used the way it recommends: this knowledge base is maintained by AI agents following a methodology that is itself part of the knowledge base. The comparative analysis of 141 memory systems was mostly agent-produced — an agent traversing linked reviews and finding the pattern. The catalogue about making agents knowledgeable is produced by agents made knowledgeable by it.
+
+## Who this is for
+
+Teams building agentic systems who are past the demo stage: you're deciding memory architecture, context strategy, or how your agents should learn from deployment, and you'd rather start from general formulations of the problem than rediscover it in production. Read first, no buy-in required.
+
+If the catalogue proves useful and you want your *own* domain captured this way — your operational knowledge, typed, linked, review-gated, maintained by your agents — that's [Commonplace, the framework this knowledge base runs on](https://github.com/zby/commonplace).
+
+---
+
+[Read the comparative review →](../../agent-memory-systems/agentic-memory-systems-comparative-review.md)
+[Browse by topic →](../../notes/tags-README.md)
+[Browse the system reviews →](../../agent-memory-systems/README.md)

--- a/kb/work/positioning/textbook-syllabus.md
+++ b/kb/work/positioning/textbook-syllabus.md
@@ -1,0 +1,47 @@
+<!-- Draft (2026-07-04): the reading path that makes the "interactive textbook" claim real —
+a curated spine through the graph for a newcomer. Companion to
+landing-for-agentic-systems-builders.md. Promotion target once stable: a curated index
+in the library (location TBD — kb/notes/ index or site page). -->
+
+# Reading path: the knowledge layer of agentic systems
+
+A curated spine through the knowledge base for builders new to it. Every note's title is its claim; each step builds on the ones before it. Read it yourself in an hour, or hand this file to your coding agent as the traversal order and ask your questions as you go.
+
+## Part 1 — The constraint
+
+Everything in agentic-system design is downstream of one scarce resource.
+
+1. [Agent context is constrained by soft degradation, not hard token limits](../../notes/agent-context-is-constrained-by-soft-degradation-not-hard-token-limits.md) — the binding constraint is silent reliability degradation across volume, complexity, and interference, not the provider's token limit.
+2. [Context efficiency is the central design concern in agent systems](../../notes/context-efficiency-is-the-central-design-concern-in-agent-systems.md) — context is scarce for two distinct reasons, feasibility and cost, and feasibility binds first; nearly every architectural pattern is a response to this pressure.
+3. [Context engineering](../../notes/definitions/context-engineering.md) — the discipline this forces: getting the right knowledge into a bounded context at the right time.
+
+## Part 2 — Knowledge that changes behavior
+
+Storing knowledge is easy. Making it change what the agent does is the actual problem.
+
+4. [Knowledge storage does not imply contextual activation](../../notes/knowledge-storage-does-not-imply-contextual-activation.md) — the load-bearing distinction of the whole KB: knowledge that exists, knowledge loaded into context, and knowledge that actually changes behavior are three different things.
+5. [In-context learning presupposes context engineering](../../notes/in-context-learning-presupposes-context-engineering.md) — "the model will figure it out from context" assumes selection machinery that is itself a system you have to build and improve.
+6. [Agent memory needs discoverable, composable, trusted knowledge under bounded context](../../notes/agent-memory-needs-discoverable-composable-trusted-knowledge-under.md) — the minimal quality basis for remembered knowledge: if artifacts aren't discoverable, composable, and trusted, storage is dead weight.
+7. [Agent memory is a crosscutting concern, not a separable niche](../../notes/agent-memory-is-a-crosscutting-concern-not-a-separable-niche.md) — memory decomposes into storage (solved), retrieval/activation (Part 1–2), and learning (Part 3); the hard problems live at the intersections, which is why "add a memory product" rarely fixes them.
+
+## Part 3 — Learning during deployment
+
+Your system will meet reality after you ship it. Where does what it learns go?
+
+8. [Deploy-time learning is the missing middle](../../notes/deploy-time-learning-is-the-missing-middle.md) — between slow parametric retraining and ephemeral in-context adaptation sits the underbuilt layer: durable, inspectable artifacts updated across sessions during deployment.
+9. [Distillation](../../notes/definitions/distillation.md) and [constraining](../../notes/definitions/constraining.md) — the two orthogonal moves that layer performs: extracting use-shaped artifacts from larger material, and narrowing the space of valid interpretations (up to [codification](../../notes/definitions/codification.md) into schemas and code).
+10. [Constraining during deployment is continuous learning](../../notes/constraining-during-deployment-is-continuous-learning.md) — continuous learning can happen outside of weights: prompts, schemas, tools, and tests accumulate adaptive capacity you can read and audit.
+
+## Part 4 — When it fails
+
+11. [Interpretation errors are failures of the interpreter](../../notes/interpretation-errors-are-failures-of-the-interpreter.md) — real LLMs violate explicit constraints and fumble fully specified bookkeeping; design for an imperfect interpreter rather than a noisy-but-valid one.
+12. [Failure modes](../../notes/failure-modes-README.md) — the taxonomy of ways knowledge can exist in your system without ever changing agent behavior.
+
+## Capstone — the field, surveyed
+
+- [What the matrix shows across 141 agent memory systems](../../agent-memory-systems/agentic-memory-systems-comparative-review.md) — every claim above, tested against the field: 141 code-grounded reviews classified on shared axes, showing that storage substrate predicts little and the real forks are who decides what to remember and whether memory ever reaches behavior.
+
+## Where next
+
+- [Browse by topic](../../notes/tags-README.md) — the tag hub: foundations, learning theory, context engineering, tool loop, observability, and more.
+- [Browse the system reviews](../../agent-memory-systems/README.md) — find the systems closest to your architecture and read what their source code actually does.


### PR DESCRIPTION
Second landing page in the positioning workshop: pitches the KB itself
as a ready-to-use catalogue of problems and solutions in agentic system
design, with the framework as the reveal rather than the pitch.
Complements the framework-first draft (the-knowledge-layer-for-ai-agents.md).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZZeenDeym8qjD3XzPRqbA