### PR TITLE
Revise self-improving-systems tag-README for flow and brevity

### DIFF
--- a/kb/notes/self-improving-systems-README.md
+++ b/kb/notes/self-improving-systems-README.md
@@ -8,58 +8,42 @@ complete: true
 
 # Self-improving systems
 
-The object is the [**self-improving system**](./definitions/self-improving-system.md): operative changes to a system's own behavior-determining organization, causally responsive to evidence bearing on an improvement objective. Membership is deliberately broad — a weight-level learner is inside, a dev team is inside without autonomy — and the definition note carries the full apparatus: the two evidence arms, the reflective/non-reflective test, exclusions, misuse cases, provenance. The central distinction is **reflective versus non-reflective self-improvement**, pathway-relative; the name alone carries little information — the design information is in the gradings, [since four independent gradings place a self-improving system](./four-independent-gradings-place-a-self-improving-system.md). Most systems in [agent-memory-systems](../agent-memory-systems/README.md) are a bid at the reflective kind — mine the traces, write the lesson down, load it next time.
+A [self-improving system](./definitions/self-improving-system.md) makes operative changes to its own behavior-determining organization in response to evidence about an improvement objective. The definition is deliberately broad — a weight-level learner qualifies, and so does a dev team. The design information is not in the label but in where a system falls on [four independent gradings](./four-independent-gradings-place-a-self-improving-system.md), and above all in whether its improvement pathway is **reflective** — routed through a self-representation — or not. Most systems in [agent-memory-systems](../agent-memory-systems/README.md) are bids at the reflective kind: mine the traces, write the lesson down, load it next time.
 
-## The stake: a conjectured sample-efficiency payoff
+## Why reflection might pay
 
-Why care which side of the distinction a pathway falls on? One argument chain, each step at its own strength — only the first is architectural rather than conjectural:
+The case for reflective pathways is a four-step chain; only the first step is architectural rather than conjectural.
 
-1. Reflection makes retention **addressable**: a lesson kept through a self-representation is one later rounds can *read* — inspect, criticize, revise selectively, carry elsewhere — [since reflection buys addressability](./reflection-buys-addressability.md). That note also carries the guard against the tempting overclaim: compounding alone needs no reflection — parametric learners have it by construction.
-2. An addressable lesson is second-order — it can reject or rescope a prior commitment outright, where a gradient can only nudge it: [reflection makes retained lessons second-order](./reflection-makes-retained-lessons-second-order.md).
-3. The conjecture the chain builds to: [addressable hypotheses may reduce target data under structured shifts](./addressable-hypotheses-may-reduce-target-data-under-structured-shifts.md) — every clause a separately failable condition; the note carries the directional prediction and the test design. Commonplace's own bet, not a result.
-4. The standing discount: the reflective wire is best-effort, and a hypothesis nothing surfaces contributes nothing — [retrieval failure is reflection failure](./retrieval-failure-is-reflection-failure.md).
+1. Reflection makes retained lessons **addressable**: later rounds can read, criticize, and selectively revise them — [reflection buys addressability](./reflection-buys-addressability.md). The guard against overclaiming: compounding alone needs no reflection; parametric learners compound by construction.
+2. An addressable lesson is **second-order**: it can reject a prior commitment outright, where a gradient can only nudge it — [reflection makes retained lessons second-order](./reflection-makes-retained-lessons-second-order.md).
+3. The payoff conjecture: [addressable hypotheses may reduce target data under structured shifts](./addressable-hypotheses-may-reduce-target-data-under-structured-shifts.md). This is Commonplace's own bet, not a result; the note carries the prediction and the test design.
+4. The standing discount: a lesson nothing surfaces contributes nothing — [retrieval failure is reflection failure](./retrieval-failure-is-reflection-failure.md).
 
-## Base terms and tests
+## The four gradings
 
-- [Behavior-determining organization](./definitions/behavior-determining-organization.md) — what the change must land in; outputs and environment excluded.
-- [Operative change](./definitions/operative-change.md) — a declared horizon plus a behavioral-authority path; permanence not required.
-- [Evidence bearing on an improvement objective](./definitions/evidence-bearing-on-an-improvement-objective.md) — what makes change improvement-directed; no evaluator component required.
-- [The self-improving-system definition classifies its boundary cases without ad hoc exceptions](./the-self-improving-system-definition-classifies-its-boundary-cases.md) — nine inclusion tests, from gradient learning to accidental self-modification.
-
-## The proposal-selection subtype
-
-The gate architecture — generate, evaluate with possible non-adoption, selectively retain — is a named subtype; the oracle, rejectability, and warranted-autonomy machinery is scoped to it, not to the category.
-
-- [A proposal-selection improvement loop requires search, evaluation, and operative retention](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) — the three functions and their weakest viable forms; when a loop stalls, ask which function is missing.
-- [False-positive generation is filtered; false-positive acceptance becomes operative](./false-positive-generation-is-filtered-before-retention.md) — the asymmetry that makes evaluation the terminal filter.
-
-## The gradings
-
-Four axes, each pairing a nearly free attribution with a costly one; the synthesis is linked from the orientation above.
-
-- **Retention form** — operative, cumulative, or addressable; the stake chain above is this grading's payoff, and the machinery is the [reflective system](./definitions/reflective-system.md)'s causally connected map plus intercession.
-- **Coverage** — [reflective coverage is graded across representational forms](./reflective-coverage-is-graded-across-representational-forms.md): claims named per form and operation depth.
+- **Retention form** — operative, cumulative, or addressable. The chain above is this axis's payoff; the machinery is the [reflective system](./definitions/reflective-system.md)'s causally connected self-map.
+- **Coverage** — [reflective coverage is graded across representational forms](./reflective-coverage-is-graded-across-representational-forms.md).
 - **Closure** — [a methodology governs its own extension only as far as it settles the meta-decisions it raises](./a-methodology-governs-its-own-extension-only-as-far-as-it-settles.md).
-- **Autonomy** — [human-inclusive boundaries make reflection cheap](./human-inclusive-boundaries-make-reflection-cheap.md): bare autonomy is free; what costs is warrant, [since warranted autonomy is bounded by oracle reach](./warranted-autonomy-is-bounded-by-oracle-reach.md).
+- **Autonomy** — bare autonomy is free; warrant is what costs. [Human-inclusive boundaries make reflection cheap](./human-inclusive-boundaries-make-reflection-cheap.md), and [warranted autonomy is bounded by oracle reach](./warranted-autonomy-is-bounded-by-oracle-reach.md).
 
-## Occupants, placed on the axes
+## Example placements
 
-- [Ashby's Homeostat](../sources/ashby-design-for-a-brain-ultrastability.md) — the floor: non-reflective, viability-driven, fully autonomous; nothing accumulates.
-- Parametric self-improvers — self-play policies, agents fine-tuned on their own trajectories — non-reflective direct determination: compounding without addressability. The dominant paradigm, the conjecture's comparison baseline, and the corner this KB has covered least.
-- The [Gödel machine](./goedel-machines-are-a-proof-governed-case-of-self-modification.md) — reflective, autonomous, proof-gated: the strongest available oracle, paid for in reach.
-- [Commonplace](../reference/commonplace-as-a-reflective-system.md) — reflective, human-inclusive: humans hold search and the judgment-heavy evaluation.
+- [Ashby's Homeostat](../sources/ashby-design-for-a-brain-ultrastability.md) — the floor: non-reflective, fully autonomous, nothing accumulates.
+- Parametric self-improvers (self-play policies, agents fine-tuned on their own trajectories) — compounding without addressability; the dominant paradigm and the conjecture's comparison baseline.
+- The [Gödel machine](./goedel-machines-are-a-proof-governed-case-of-self-modification.md) — reflective, autonomous, proof-gated: the strongest oracle, paid for in reach.
+- [Commonplace itself](../reference/commonplace-as-a-reflective-system.md) — reflective, human-inclusive: humans hold search and the judgment-heavy evaluation.
 
-## Status of the claims
+Read every claim at its stated strength: the definitions are stipulated and revisable, the reflective advantage is a hypothesis, and whether it holds is the open empirical question the chain above sharpens.
 
-Read each statement at its own strength. The definitions are stipulated explications — chosen and revisable, with the taxonomic choices, literature alignment, and retired formulations recorded in the definition's own provenance section. The expected advantages of reflective pathways are hypotheses, listed as such in the addressability note. Whether reflective pathways actually improve faster, more reliably, or on less target data is the open empirical question the stake chain sharpens.
+## Further notes under the tag
 
-## Consequence for agentic systems
-
-- [Improving an agentic system crosses the prose-symbolic boundary](./improving-an-agentic-system-crosses-the-prose-symbolic-boundary.md) — reliability gains move behavior between prose and code, so coverage of a single form cannot carry them.
-- The external reviews run on this vocabulary: the [agent-memory-system-review](../agent-memory-systems/types/agent-memory-system-review.md) type asks for representational forms, behavioral authority, and the promotion path; the [comparison matrix](../agent-memory-systems/systems-table.md) is generated from those terms.
+- [Behavior-determining organization](./definitions/behavior-determining-organization.md), [operative change](./definitions/operative-change.md), [evidence bearing on an improvement objective](./definitions/evidence-bearing-on-an-improvement-objective.md) — the definition's three base terms.
+- [The definition classifies its boundary cases without ad hoc exceptions](./the-self-improving-system-definition-classifies-its-boundary-cases.md) — nine inclusion tests, from gradient learning to accidental self-modification.
+- [A proposal-selection loop requires search, evaluation, and operative retention](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) and [false-positive acceptance becomes operative](./false-positive-generation-is-filtered-before-retention.md) — the generate-evaluate-retain subtype and why evaluation is its terminal filter.
+- [Improving an agentic system crosses the prose-symbolic boundary](./improving-an-agentic-system-crosses-the-prose-symbolic-boundary.md) — reliability gains move behavior between prose and code, so coverage of one form cannot carry them. The [agent-memory-system reviews](../agent-memory-systems/types/agent-memory-system-review.md) and the [comparison matrix](../agent-memory-systems/systems-table.md) run on this vocabulary.
 
 ## Related Tags
 
-- [foundations](./foundations-README.md) — the broader core theory this sits inside, including [actionable methodology](./definitions/actionable-methodology.md)
+- [foundations](./foundations-README.md) — the broader core theory this sits inside
 - [constraining](./constraining-README.md) — closure is a constraining property of methodology-as-input
 - [computational-model](./computational-model-README.md) — reflection and intercession as computational concepts generalized to socio-technical boundaries


### PR DESCRIPTION
Narrate only the core thread (definition, stake chain, gradings,
placements); relegate base terms, boundary cases, the proposal-selection
subtype, and the agentic-systems consequence to a compact list at the
end. Keeps the complete mark valid (all members still linked) and drops
weight from 7.6 KB to 5.6 KB.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQ5qfBWmDf5csyG5Hajbo2