### PR TITLE
Decouple commands from git: package-owned visibility, plain renames

### DIFF
--- a/kb/reference/README.md
+++ b/kb/reference/README.md
@@ -206,6 +206,7 @@ Imperative how-to procedures live in [kb/instructions/](../instructions/) rather
 - [ADR-021: ship library content under kb/commonplace](./adr/021-ship-library-content-under-kb-commonplace.md) — the library/user boundary, path invariance rules, and scaffold layout behind the current installed surface
 - [ADR-027: package scaffold assets without source-tree symlinks](./adr/027-package-scaffold-assets-without-source-tree-symlinks.md) — the current packaging mechanism for scaffold assets in source checkouts, sdists, and wheels
 - [ADR-037: promote skills into runtime surfaces by copying](./adr/037-promote-skills-into-runtime-surfaces-by-copying.md) — why `commonplace-init` copies skill directories instead of symlinking or junctioning them
+- [ADR-039: tool visibility is package-owned and git is never invoked](./adr/039-tool-visibility-is-package-owned-and-git-is-never-invoked.md) — the name-based visibility contract that replaced gitignore filtering and `git mv`
 - [ADR-014: scripts as python package, one-tree model](./adr/014-scripts-as-python-package-one-tree-model.md) — the packaging and install decision ADR-021 refines
 - [ADR-012: types for structure, traits for review](./adr/012-types-for-structure-traits-for-review.md) — why structural types and semantic-review traits are separate axes
 - [ADR-015: standardize authored type definitions on JSON schema](./adr/015-standardize-authored-type-definitions-on-json-schema.md) — the authored type-definition format

--- a/kb/reference/adr/039-tool-visibility-is-package-owned-and-git-is-never-invoked.md
+++ b/kb/reference/adr/039-tool-visibility-is-package-owned-and-git-is-never-invoked.md
@@ -1,0 +1,53 @@
+---
+description: Replaces per-path git check-ignore visibility and git-mv relocation with a package-owned name-based visibility contract; commonplace commands never invoke the git binary
+type: ../types/adr.md
+tags: []
+status: accepted
+---
+
+# 039-Tool visibility is package-owned and git is never invoked
+
+**Status:** accepted
+**Date:** 2026-07-05
+
+## Context
+
+Which files the tools could see was delegated to git: `project_paths.is_git_ignored` spawned one `git check-ignore --no-index` subprocess per file and directory, and every tree enumeration — validation, tag collection, dir-index generation, relocation link rewriting, the mkdocs build hooks — sat on top of it. Relocation additionally preferred `git mv` for moves, silently falling back to `Path.rename`.
+
+This coupling had three costs. Enumerating the Commonplace repo's ~1,000 notes spawned ~2,300 subprocesses and took about five seconds before any file was read. Behavior differed by environment: in a plain directory or a vendored install without git, the filter silently vanished and the tools saw *more* files than in a git checkout. And `--no-index` applies ignore *patterns* where git applies ignore *semantics*: a directory that was tracked in git but matched by a later-added `.gitignore` rule (`kb/work/agent-memory-design/`) was committed KB content that the KB's own tools could not see, while real `git check-ignore` reported it as not ignored.
+
+An inventory of what gitignore filtering actually excluded showed the delegation was overweight. Almost every exclusion the tools need is structural and already expressed by name in code — `types/`, `COLLECTION.md`, `.replaced.*` archives, `dir-index.md` (ADR 025), nested git repos — or is a build/vendor tree (`.venv/`, `site/`, `tmp/`) that only the repository-wide relocation walk ever encounters. ADR 032 had already removed git from review freshness for the same class of reason: users and agents use git differently, and correctness should not depend on how.
+
+## Decision
+
+Visibility is a package-owned contract and the `commonplace-*` commands never invoke the git binary.
+
+The contract, implemented in `project_paths.walk_visible`: hidden (dot-prefixed) entries and nested git repositories are invisible to every markdown walk; repository-wide walks (relocation's `find_repo_markdown_files`) additionally skip a fixed set of build/vendor artifact directory names (`build`, `dist`, `node_modules`, `site`, `tmp`, `__pycache__`); collection walks also exclude the reserved generated name `dir-index.md`, preserving ADR 025 against stale on-disk leftovers. Gitignore rules have no effect on what the tools see. Nested repositories are detected by the presence of a `.git` entry — a filesystem layout check, not a git invocation.
+
+There is no mechanism for declaring collection content local-only. Everything visible under a collection is KB content; content that must not be swept lives outside collections, in hidden directories, or does not exist in the working tree. If a declaration mechanism is ever needed, it will be an explicit package-owned one, not gitignore.
+
+Relocation moves files with `Path.rename` (creating destination parents first). Git detects renames on commit; the `git mv` path and its silent strategy degradation are deleted.
+
+## Consequences
+
+Easier:
+
+- Tree enumeration drops from seconds of subprocess churn to a plain filesystem walk, in every command and in the mkdocs build.
+- Behavior is identical with or without git, in checkouts, plain directories, and vendored installs.
+- Committed KB content can no longer be hidden from the tools by an ignore pattern; the tracked-but-pattern-matched divergence is gone by construction.
+- Relocation has one move path instead of two strategies chosen by environment.
+
+Harder:
+
+- Gitignoring a file inside a collection no longer hides it from sweeps. Local scratch under a collection (for example gitignored subtrees of `kb/work/`) now appears in validation and local site builds; fresh-clone CI is unchanged because such files do not exist there. Keeping something out of sweeps now means keeping it out of collections.
+- The repo-wide walk no longer descends hidden directories, so links inside `.claude/skills/` and `.agents/skills/` copies are not rewritten on relocation; the canonical sources under `kb/` still are, and runtime copies are refreshed by re-init (ADR 037).
+
+Risks:
+
+- The artifact name set is a blunt instrument: a knowledge directory named `site` or `tmp` at any depth is invisible to the repository-wide walk (collection walks are unaffected). The names are documented on `REPO_ARTIFACT_DIR_NAMES`.
+
+## Links
+
+- [032-review-freshness-uses-db-snapshots-not-git](./032-review-freshness-uses-db-snapshots-not-git.md) — extends: removes the remaining git dependencies from the non-review commands after review correctness left git
+- [025-complete-generated-indexes-are-build-time-only](./025-complete-generated-indexes-are-build-time-only.md) — implements: carries that decision's dir-index invisibility on the reserved name instead of a gitignore rule
+- [lib-modules](../lib-modules.md) — implemented-by: `project_paths` and `relocation` sections describe the visibility walker and plain-rename move

--- a/kb/reference/lib-modules.md
+++ b/kb/reference/lib-modules.md
@@ -160,10 +160,10 @@ Deterministic validation rules for KB notes. Used by `commonplace-validate`. The
 **`ParsedNote`** — dataclass bundling a note's `path`, `content`, `note_type`, `profile` (`TypeProfile`), and `document` (`ParsedDocument`).
 
 **`list_kb_note_paths(notes_root: Path) -> list[Path]`**
-Return all `.md` files under `notes_root`, skipping nested git repositories and `types/` template directories.
+Return all `.md` files under `notes_root`, skipping hidden entries, nested git repositories, and `types/` template directories. Visibility is package-owned (`project_paths.walk_visible`): hidden (dot-prefixed) entries and nested git repositories are always invisible, repo-wide walks additionally skip build/vendor artifact trees, and gitignore rules have no effect on what the tools see.
 
-**`is_nested_git_repo_content(path: Path, notes_root: Path) -> bool`** / **`is_type_definition_content(path: Path, notes_root: Path) -> bool`**
-Predicates used by `list_kb_note_paths` for the two skip rules.
+**`is_type_definition_content(path: Path, notes_root: Path) -> bool`**
+Predicate used by `list_kb_note_paths` for the `types/` skip rule.
 
 **`parse_note(path: Path, *, repo_root: Path) -> tuple[ParsedNote | None, str | None]`**
 Read a note, parse its frontmatter and body, resolve its type. Returns `(parsed, None)` on success or `(None, error_message)` on parse failure.
@@ -195,7 +195,7 @@ Move or rename a KB note: rewrite inbound and outbound links across the repo and
 ### Public API
 
 **`relocate_note(*, root: Path, note_arg: str, new_name: str | None = None, dest_path: str | None = None, apply: bool = False) -> int`**
-Top-level orchestrator. Resolves the source note from a path or unique stem, computes the destination, walks all repo markdown files to plan link rewrites, and either prints a dry-run plan or executes everything (file move via `git mv` if available, link rewrites, mkdocs update). Returns a process exit code.
+Top-level orchestrator. Resolves the source note from a path or unique stem, computes the destination, walks all repo markdown files to plan link rewrites, and either prints a dry-run plan or executes everything (file move, link rewrites, mkdocs update). Returns a process exit code.
 
 **`resolve_note(arg, *, root)`**
 Find a note by absolute path, repo-relative path, full filename, or unique stem. Searches the entire `kb/` tree, not just `kb/notes/`, so notes can be relocated between collections.
@@ -212,7 +212,7 @@ For the note that's being moved: rewrite each of its outbound relative links so 
 **`update_mkdocs_config(content, old_docs_path, new_docs_path) -> tuple[str, list[str]]`**
 Update `mkdocs.yml` in place: rewrite any matching `nav` entries and `redirect_maps` targets, and append a new redirect entry from `old_docs_path` to `new_docs_path`. Preserves indentation and quoting style.
 
-**`move_path(source, destination, *, repo_root)`** / **`move_note(source, destination, *, repo_root)`**
-Move a path on disk, preferring `git mv` and falling back to `Path.rename` if git isn't available. `move_note` is a thin wrapper kept separate so tests can monkeypatch it.
+**`move_path(source, destination)`**
+Move a path on disk with `Path.rename`, creating the destination's parent directories first. Git is not involved; it detects the rename on commit.
 
-The smaller helpers (`format_relative_link`, `iter_markdown_tokens`, `split_link_target`, `is_relative_markdown_target`, `resolve_directory`, `rewrite_links_to_moved_files`, `rebase_and_rewrite_in_moved_file`, `add_single_redirect`, `is_nested_git_repo_content`) are exported but rarely interesting outside the orchestrator.
+The smaller helpers (`format_relative_link`, `iter_markdown_tokens`, `split_link_target`, `is_relative_markdown_target`, `resolve_directory`, `rewrite_links_to_moved_files`, `rebase_and_rewrite_in_moved_file`, `add_single_redirect`) are exported but rarely interesting outside the orchestrator.

--- a/kb/reference/lib-modules.md
+++ b/kb/reference/lib-modules.md
@@ -195,7 +195,7 @@ Move or rename a KB note: rewrite inbound and outbound links across the repo and
 ### Public API
 
 **`relocate_note(*, root: Path, note_arg: str, new_name: str | None = None, dest_path: str | None = None, apply: bool = False) -> int`**
-Top-level orchestrator. Resolves the source note from a path or unique stem, computes the destination, walks all repo markdown files to plan link rewrites, and either prints a dry-run plan or executes everything (file move, link rewrites, mkdocs update). Returns a process exit code.
+Top-level orchestrator. Resolves the source note from a path or unique stem, computes the destination, walks all repo markdown files to plan link rewrites, and either prints a dry-run plan or executes everything (file move, link rewrites, mkdocs update). The mkdocs step is skipped when the project has no `mkdocs.yml`. Returns a process exit code.
 
 **`resolve_note(arg, *, root)`**
 Find a note by absolute path, repo-relative path, full filename, or unique stem. Searches the entire `kb/` tree, not just `kb/notes/`, so notes can be relocated between collections.
@@ -203,16 +203,16 @@ Find a note by absolute path, repo-relative path, full filename, or unique stem.
 **`resolve_destination_path(source, new_name, dest_path, *, repo_root, kb_root)`**
 Compute the destination path from either a `--to` argument (file or directory) or a positional new title. Enforces the slug length limit.
 
-**`rewrite_links_to_relocated_note(content, source_file, old_path, new_path) -> tuple[str, list[str]]`**
-For each markdown link in `content` whose target resolves to `old_path`, rewrite it to point at `new_path`. Skips links inside fenced or inline code regions. Returns the updated text and a list of human-readable change descriptions.
+**`rewrite_links_to_moved_files(content, source_file, moves) -> tuple[str, list[str]]`**
+For each markdown link in `content` whose target resolves to a key of `moves` (a `{old_resolved_path: new_path}` dict), rewrite it to point at the new location. Skips links inside fenced or inline code regions. Returns the updated text and a list of human-readable change descriptions. Single-note relocation is the one-entry-dict case.
 
-**`rebase_relative_markdown_links(content, old_source_file, new_source_file) -> tuple[str, list[str]]`**
-For the note that's being moved: rewrite each of its outbound relative links so they still resolve from the new location. Self-referential links update to the new filename; existing-target links rebase to the new directory.
+**`rebase_and_rewrite_in_moved_file(content, old_source_file, new_source_file, moves) -> tuple[str, list[str]]`**
+For a file that is itself being moved: rewrite each of its outbound relative links so they still resolve from the new location, mapping targets that are also in `moves` to their new locations.
 
 **`update_mkdocs_config(content, old_docs_path, new_docs_path) -> tuple[str, list[str]]`**
-Update `mkdocs.yml` in place: rewrite any matching `nav` entries and `redirect_maps` targets, and append a new redirect entry from `old_docs_path` to `new_docs_path`. Preserves indentation and quoting style.
+Update `mkdocs.yml` in place: rewrite any matching `nav` entries and `redirect_maps` targets, and append a new redirect entry from `old_docs_path` to `new_docs_path`. Preserves indentation and quoting style. A config without a `redirect_maps:` section still gets its values rewritten; the redirect entry is skipped.
 
 **`move_path(source, destination)`**
 Move a path on disk with `Path.rename`, creating the destination's parent directories first. Git is not involved; it detects the rename on commit.
 
-The smaller helpers (`format_relative_link`, `iter_markdown_tokens`, `split_link_target`, `is_relative_markdown_target`, `resolve_directory`, `rewrite_links_to_moved_files`, `rebase_and_rewrite_in_moved_file`, `add_single_redirect`) are exported but rarely interesting outside the orchestrator.
+The smaller helpers (`format_relative_link`, `split_link_target`, `is_relative_markdown_target`, `resolve_directory`, `add_single_redirect`) are exported but rarely interesting outside the orchestrator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
     "Topic :: Text Processing :: Markup :: Markdown",
 ]
-dependencies = ["jsonschema>=4.25.0", "PyYAML>=6.0.0"]
+dependencies = ["jsonschema>=4.25.0", "PyYAML>=6.0.0", "referencing>=0.31.0"]
 
 [project.urls]
 Documentation = "https://zby.github.io/commonplace/"
@@ -73,7 +73,7 @@ include = [
     "/kb/sources/types",
     "/kb/types",
     "/src",
-    "/test",
+    "/tests",
 ]
 
 [tool.hatch.build.targets.sdist.force-include]

--- a/src/commonplace/cli/github_snapshot.py
+++ b/src/commonplace/cli/github_snapshot.py
@@ -100,6 +100,9 @@ def _render_markdown(data: dict) -> str:
     body = str(data.get("body") or "").strip()
     if body:
         lines.append(body[:10000])
+        if len(body) > 10000:
+            lines.append("")
+            lines.append("*(body truncated at 10000 characters; full text in the JSON source)*")
     else:
         lines.append("(no body)")
     lines.append("")

--- a/src/commonplace/cli/init_project.py
+++ b/src/commonplace/cli/init_project.py
@@ -292,24 +292,20 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    pre_init_warnings: list[str] = []
-    if sys.platform == "win32":
-        pre_init_warnings = direnv_warnings(root)
-        if pre_init_warnings:
-            print("Environment setup:")
-            for line in pre_init_warnings:
-                print(f"- {line}")
-            print()
+    warnings = direnv_warnings(root)
+
+    # On Windows the guidance prints before init so it survives an init failure.
+    if sys.platform == "win32" and warnings:
+        print("Environment setup:")
+        for line in warnings:
+            print(f"- {line}")
+        print()
 
     try:
         report = init_project(root, name=args.name)
     except OSError as exc:
         if sys.platform == "win32":
             print(f"Failed to initialize Commonplace project at {root}: {exc}")
-            if not pre_init_warnings:
-                print("\nEnvironment setup:")
-                for line in direnv_warnings(root):
-                    print(f"- {line}")
             return 1
         raise
 
@@ -333,8 +329,7 @@ def main(argv: list[str] | None = None) -> int:
     ):
         print("No changes needed.")
 
-    warnings = [] if pre_init_warnings else direnv_warnings(root)
-    if warnings:
+    if sys.platform != "win32" and warnings:
         print("\nEnvironment setup:")
         for line in warnings:
             print(f"- {line}")

--- a/src/commonplace/cli/validate_notes.py
+++ b/src/commonplace/cli/validate_notes.py
@@ -10,9 +10,8 @@ from pathlib import Path
 from commonplace.lib.project_paths import (
     collection_for_path,
     is_collection_dir,
-    is_nested_git_repo,
     is_type_definition_content,
-    iter_unignored_markdown_files,
+    iter_visible_markdown_files,
     kb_root,
     list_collection_note_paths,
     list_kb_note_paths,
@@ -161,10 +160,10 @@ def validate_collection_structure(collection: Path, *, repo_root: Path) -> list[
         return []
 
     failures: list[str] = []
-    for path in iter_unignored_markdown_files(collection, ignore_root=repo_root):
+    for path in iter_visible_markdown_files(collection):
         if path.name != "COLLECTION.md" or path.parent == collection:
             continue
-        if is_nested_git_repo(path, collection) or is_type_definition_content(path, collection):
+        if is_type_definition_content(path, collection):
             continue
         failures.append(
             "nested COLLECTION.md: "

--- a/src/commonplace/cli/validate_notes.py
+++ b/src/commonplace/cli/validate_notes.py
@@ -14,8 +14,8 @@ from commonplace.lib.project_paths import (
     iter_visible_markdown_files,
     kb_root,
     list_collection_note_paths,
-    list_kb_note_paths,
     list_notes_collection_paths,
+    resolve_note,
 )
 from commonplace.lib.type_resolver import validate_type_specs
 from commonplace.lib.validation import (
@@ -72,19 +72,7 @@ def resolve_targets(arg: str, *, repo_root: Path) -> list[Path]:
             raise ValueError(_TOO_BROAD_MESSAGE)
         return list_collection_note_paths(collection_candidate)
 
-    all_paths = list_kb_note_paths(repo_root)
-    name = arg if arg.endswith(".md") else f"{arg}.md"
-    matches = sorted(path for path in all_paths if path.name == name)
-    if not matches:
-        matches = sorted(path for path in all_paths if path.stem == arg)
-
-    if not matches:
-        raise FileNotFoundError(f"No matching note found for: {arg}")
-    if len(matches) > 1:
-        raise FileNotFoundError(
-            "Multiple matching notes found:\n" + "\n".join(str(path.relative_to(repo_root)) for path in matches)
-        )
-    return matches
+    return [resolve_note(arg, repo_root)]
 
 
 def _display_path(path: Path, *, repo_root: Path) -> str:
@@ -207,7 +195,10 @@ def format_block(path: Path, results: CheckResults) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("target", help="note path, directory, note name, all, or recent")
+    parser.add_argument(
+        "target",
+        help="collection directory, note path or name, or today/recent (kb/notes modified today)",
+    )
     args = parser.parse_args(argv)
 
     repo_root = Path.cwd().resolve()

--- a/src/commonplace/docs/mkdocs_hooks.py
+++ b/src/commonplace/docs/mkdocs_hooks.py
@@ -113,12 +113,18 @@ def _matches_tag_index(candidate: Path, tag: str) -> bool:
     return note_type in TAG_PAGE_TYPES and index_source == "tag" and index_key == tag
 
 
-def _find_tag_index(tag: str, note_dir: Path) -> str | None:
-    """Find relative path from note_dir to the declared index page for a tag."""
+def _find_tag_index(tag: str, note_dir: Path, boundary: Path | None = None) -> str | None:
+    """Find relative path from note_dir to the declared index page for a tag.
+
+    `boundary` (the docs root) caps the upward walk so shallow layouts never
+    scan directories outside the site tree.
+    """
     search_dir = note_dir.resolve()
     note_dir_resolved = note_dir.resolve()
 
     for _ in range(4):
+        if boundary is not None and boundary != search_dir and boundary not in search_dir.parents:
+            break
         if search_dir.is_dir():
             for candidate in sorted(search_dir.glob("*.md")):
                 if _matches_tag_index(candidate, tag):
@@ -202,9 +208,10 @@ def on_page_markdown(markdown: str, page, config=None, **kwargs) -> str:
 
     if tags:
         note_dir = Path(page.file.abs_src_path).parent
+        boundary = Path(config["docs_dir"]).resolve() if config else None
         tag_links = []
         for tag in tags:
-            relpath = _find_tag_index(tag, note_dir)
+            relpath = _find_tag_index(tag, note_dir, boundary)
             if relpath:
                 tag_links.append(f"[{tag}]({relpath})")
             else:

--- a/src/commonplace/docs/mkdocs_hooks.py
+++ b/src/commonplace/docs/mkdocs_hooks.py
@@ -79,7 +79,6 @@ def on_files(files, config):
         pages = index_directory.collect_index_pages(
             collection,
             max_depth=COLLECTION_MAX_DEPTH.get(collection.name),
-            ignore_root=root,
         )
         for output_path, content in pages:
             src_uri = output_path.relative_to(docs_dir).as_posix()

--- a/src/commonplace/lib/frontmatter.py
+++ b/src/commonplace/lib/frontmatter.py
@@ -26,13 +26,21 @@ class FrontmatterResult:
         return not self.errors
 
 
-_FM_RE = re.compile(r"^---\n(.*?)\n---(?:\n|$)", re.DOTALL)
+# CRLF-tolerant: a note saved with Windows line endings must parse as
+# frontmatter, not silently fall through to the untyped-text path.
+_FM_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?(?:\n|$)", re.DOTALL)
+_FM_OPEN_RE = re.compile(r"^---\r?\n")
+
+
+def opens_frontmatter(content: str) -> bool:
+    """True when content starts with a frontmatter opening delimiter."""
+    return _FM_OPEN_RE.match(content) is not None
 
 
 def parse(content: str) -> FrontmatterResult:
     match = _FM_RE.match(content)
     if match is None:
-        if content.startswith("---\n"):
+        if opens_frontmatter(content):
             return FrontmatterResult(errors=["frontmatter: missing closing delimiter"])
         return FrontmatterResult()
 

--- a/src/commonplace/lib/index_directory.py
+++ b/src/commonplace/lib/index_directory.py
@@ -9,8 +9,8 @@ from commonplace.lib.note_parser import extract_title, strip_frontmatter
 from commonplace.lib.project_paths import (
     is_replaced_archive,
     is_type_definition_content,
+    iter_visible_markdown_files,
 )
-from commonplace.lib.project_paths import is_git_ignored, iter_unignored_markdown_files
 
 
 SKIP_DIR_NAMES = {"types"}
@@ -34,14 +34,14 @@ def _display_type(note_type: str) -> str:
     return note_type
 
 
-def _has_indexable_content(directory: Path, *, ignore_root: Path | None = None) -> bool:
+def _has_indexable_content(directory: Path) -> bool:
     """True if the directory or any descendant holds an indexable .md file.
 
     Excludes README.md (curated landing) and dir-index.md (the generated index
     itself), and skips type-definition directories. Used to decide whether a
     subdirectory deserves its own dir-index.md.
     """
-    for path in iter_unignored_markdown_files(directory, ignore_root=ignore_root):
+    for path in iter_visible_markdown_files(directory):
         if path.name in ("README.md", "dir-index.md"):
             continue
         if is_replaced_archive(path):
@@ -54,20 +54,19 @@ def _has_indexable_content(directory: Path, *, ignore_root: Path | None = None) 
     return False
 
 
-def _should_skip_subdir(subdir: Path, *, ignore_root: Path | None = None) -> bool:
+def _should_skip_subdir(subdir: Path) -> bool:
     if subdir.name.startswith("."):
         return True
     if subdir.name in SKIP_DIR_NAMES:
         return True
-    if is_git_ignored(subdir, ignore_root):
+    if (subdir / ".git").exists():
         return True
-    return not _has_indexable_content(subdir, ignore_root=ignore_root)
+    return not _has_indexable_content(subdir)
 
 
 def _subdir_link_target(
     subdir: Path,
     *,
-    ignore_root: Path | None = None,
     has_dir_index: bool = False,
 ) -> str:
     """Pick the best landing inside `subdir` to link from a parent dir-index.
@@ -80,15 +79,15 @@ def _subdir_link_target(
     readme = subdir / "README.md"
     if has_dir_index:
         return f"./{subdir.name}/dir-index.md"
-    if readme.is_file() and not is_git_ignored(readme, ignore_root):
+    if readme.is_file():
         return f"./{subdir.name}/README.md"
     md_files = [
         p
         for p in subdir.iterdir()
         if p.is_file()
         and p.suffix == ".md"
+        and not p.name.startswith(".")
         and not is_replaced_archive(p)
-        and not is_git_ignored(p, ignore_root)
     ]
     if len(md_files) == 1:
         return f"./{subdir.name}/{md_files[0].name}"
@@ -99,7 +98,6 @@ def generate(
     notes_dir: Path,
     *,
     parent_link: str,
-    ignore_root: Path | None = None,
     subdirs_have_index: bool = False,
 ) -> str:
     """Generate dir-index.md content for a single directory level.
@@ -115,13 +113,11 @@ def generate(
 
     for path in sorted(notes_dir.iterdir()):
         if path.is_dir():
-            if _should_skip_subdir(path, ignore_root=ignore_root):
+            if _should_skip_subdir(path):
                 continue
             subdirs.append(path)
             continue
-        if is_git_ignored(path, ignore_root):
-            continue
-        if path.suffix != ".md":
+        if path.suffix != ".md" or path.name.startswith("."):
             continue
         if path == output or path.name == "README.md":
             continue
@@ -158,11 +154,7 @@ def generate(
         lines.append("## Subdirectories")
         lines.append("")
         for subdir in subdirs:
-            target = _subdir_link_target(
-                subdir,
-                ignore_root=ignore_root,
-                has_dir_index=subdirs_have_index,
-            )
+            target = _subdir_link_target(subdir, has_dir_index=subdirs_have_index)
             lines.append(f"- [{subdir.name}/]({target})")
         lines.append("")
 
@@ -188,7 +180,6 @@ def collect_index_pages(
     is_root: bool = True,
     max_depth: int | None = None,
     _depth: int = 0,
-    ignore_root: Path | None = None,
 ) -> list[tuple[Path, str]]:
     """Generate dir-index pages for `notes_dir` and qualifying subdirs, in memory.
 
@@ -204,16 +195,12 @@ def collect_index_pages(
     only generate the dir-index at this level (no nested dir-indexes), in
     which case subdir links fall back to README.md or a bare directory URL.
     """
-    resolved_ignore_root = (ignore_root or notes_dir).resolve()
     will_recurse = max_depth is None or _depth + 1 < max_depth
 
     pages: list[tuple[Path, str]] = []
     if will_recurse:
         for subdir in sorted(notes_dir.iterdir()):
-            if not subdir.is_dir() or _should_skip_subdir(
-                subdir,
-                ignore_root=resolved_ignore_root,
-            ):
+            if not subdir.is_dir() or _should_skip_subdir(subdir):
                 continue
             pages.extend(
                 collect_index_pages(
@@ -221,14 +208,12 @@ def collect_index_pages(
                     is_root=False,
                     max_depth=max_depth,
                     _depth=_depth + 1,
-                    ignore_root=resolved_ignore_root,
                 )
             )
 
     content = generate(
         notes_dir,
         parent_link="../index.md" if is_root else "../dir-index.md",
-        ignore_root=resolved_ignore_root,
         subdirs_have_index=will_recurse,
     )
     pages.append((notes_dir / "dir-index.md", content))

--- a/src/commonplace/lib/index_generated.py
+++ b/src/commonplace/lib/index_generated.py
@@ -13,7 +13,7 @@ from commonplace.lib.project_paths import (
     collection_for_path,
     is_replaced_archive,
     is_type_definition_content,
-    iter_unignored_markdown_files,
+    iter_visible_markdown_files,
 )
 
 
@@ -38,7 +38,7 @@ def collect_notes_by_tag(
     """Scan a collection and group notes by tag."""
     by_tag: dict[str, list[tuple[Path, str, str]]] = {}
 
-    for path in sorted(iter_unignored_markdown_files(collection_dir)):
+    for path in sorted(iter_visible_markdown_files(collection_dir)):
         if is_replaced_archive(path):
             continue
         content = path.read_text(encoding="utf-8")
@@ -93,7 +93,7 @@ def collect_tag_index_entries(
 ) -> list[tuple[Path, str, str]]:
     """Return all tag indexes within a collection."""
     entries: list[tuple[Path, str, str]] = []
-    for path in sorted(iter_unignored_markdown_files(collection_dir)):
+    for path in sorted(iter_visible_markdown_files(collection_dir)):
         if is_replaced_archive(path):
             continue
         content = path.read_text(encoding="utf-8")

--- a/src/commonplace/lib/index_generated.py
+++ b/src/commonplace/lib/index_generated.py
@@ -50,8 +50,8 @@ def collect_notes_by_tag(
         if "types" in rel_parts or ".collection" in rel_parts:
             continue
 
-        tags = fm.get(FIELD_NAME, [])
-        if not tags:
+        tags = fm.get(FIELD_NAME)
+        if not isinstance(tags, list) or not tags:
             continue
 
         title = extract_title(strip_frontmatter(content))

--- a/src/commonplace/lib/note_parser.py
+++ b/src/commonplace/lib/note_parser.py
@@ -94,7 +94,7 @@ def extract_body_dates(body: str) -> tuple[str, ...]:
 
 def parse_document(content: str) -> tuple[ParsedDocument | None, str | None]:
     frontmatter: dict[str, Any] | None = None
-    if content.startswith("---\n"):
+    if fm_mod.opens_frontmatter(content):
         result = fm_mod.parse(content)
         if result.errors:
             return None, "; ".join(result.errors)

--- a/src/commonplace/lib/project_paths.py
+++ b/src/commonplace/lib/project_paths.py
@@ -1,12 +1,24 @@
-"""Shared path conventions for a Commonplace project."""
+"""Shared path conventions for a Commonplace project.
+
+Visibility is package-owned: hidden entries (dot-prefixed) and nested git
+repositories are invisible to every markdown walk, and repository-wide walks
+additionally skip common build/vendor artifact trees. Git is never consulted;
+gitignore rules do not affect what the tools see.
+"""
 
 from __future__ import annotations
 
 import os
-import subprocess
 from collections.abc import Iterator
-from functools import lru_cache
 from pathlib import Path
+
+
+# Directory names pruned from repository-wide markdown walks: build and vendor
+# trees that are never knowledge content. Collection walks under kb/ do not
+# apply these; they only matter when sweeping the whole repository.
+REPO_ARTIFACT_DIR_NAMES = frozenset(
+    {"build", "dist", "node_modules", "site", "tmp", "__pycache__"}
+)
 
 
 def kb_root(root: Path) -> Path:
@@ -22,17 +34,14 @@ def collection_dirs(root: Path) -> list[Path]:
     support directories such as kb/reports/ are ignored unless they explicitly
     opt in as collections.
     """
-    boundary = kb_root(root)
+    boundary = kb_root(root).resolve()
     if not boundary.is_dir():
         raise FileNotFoundError(f"KB root does not exist: {boundary}")
     return sorted(
         path.parent
-        for path in iter_unignored_markdown_files(boundary, ignore_root=root)
-        if not any(
-            part.startswith(".") or part == "types"
-            for part in path.relative_to(boundary).parts
-        )
-        and path.name == "COLLECTION.md"
+        for path in iter_visible_markdown_files(boundary)
+        if path.name == "COLLECTION.md"
+        and "types" not in path.relative_to(boundary).parts
     )
 
 
@@ -51,17 +60,6 @@ def collection_for_path(path: Path, root: Path) -> Path:
             return current
         current = current.parent
     raise ValueError(f"Path is not inside a KB collection: {path}")
-
-
-def is_nested_git_repo(path: Path, boundary: Path) -> bool:
-    """Return True when path lives inside a nested git repository under boundary."""
-    resolved_boundary = boundary.resolve()
-    current = path.resolve().parent
-    while current != resolved_boundary and resolved_boundary in current.parents:
-        if (current / ".git").exists():
-            return True
-        current = current.parent
-    return False
 
 
 def is_type_definition_content(path: Path, boundary: Path) -> bool:
@@ -95,19 +93,19 @@ def is_collection_dir(path: Path) -> bool:
 
 
 def list_collection_note_paths(collection: Path) -> list[Path]:
-    """Return markdown note paths under a collection, excluding nested repos,
-    types, and replaced archives."""
+    """Return markdown note paths under a collection, excluding types, replaced
+    archives, and stale generated dir-index pages (build-time-only, ADR 025)."""
     if not collection.is_dir():
         raise FileNotFoundError(f"Collection directory does not exist: {collection}")
     if not is_collection_dir(collection):
         raise ValueError(f"Directory is not a KB collection: {collection}")
     return sorted(
         path
-        for path in iter_unignored_markdown_files(collection)
-        if not is_nested_git_repo(path, collection)
-        and not is_type_definition_content(path, collection)
+        for path in iter_visible_markdown_files(collection)
+        if not is_type_definition_content(path, collection)
         and not is_collection_metadata(path)
         and not is_replaced_archive(path)
+        and path.name != "dir-index.md"
     )
 
 
@@ -140,80 +138,50 @@ def list_notes_collection_paths(root: Path) -> list[Path]:
 
 
 def find_repo_markdown_files(root: Path) -> list[Path]:
-    """Return markdown files under a repository, excluding nested git repositories."""
-    resolved = root.resolve()
+    """Return markdown files under a repository.
+
+    Excludes hidden entries, nested git repositories, and build/vendor
+    artifact trees (`REPO_ARTIFACT_DIR_NAMES`).
+    """
     return sorted(
-        path
-        for path in iter_unignored_markdown_files(resolved, ignore_root=resolved)
-        if not is_nested_git_repo(path, resolved)
+        iter_visible_markdown_files(root, exclude_dir_names=REPO_ARTIFACT_DIR_NAMES)
     )
 
 
-@lru_cache(maxsize=None)
-def is_git_ignored(path: Path, root: Path | None = None) -> bool:
-    """Return True when Git ignore rules exclude `path`.
-
-    Git is the source of truth because .gitignore syntax is richer than the
-    small subset this package should own. Outside a Git worktree, paths are
-    treated as visible so Commonplace can still operate in plain directories.
-    """
-    check_root = (root or path.parent).resolve()
-    try:
-        result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(check_root),
-                "check-ignore",
-                "--quiet",
-                "--no-index",
-                "--",
-                str(path.resolve()),
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-    except (FileNotFoundError, OSError):
-        return False
-    return result.returncode == 0
-
-
-def walk_unignored(
+def walk_visible(
     root: Path,
     *,
-    ignore_root: Path | None = None,
+    exclude_dir_names: frozenset[str] = frozenset(),
 ) -> Iterator[tuple[Path, list[str], list[str]]]:
-    """Yield an os.walk stream with gitignored directories pruned."""
-    resolved_root = root.resolve()
-    resolved_ignore_root = (ignore_root or resolved_root).resolve()
-    if is_git_ignored(resolved_root, resolved_ignore_root):
-        return
+    """Yield an os.walk stream over visible entries.
 
-    for current, dirnames, filenames in os.walk(resolved_root):
+    Prunes hidden directories (dot-prefixed), nested git repositories, and any
+    directory whose name is in `exclude_dir_names`.
+    """
+    for current, dirnames, filenames in os.walk(root.resolve()):
         current_path = Path(current)
         dirnames[:] = sorted(
             dirname
             for dirname in dirnames
-            if not is_git_ignored(current_path / dirname, resolved_ignore_root)
+            if not dirname.startswith(".")
+            and dirname not in exclude_dir_names
+            and not (current_path / dirname / ".git").exists()
         )
         yield current_path, dirnames, sorted(filenames)
 
 
-def iter_unignored_markdown_files(
+def iter_visible_markdown_files(
     root: Path,
     *,
-    ignore_root: Path | None = None,
+    exclude_dir_names: frozenset[str] = frozenset(),
 ) -> Iterator[Path]:
-    """Yield visible markdown files below `root`, pruning gitignored directories."""
-    resolved_ignore_root = (ignore_root or root).resolve()
-    for current, _dirnames, filenames in walk_unignored(
-        root, ignore_root=resolved_ignore_root
+    """Yield visible markdown files below `root` (see `walk_visible`)."""
+    for current, _dirnames, filenames in walk_visible(
+        root, exclude_dir_names=exclude_dir_names
     ):
         for filename in filenames:
-            path = current / filename
-            if path.suffix == ".md" and not is_git_ignored(path, resolved_ignore_root):
-                yield path
+            if filename.endswith(".md") and not filename.startswith("."):
+                yield current / filename
 
 
 def resolve_note(arg: str, root: Path) -> Path:

--- a/src/commonplace/lib/promotion.py
+++ b/src/commonplace/lib/promotion.py
@@ -46,7 +46,7 @@ def write_promotion_candidates_report(root: Path) -> PromotionReportResult:
 
         abs_path = path.resolve()
         content = path.read_text(encoding="utf-8")
-        frontmatter = fm_mod.parse(content).data if content.startswith("---\n") else None
+        frontmatter = fm_mod.parse(content).data if fm_mod.opens_frontmatter(content) else None
         body = strip_frontmatter(content)
         title = extract_title(body)
         links = find_markdown_links(body)
@@ -64,21 +64,36 @@ def write_promotion_candidates_report(root: Path) -> PromotionReportResult:
             if resolved and resolved in all_notes:
                 incoming_links[resolved].append(source_path)
 
-    text_with_links = []
-    for path, title in sorted(text_files.items()):
-        sources = incoming_links.get(path, [])
-        real_sources = [s for s in sources if all_notes[s]["rel"].name not in ("index.md", "dir-index.md")]
-        rel = all_notes[path]["rel"].relative_to(notes_dir)
-        text_with_links.append((rel, title, len(real_sources), real_sources))
-    text_with_links.sort(key=lambda x: (-x[2], str(x[0])))
+    def rank(candidates: dict[Path, str]) -> list[tuple[Path, str, int, list[Path]]]:
+        ranked = [
+            (
+                all_notes[path]["rel"].relative_to(notes_dir),
+                title,
+                len(incoming_links.get(path, [])),
+                incoming_links.get(path, []),
+            )
+            for path, title in sorted(candidates.items())
+        ]
+        ranked.sort(key=lambda x: (-x[2], str(x[0])))
+        return ranked
 
-    seedling_ranked = []
-    for path, title in sorted(seedlings.items()):
-        sources = incoming_links.get(path, [])
-        real_sources = [s for s in sources if all_notes[s]["rel"].name not in ("index.md", "dir-index.md")]
-        rel = all_notes[path]["rel"].relative_to(notes_dir)
-        seedling_ranked.append((rel, title, len(real_sources), real_sources))
-    seedling_ranked.sort(key=lambda x: (-x[2], str(x[0])))
+    def render_entries(entries: list[tuple[Path, str, int, list[Path]]]) -> list[str]:
+        lines: list[str] = []
+        for rel, title, count, sources in entries:
+            source_list = ", ".join(
+                f"[{all_notes[s]['title']}](../notes/{all_notes[s]['rel'].relative_to(notes_dir)})"
+                for s in sources[:3]
+            )
+            if len(sources) > 3:
+                source_list += f" +{len(sources) - 3} more"
+            lines.append(f"- [{title}](../notes/{rel}) - **{count} links in**")
+            if source_list:
+                lines.append(f"  Sources: {source_list}")
+            lines.append("")
+        return lines
+
+    text_with_links = rank(text_files)
+    seedling_ranked = rank(seedlings)
 
     lines = [
         f"# Promotion Candidates - {date.today()}",
@@ -89,34 +104,13 @@ def write_promotion_candidates_report(root: Path) -> PromotionReportResult:
 
     lines.extend(["## Text -> Note", ""])
     if text_with_links:
-        for rel, title, count, sources in text_with_links:
-            source_list = ", ".join(
-                f"[{all_notes[s]['title']}](../notes/{all_notes[s]['rel'].relative_to(notes_dir)})"
-                for s in sources[:3]
-            )
-            if len(sources) > 3:
-                source_list += f" +{len(sources) - 3} more"
-            lines.append(f"- [{title}](../notes/{rel}) - **{count} links in**")
-            if source_list:
-                lines.append(f"  Sources: {source_list}")
-            lines.append("")
+        lines.extend(render_entries(text_with_links))
     else:
         lines.extend(["No text files found.", ""])
 
     lines.extend(["## Seedling -> Current (top 20 by incoming links)", ""])
-    top_seedlings = seedling_ranked[:20]
-    if top_seedlings:
-        for rel, title, count, sources in top_seedlings:
-            source_list = ", ".join(
-                f"[{all_notes[s]['title']}](../notes/{all_notes[s]['rel'].relative_to(notes_dir)})"
-                for s in sources[:3]
-            )
-            if len(sources) > 3:
-                source_list += f" +{len(sources) - 3} more"
-            lines.append(f"- [{title}](../notes/{rel}) - **{count} links in**")
-            if source_list:
-                lines.append(f"  Sources: {source_list}")
-            lines.append("")
+    if seedling_ranked:
+        lines.extend(render_entries(seedling_ranked[:20]))
     else:
         lines.extend(["No seedling notes found.", ""])
     lines.append("")

--- a/src/commonplace/lib/relocation.py
+++ b/src/commonplace/lib/relocation.py
@@ -68,16 +68,6 @@ def format_relative_link(from_file: Path, to_file: Path) -> str:
     return rel if rel.startswith("..") else f"./{rel}"
 
 
-def iter_markdown_tokens(content: str):
-    for match in TOKEN_PATTERN.finditer(content):
-        if match.group(1):
-            continue
-        text = match.group(3)
-        target = match.group(4)
-        if text and target:
-            yield match, text, target
-
-
 def split_link_target(target: str) -> tuple[str, str]:
     if "#" in target:
         bare, anchor = target.rsplit("#", 1)
@@ -94,74 +84,73 @@ def is_relative_markdown_target(target: str) -> bool:
     return bare.endswith(".md")
 
 
-def rewrite_links_to_relocated_note(
-    content: str,
-    source_file: Path,
-    old_path: Path,
-    new_path: Path,
-) -> tuple[str, list[str]]:
-    changes: list[str] = []
-    old_resolved = old_path.resolve()
+class _RedirectMaps:
+    """The parsed `redirect_maps:` section of an mkdocs config.
 
-    def replace_match(match: re.Match[str]) -> str:
-        if match.group(1):
-            return match.group(0)
+    `lines` is the config with the whole section collapsed to its single
+    header line at `header_index`; `render` expands it back with the current
+    `redirects` mapping. `parsed` is False when the config has no section.
+    """
 
-        text = match.group(3)
-        target = match.group(4)
-        if not text or not target or not is_relative_markdown_target(target):
-            return match.group(0)
+    def __init__(self, content: str) -> None:
+        self.redirects: dict[str, str] = {}
+        self.lines: list[str] = []
+        self.parsed = False
+        self._header_index = 0
+        self._header_indent = 0
+        self._entry_indent: int | None = None
+        self._trailing_newline = content.endswith("\n")
 
-        bare_target, anchor = split_link_target(target)
-        resolved = (source_file.parent / bare_target).resolve()
-        if resolved != old_resolved:
-            return match.group(0)
+        source = content.splitlines()
+        index = 0
+        while index < len(source):
+            line = source[index]
+            header_match = REDIRECT_MAP_HEADER.match(line)
+            if not header_match:
+                self.lines.append(line)
+                index += 1
+                continue
 
-        new_target = format_relative_link(source_file, new_path)
-        if anchor:
-            new_target = f"{new_target}{anchor}"
-        changes.append(f"{target} -> {new_target}")
-        return f"[{text}]({new_target})"
+            self.parsed = True
+            self._header_index = len(self.lines)
+            self._header_indent = len(header_match.group(1))
+            self.lines.append(line)
+            index += 1
+            while index < len(source):
+                candidate = source[index]
+                stripped = candidate.strip()
+                indent = len(candidate) - len(candidate.lstrip(" "))
+                if stripped and indent <= self._header_indent:
+                    break
+                if stripped:
+                    entry_match = REDIRECT_ENTRY.match(candidate)
+                    if not entry_match:
+                        raise ValueError(f"Unsupported redirect_maps entry: {candidate}")
+                    self.redirects[entry_match.group(1)] = entry_match.group(2)
+                    self._entry_indent = indent
+                index += 1
 
-    return TOKEN_PATTERN.sub(replace_match, content), changes
+    def add(self, old_docs_path: str, new_docs_path: str, changes: list[str]) -> None:
+        if self.redirects.get(old_docs_path) != new_docs_path:
+            self.redirects[old_docs_path] = new_docs_path
+            changes.append(f"mkdocs redirect: {old_docs_path} -> {new_docs_path}")
 
-
-def rebase_relative_markdown_links(
-    content: str,
-    old_source_file: Path,
-    new_source_file: Path,
-) -> tuple[str, list[str]]:
-    changes: list[str] = []
-    old_source_resolved = old_source_file.resolve()
-    new_source_resolved = new_source_file.resolve()
-
-    def replace_match(match: re.Match[str]) -> str:
-        if match.group(1):
-            return match.group(0)
-
-        text = match.group(3)
-        target = match.group(4)
-        if not text or not target or not is_relative_markdown_target(target):
-            return match.group(0)
-
-        bare_target, anchor = split_link_target(target)
-        resolved = (old_source_file.parent / bare_target).resolve()
-        if resolved == old_source_resolved:
-            destination = new_source_resolved
-        elif resolved.exists():
-            destination = resolved
-        else:
-            return match.group(0)
-
-        new_target = format_relative_link(new_source_file, destination)
-        if anchor:
-            new_target = f"{new_target}{anchor}"
-        if new_target == target:
-            return match.group(0)
-        changes.append(f"{target} -> {new_target}")
-        return f"[{text}]({new_target})"
-
-    return TOKEN_PATTERN.sub(replace_match, content), changes
+    def render(self) -> str:
+        rebuilt = list(self.lines)
+        if self.parsed:
+            indent = (
+                self._entry_indent
+                if self._entry_indent is not None
+                else self._header_indent + 2
+            )
+            redirect_lines = [f'{" " * self._header_indent}redirect_maps:']
+            for key in sorted(self.redirects, key=str.casefold):
+                redirect_lines.append(f"{' ' * indent}'{key}': '{self.redirects[key]}'")
+            rebuilt[self._header_index : self._header_index + 1] = redirect_lines
+        new_content = "\n".join(rebuilt)
+        if self._trailing_newline:
+            new_content += "\n"
+        return new_content
 
 
 def update_mkdocs_config(
@@ -169,72 +158,35 @@ def update_mkdocs_config(
     old_docs_path: str,
     new_docs_path: str,
 ) -> tuple[str, list[str]]:
-    lines = content.splitlines()
-    rebuilt_lines: list[str] = []
+    """Rewrite doc-path values (nav entries etc.) and maintain the redirect map.
+
+    A config without a `redirect_maps:` section still gets its values
+    rewritten; the redirect entry is simply skipped, so projects that use
+    mkdocs without the redirects plugin can relocate notes.
+    """
     changes: list[str] = []
-    redirects: dict[str, str] | None = None
-    header_index: int | None = None
-    header_indent = 0
-    entry_indent: int | None = None
-    index = 0
+    maps = _RedirectMaps(content)
 
-    while index < len(lines):
-        line = lines[index]
-        header_match = REDIRECT_MAP_HEADER.match(line)
-        if header_match:
-            redirects = {}
-            header_index = len(rebuilt_lines)
-            header_indent = len(header_match.group(1))
-            rebuilt_lines.append(line)
-            index += 1
-
-            while index < len(lines):
-                candidate = lines[index]
-                stripped = candidate.strip()
-                indent = len(candidate) - len(candidate.lstrip(" "))
-                if stripped and indent <= header_indent:
-                    break
-                if stripped:
-                    entry_match = REDIRECT_ENTRY.match(candidate)
-                    if not entry_match:
-                        raise ValueError(f"Unsupported redirect_maps entry: {candidate}")
-                    redirects[entry_match.group(1)] = entry_match.group(2)
-                    entry_indent = indent
-                index += 1
-            continue
-
-        updated_line = re.sub(
-            rf"(:\s*)(['\"]?){re.escape(old_docs_path)}\2(\s*(?:#.*)?)$",
+    value_re = re.compile(
+        rf"(:\s*)(['\"]?){re.escape(old_docs_path)}\2(\s*(?:#.*)?)$"
+    )
+    for index, line in enumerate(maps.lines):
+        updated_line = value_re.sub(
             lambda match: f"{match.group(1)}{match.group(2)}{new_docs_path}{match.group(2)}{match.group(3)}",
             line,
         )
         if updated_line != line:
             changes.append(f"mkdocs value: {old_docs_path} -> {new_docs_path}")
-        rebuilt_lines.append(updated_line)
-        index += 1
+            maps.lines[index] = updated_line
 
-    if redirects is None or header_index is None:
-        raise ValueError("No redirect_maps section found in mkdocs config")
+    if maps.parsed:
+        for key, value in list(maps.redirects.items()):
+            if value == old_docs_path and key != old_docs_path:
+                maps.redirects[key] = new_docs_path
+                changes.append(f"mkdocs redirect target: {key} -> {new_docs_path}")
+        maps.add(old_docs_path, new_docs_path, changes)
 
-    for key, value in list(redirects.items()):
-        if value == old_docs_path and key != old_docs_path:
-            redirects[key] = new_docs_path
-            changes.append(f"mkdocs redirect target: {key} -> {new_docs_path}")
-
-    if redirects.get(old_docs_path) != new_docs_path:
-        redirects[old_docs_path] = new_docs_path
-        changes.append(f"mkdocs redirect: {old_docs_path} -> {new_docs_path}")
-
-    indent = entry_indent if entry_indent is not None else header_indent + 2
-    redirect_lines = [f'{" " * header_indent}redirect_maps:']
-    for key in sorted(redirects, key=str.casefold):
-        redirect_lines.append(f'{" " * indent}\'{key}\': \'{redirects[key]}\'')
-    rebuilt_lines[header_index : header_index + 1] = redirect_lines
-
-    new_content = "\n".join(rebuilt_lines)
-    if content.endswith("\n"):
-        new_content += "\n"
-    return new_content, changes
+    return maps.render(), changes
 
 
 def move_path(source: Path, destination: Path) -> None:
@@ -338,58 +290,12 @@ def add_single_redirect(
     new_docs_path: str,
 ) -> tuple[str, list[str]]:
     """Add or update a single redirect entry in mkdocs config."""
-    lines = content.splitlines()
-    rebuilt_lines: list[str] = []
-    changes: list[str] = []
-    redirects: dict[str, str] | None = None
-    header_index: int | None = None
-    header_indent = 0
-    entry_indent: int | None = None
-    index = 0
-
-    while index < len(lines):
-        line = lines[index]
-        header_match = REDIRECT_MAP_HEADER.match(line)
-        if header_match:
-            redirects = {}
-            header_index = len(rebuilt_lines)
-            header_indent = len(header_match.group(1))
-            rebuilt_lines.append(line)
-            index += 1
-            while index < len(lines):
-                candidate = lines[index]
-                stripped = candidate.strip()
-                indent = len(candidate) - len(candidate.lstrip(" "))
-                if stripped and indent <= header_indent:
-                    break
-                if stripped:
-                    entry_match = REDIRECT_ENTRY.match(candidate)
-                    if not entry_match:
-                        raise ValueError(f"Unsupported redirect_maps entry: {candidate}")
-                    redirects[entry_match.group(1)] = entry_match.group(2)
-                    entry_indent = indent
-                index += 1
-            continue
-        rebuilt_lines.append(line)
-        index += 1
-
-    if redirects is None or header_index is None:
+    maps = _RedirectMaps(content)
+    if not maps.parsed:
         raise ValueError("No redirect_maps section found in mkdocs config")
-
-    if redirects.get(old_docs_path) != new_docs_path:
-        redirects[old_docs_path] = new_docs_path
-        changes.append(f"mkdocs redirect: {old_docs_path} -> {new_docs_path}")
-
-    indent = entry_indent if entry_indent is not None else header_indent + 2
-    redirect_lines = [f'{" " * header_indent}redirect_maps:']
-    for key in sorted(redirects, key=str.casefold):
-        redirect_lines.append(f'{" " * indent}\'{key}\': \'{redirects[key]}\'')
-    rebuilt_lines[header_index : header_index + 1] = redirect_lines
-
-    new_content = "\n".join(rebuilt_lines)
-    if content.endswith("\n"):
-        new_content += "\n"
-    return new_content, changes
+    changes: list[str] = []
+    maps.add(old_docs_path, new_docs_path, changes)
+    return maps.render(), changes
 
 
 def relocate_directory(
@@ -522,23 +428,29 @@ def relocate_note(
     old_docs_path = source.relative_to(kb_root).as_posix()
     new_docs_path = destination.relative_to(kb_root).as_posix()
 
+    md_moves = {source: destination}
     markdown_updates: dict[Path, tuple[str, list[str]]] = {}
 
     for md_file in find_repo_markdown_files(repo_root):
         original = md_file.read_text(encoding="utf-8")
         if md_file.resolve() == source:
-            updated, changes = rebase_relative_markdown_links(original, source, destination)
+            updated, changes = rebase_and_rewrite_in_moved_file(
+                original, md_file, destination, md_moves
+            )
         else:
-            updated, changes = rewrite_links_to_relocated_note(original, md_file, source, destination)
+            updated, changes = rewrite_links_to_moved_files(original, md_file, md_moves)
         if changes:
             markdown_updates[md_file] = (updated, changes)
 
-    mkdocs_original = mkdocs_config.read_text(encoding="utf-8")
-    mkdocs_updated, mkdocs_changes = update_mkdocs_config(
-        mkdocs_original,
-        old_docs_path=old_docs_path,
-        new_docs_path=new_docs_path,
-    )
+    # Projects without an mkdocs site have nothing to update here.
+    mkdocs_updated = None
+    mkdocs_changes: list[str] = []
+    if mkdocs_config.is_file():
+        mkdocs_updated, mkdocs_changes = update_mkdocs_config(
+            mkdocs_config.read_text(encoding="utf-8"),
+            old_docs_path=old_docs_path,
+            new_docs_path=new_docs_path,
+        )
 
     mode = "APPLYING" if apply else "DRY RUN"
     print(f"=== {mode} ===\n")
@@ -569,6 +481,7 @@ def relocate_note(
     for path, (updated, _changes) in markdown_updates.items():
         target = destination if path.resolve() == source else path
         target.write_text(updated, encoding="utf-8")
-    mkdocs_config.write_text(mkdocs_updated, encoding="utf-8")
+    if mkdocs_updated is not None:
+        mkdocs_config.write_text(mkdocs_updated, encoding="utf-8")
     print("\nDone.")
     return 0

--- a/src/commonplace/lib/relocation.py
+++ b/src/commonplace/lib/relocation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -238,29 +237,9 @@ def update_mkdocs_config(
     return new_content, changes
 
 
-def move_path(source: Path, destination: Path, *, repo_root: Path) -> str:
+def move_path(source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "mv",
-                str(source.relative_to(repo_root)),
-                str(destination.relative_to(repo_root)),
-            ],
-            cwd=repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        return "git mv"
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        source.rename(destination)
-        return "rename"
-
-
-def move_note(source: Path, destination: Path, *, repo_root: Path) -> str:
-    return move_path(source, destination, repo_root=repo_root)
+    source.rename(destination)
 
 
 def resolve_directory(arg: str, *, repo_root: Path, kb_root: Path) -> Path:
@@ -498,25 +477,7 @@ def relocate_directory(
         print("\nThis was a dry run. Pass --apply to execute.")
         return 0
 
-    # Execute: git mv the whole directory
-    try:
-        subprocess.run(
-            [
-                "git",
-                "mv",
-                str(source.relative_to(repo_root)),
-                str(destination.relative_to(repo_root)),
-            ],
-            cwd=repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        strategy = "git mv"
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        source.rename(destination)
-        strategy = "rename"
+    move_path(source, destination)
 
     # Write updated markdown files (targets reflect post-move locations)
     for _, (target, updated, _changes) in markdown_updates.items():
@@ -526,8 +487,7 @@ def relocate_directory(
     if mkdocs_updated is not None:
         mkdocs_config.write_text(mkdocs_updated, encoding="utf-8")
 
-    print(f"\nMove strategy: {strategy}")
-    print("Done.")
+    print("\nDone.")
     return 0
 
 
@@ -605,11 +565,10 @@ def relocate_note(
         print("\nThis was a dry run. Pass --apply to execute.")
         return 0
 
-    strategy = move_note(source, destination, repo_root=repo_root)
+    move_path(source, destination)
     for path, (updated, _changes) in markdown_updates.items():
         target = destination if path.resolve() == source else path
         target.write_text(updated, encoding="utf-8")
     mkdocs_config.write_text(mkdocs_updated, encoding="utf-8")
-    print(f"\nMove strategy: {strategy}")
-    print("Done.")
+    print("\nDone.")
     return 0

--- a/src/commonplace/lib/snapshot.py
+++ b/src/commonplace/lib/snapshot.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 def dedup_existing_snapshot(out_dir: Path, source_url: str) -> Path | None:
     """Return an existing markdown snapshot path for source_url, if present."""
-    marker = f"source: {source_url}"
+    # Newline-terminated so a URL that prefixes another URL never matches it
+    # (issues/12 vs issues/123). Snapshot frontmatter always writes the line
+    # with a trailing newline.
+    marker = f"source: {source_url}\n"
     for existing in out_dir.glob("*.md"):
         try:
             header = existing.read_text(encoding="utf-8")[:1000]

--- a/src/commonplace/lib/systems_matrix.py
+++ b/src/commonplace/lib/systems_matrix.py
@@ -3,7 +3,8 @@
 Pure parsing logic for the systems matrix (``kb/agent-memory-systems/systems.csv``).
 Text-in, row-out, so it is unit-testable; the CLI runner
 (``scripts/build_systems_matrix.py``) owns file discovery, the identity join, and
-CSV writing. Stdlib only (ADR-008 — the package carries no runtime deps).
+CSV writing. This module stays stdlib-only so the runner script works without the
+package's dependencies installed.
 
 The matrix is **faithful**: multi-valued axes are one-hot indicator columns
 (``1`` present / ``0`` assessed-absent / ``''`` not assessed or assessed-unknown),

--- a/src/commonplace/lib/type_resolver.py
+++ b/src/commonplace/lib/type_resolver.py
@@ -302,14 +302,9 @@ def resolve_type(
         source_file=file_path,
     )
     type_frontmatter = _load_type_frontmatter(type_doc_path, workspace_root)
-    declared_type = type_frontmatter.get("type")
-    if type_doc_rel == TYPE_SPEC_PATH:
-        expected_type = TYPE_SPEC_PATH
-    else:
-        expected_type = TYPE_SPEC_PATH
-    if declared_type != expected_type:
+    if type_frontmatter.get("type") != TYPE_SPEC_PATH:
         raise ValueError(
-            f"{type_doc_rel}: type spec must declare type: {expected_type}"
+            f"{type_doc_rel}: type spec must declare type: {TYPE_SPEC_PATH}"
         )
 
     type_name = type_frontmatter.get("name")

--- a/tests/commonplace/cli/test_relocate_note.py
+++ b/tests/commonplace/cli/test_relocate_note.py
@@ -147,7 +147,7 @@ def test_resolve_destination_path_accepts_directory_target(tmp_path: Path) -> No
 
 
 def test_relocate_note_apply_leaves_review_state_rows_unchanged_and_paths_derived(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     repo_root = tmp_path
     kb_root = repo_root / "kb"
@@ -160,13 +160,6 @@ def test_relocate_note_apply_leaves_review_state_rows_unchanged_and_paths_derive
     review_pair_id = seed_accepted_review(repo_root, db_path, note_path="kb/notes/old-note.md")
     with review_db.connect(db_path) as conn:
         rows_before = review_state_rows(conn)
-
-    def fake_move(source: Path, destination: Path, *, repo_root: Path) -> str:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        source.rename(destination)
-        return "rename"
-
-    monkeypatch.setattr(relocation, "move_note", fake_move)
 
     result = relocation.relocate_note(
         root=repo_root,
@@ -219,7 +212,7 @@ def test_relocate_note_apply_leaves_review_state_rows_unchanged_and_paths_derive
     ]
 
 
-def test_relocate_note_apply_moves_file_with_to_directory(tmp_path: Path, monkeypatch) -> None:
+def test_relocate_note_apply_moves_file_with_to_directory(tmp_path: Path) -> None:
     repo_root = tmp_path
     kb_root = repo_root / "kb"
     notes_root = kb_root / "notes"
@@ -233,13 +226,6 @@ See [concept](./definitions/concept.md)
     )
     write(notes_root / "definitions" / "concept.md", "# Concept\n")
     write(repo_root / "mkdocs.yml", "plugins:\n  - redirects:\n      redirect_maps:\n")
-
-    def fake_move(source: Path, destination: Path, *, repo_root: Path) -> str:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        source.rename(destination)
-        return "rename"
-
-    monkeypatch.setattr(relocation, "move_note", fake_move)
 
     result = relocation.relocate_note(
         root=repo_root,
@@ -256,9 +242,7 @@ See [concept](./definitions/concept.md)
     assert "[concept](../definitions/concept.md)" in relocated_text
 
 
-def test_relocate_note_apply_moves_note_across_kb_collections(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_relocate_note_apply_moves_note_across_kb_collections(tmp_path: Path) -> None:
     repo_root = tmp_path
     kb_root = repo_root / "kb"
     notes_root = kb_root / "notes"
@@ -288,13 +272,6 @@ nav:
   - Doc System: notes/document-classification.md
 """,
     )
-
-    def fake_move(source_path: Path, destination_path: Path, *, repo_root: Path) -> str:
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        source_path.rename(destination_path)
-        return "rename"
-
-    monkeypatch.setattr(relocation, "move_note", fake_move)
 
     result = relocation.relocate_note(
         root=repo_root,

--- a/tests/commonplace/cli/test_relocate_note.py
+++ b/tests/commonplace/cli/test_relocate_note.py
@@ -23,7 +23,7 @@ def write(path: Path, content: str) -> Path:
     return path
 
 
-def test_rewrite_links_to_relocated_note_updates_real_links_only(tmp_path: Path) -> None:
+def test_rewrite_links_to_moved_files_updates_real_links_only(tmp_path: Path) -> None:
     old_note = tmp_path / "kb" / "notes" / "old-note.md"
     new_note = tmp_path / "kb" / "notes" / "new-note.md"
     ref_file = tmp_path / "kb" / "sources" / "source.ingest.md"
@@ -37,11 +37,10 @@ Inline: `[skip](../notes/old-note.md)`
 ```
 """
 
-    updated, changes = relocation.rewrite_links_to_relocated_note(
+    updated, changes = relocation.rewrite_links_to_moved_files(
         content,
         ref_file,
-        old_note,
-        new_note,
+        {old_note.resolve(): new_note},
     )
 
     assert "[old](../notes/new-note.md)" in updated
@@ -55,17 +54,19 @@ Inline: `[skip](../notes/old-note.md)`
     ]
 
 
-def test_rebase_relative_markdown_links_updates_outbound_links_for_moved_note(tmp_path: Path) -> None:
+def test_rebase_and_rewrite_updates_outbound_links_for_moved_note(tmp_path: Path) -> None:
     old_note = tmp_path / "kb" / "notes" / "old-note.md"
+    new_note = tmp_path / "kb" / "notes" / "archive" / "relocated-note.md"
     write(tmp_path / "kb" / "notes" / "definitions" / "concept.md", "# Concept\n")
     content = """Self: [self](./old-note.md)
 Target: [concept](./definitions/concept.md)
 """
 
-    updated, changes = relocation.rebase_relative_markdown_links(
+    updated, changes = relocation.rebase_and_rewrite_in_moved_file(
         content,
         old_note,
-        tmp_path / "kb" / "notes" / "archive" / "relocated-note.md",
+        new_note,
+        {old_note.resolve(): new_note},
     )
 
     assert "[self](./relocated-note.md)" in updated
@@ -98,6 +99,40 @@ nav:
     assert "- Example: notes/archive/new-name.md" in updated
     assert any("mkdocs redirect: notes/old-name.md -> notes/archive/new-name.md" == item for item in changes)
     assert any("mkdocs redirect target: notes/older-name.md -> notes/archive/new-name.md" == item for item in changes)
+
+
+def test_update_mkdocs_config_without_redirect_maps_rewrites_values_only() -> None:
+    content = """site_name: Project
+nav:
+  - Example: notes/old-name.md
+"""
+
+    updated, changes = relocation.update_mkdocs_config(
+        content,
+        old_docs_path="notes/old-name.md",
+        new_docs_path="notes/new-name.md",
+    )
+
+    assert "- Example: notes/new-name.md" in updated
+    assert "redirect" not in updated
+    assert changes == ["mkdocs value: notes/old-name.md -> notes/new-name.md"]
+
+
+def test_relocate_note_apply_works_without_mkdocs_config(tmp_path: Path) -> None:
+    notes_root = tmp_path / "kb" / "notes"
+    write(notes_root / "COLLECTION.md", "# Notes collection\n")
+    old_note = write(notes_root / "old-note.md", "# Old note\n")
+
+    result = relocation.relocate_note(
+        root=tmp_path,
+        note_arg="old-note",
+        new_name="renamed note",
+        apply=True,
+    )
+
+    assert result == 0
+    assert not old_note.exists()
+    assert (notes_root / "renamed-note.md").exists()
 
 
 def test_slugify_rejects_overlong_note_slug() -> None:

--- a/tests/commonplace/lib/test_frontmatter.py
+++ b/tests/commonplace/lib/test_frontmatter.py
@@ -64,6 +64,28 @@ def test_parse_requires_frontmatter_to_be_mapping() -> None:
     assert result.errors == ["frontmatter must parse to a mapping"]
 
 
+def test_parse_accepts_crlf_line_endings() -> None:
+    result = frontmatter.parse(
+        "---\r\n"
+        "description: Windows note\r\n"
+        "type: kb/types/note.md\r\n"
+        "---\r\n"
+        "# Title\r\n"
+    )
+
+    assert result.ok
+    assert result.data == {
+        "description": "Windows note",
+        "type": "kb/types/note.md",
+    }
+
+
+def test_strip_removes_crlf_frontmatter_block() -> None:
+    content = "---\r\ntype: kb/types/note.md\r\n---\r\n# Title\r\nBody."
+
+    assert frontmatter.strip(content) == "# Title\r\nBody."
+
+
 def test_strip_removes_frontmatter_block() -> None:
     content = "---\ntype: kb/types/note.md\n---\n# Title\nBody."
 

--- a/tests/commonplace/lib/test_index_directory.py
+++ b/tests/commonplace/lib/test_index_directory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 from commonplace.lib.index_directory import collect_index_pages, generate
@@ -10,16 +9,6 @@ def write(path: Path, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
-
-
-def init_git_repo(path: Path) -> None:
-    subprocess.run(
-        ["git", "init"],
-        cwd=path,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
 
 
 def test_generate_directory_index_skips_readme_index_and_types(tmp_path: Path) -> None:
@@ -151,9 +140,7 @@ def test_collect_index_pages_max_depth_skips_nested_indexes(tmp_path: Path) -> N
     assert "- [skill-foo/](./skill-foo/SKILL.md)" in root_index
 
 
-def test_collect_index_pages_prunes_gitignored_directories(tmp_path: Path) -> None:
-    init_git_repo(tmp_path)
-    write(tmp_path / ".gitignore", "kb/reference/generated/\n")
+def test_collect_index_pages_prunes_hidden_dirs_and_nested_repos(tmp_path: Path) -> None:
     collection = tmp_path / "kb" / "reference"
     write(
         collection / "kept.md",
@@ -166,20 +153,25 @@ type: kb/types/note.md
 """,
     )
     write(
-        collection / "generated" / "ignored.md",
+        collection / ".hidden" / "invisible.md",
         """---
-description: Ignored note
+description: Hidden note
 type: kb/types/note.md
 ---
 
-# Ignored
+# Hidden
 """,
     )
-    pages = as_dict(collect_index_pages(collection, ignore_root=tmp_path))
+    write(collection / "vendored" / "cloned.md", "# Cloned\n")
+    (collection / "vendored" / ".git").mkdir()
+    pages = as_dict(collect_index_pages(collection))
 
     root_index = pages[collection / "dir-index.md"]
 
     assert "- [Kept](./kept.md) *(note)* - Kept note" in root_index
-    assert "generated/" not in root_index
-    assert "Ignored note" not in root_index
-    assert collection / "generated" / "dir-index.md" not in pages
+    assert ".hidden/" not in root_index
+    assert "Hidden note" not in root_index
+    assert "vendored/" not in root_index
+    assert "Cloned" not in root_index
+    assert collection / ".hidden" / "dir-index.md" not in pages
+    assert collection / "vendored" / "dir-index.md" not in pages

--- a/tests/commonplace/lib/test_project_paths.py
+++ b/tests/commonplace/lib/test_project_paths.py
@@ -63,6 +63,39 @@ def test_list_collection_note_paths_skips_nested_repos_and_type_dirs(tmp_path: P
     assert nested_template not in discovered
 
 
+def test_list_collection_note_paths_skips_hidden_entries_and_stale_dir_indexes(
+    tmp_path: Path,
+) -> None:
+    collection_root = collection(tmp_path / "kb" / "notes")
+    kept = write(collection_root / "kept.md")
+    hidden_dir_note = write(collection_root / ".obsidian" / "workspace.md")
+    hidden_file = write(collection_root / ".draft.md")
+    stale_dir_index = write(collection_root / "dir-index.md")
+
+    discovered = project_paths.list_collection_note_paths(collection_root)
+
+    assert kept in discovered
+    assert hidden_dir_note not in discovered
+    assert hidden_file not in discovered
+    assert stale_dir_index not in discovered
+
+
+def test_find_repo_markdown_files_skips_artifact_trees_and_hidden_dirs(tmp_path: Path) -> None:
+    kept = write(tmp_path / "kb" / "notes" / "note.md")
+    top_level = write(tmp_path / "README.md")
+    venv_doc = write(tmp_path / ".venv" / "lib" / "pkg" / "README.md")
+    site_doc = write(tmp_path / "site" / "notes" / "note.md")
+    tmp_doc = write(tmp_path / "tmp" / "scratch.md")
+
+    discovered = project_paths.find_repo_markdown_files(tmp_path)
+
+    assert kept in discovered
+    assert top_level in discovered
+    assert venv_doc not in discovered
+    assert site_doc not in discovered
+    assert tmp_doc not in discovered
+
+
 def test_list_kb_note_paths_spans_all_content_collections(tmp_path: Path) -> None:
     collection(tmp_path / "kb" / "notes")
     collection(tmp_path / "kb" / "sources")

--- a/tests/commonplace/lib/test_snapshot.py
+++ b/tests/commonplace/lib/test_snapshot.py
@@ -21,3 +21,12 @@ def test_dedup_existing_snapshot_ignores_non_matching_snapshots(tmp_path: Path) 
     (tmp_path / "other.md").write_text("---\nsource: https://example.com/other\n---\n", encoding="utf-8")
 
     assert dedup_existing_snapshot(tmp_path, "https://example.com/source") is None
+
+
+def test_dedup_existing_snapshot_does_not_match_url_prefixes(tmp_path: Path) -> None:
+    (tmp_path / "issue-123.md").write_text(
+        "---\nsource: https://github.com/o/r/issues/123\n---\n",
+        encoding="utf-8",
+    )
+
+    assert dedup_existing_snapshot(tmp_path, "https://github.com/o/r/issues/12") is None


### PR DESCRIPTION
Replace the per-path 'git check-ignore' oracle with a name-based
visibility contract (ADR 039): hidden entries and nested git repos are
invisible to every markdown walk, repo-wide walks also skip build/vendor
artifact trees, and collection walks exclude the reserved dir-index.md
name (preserving ADR 025 without its gitignore rule). Gitignore no
longer affects what the tools see, so behavior is identical with or
without git and enumeration drops from ~5s of subprocess churn to a
plain filesystem walk (~0.02s on this repo).

Relocation moves files with Path.rename instead of 'git mv' with a
silent fallback; git detects renames on commit.

Visibility change on this repo: kb/work/agent-memory-design/ (tracked
but matched by a gitignore pattern, hidden by the old --no-index check)
is visible to sweeps again; nothing else changes on a fresh clone.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N7HsbyXh72K1P7xoewp32b