### PR TITLE
Move the gradings section up in self-improving-systems README

### DIFF
--- a/kb/notes/self-improving-systems-README.md
+++ b/kb/notes/self-improving-systems-README.md
@@ -8,7 +8,17 @@ complete: true
 
 # Self-improving systems
 
-A [self-improving system](./definitions/self-improving-system.md) makes operative changes to its own behavior-determining organization in response to evidence about an improvement objective. The definition is deliberately broad — it asks for this functional shape and nothing else — so even a dev team qualifies: people who revise their system's code and conventions in response to its failures count, once the declared boundary includes them. Where that boundary lies is the analyst's choice. A change pathway is **reflective** if it routes through a representation of the system's own behavior that the system can read and edit — a lessons file, a policy document. It is non-reflective if it ends in what nothing inside the system can read — a weight update. Most systems in [agent-memory-systems](../agent-memory-systems/README.md) mine their traces for lessons and load them into later runs. Whether that qualifies as a reflective pathway is again a boundary choice: are the lessons data the system consults, or part of its [system definition](./definitions/system-definition-artifact.md)?
+A [self-improving system](./definitions/self-improving-system.md) makes operative changes to its own behavior-determining organization in response to evidence about an improvement objective. The definition is deliberately broad, so even a dev team qualifies: people who revise their system's code and conventions in response to its failures count, once the declared boundary includes them. Where that boundary lies is the analyst's choice. A change pathway is **reflective** if it routes through a representation of the system's own behavior that the system can read and edit — a lessons file, a policy document. It is non-reflective if it ends in what nothing inside the system can read — a weight update. Most systems in [agent-memory-systems](../agent-memory-systems/README.md) mine their traces for lessons and load them into later runs. Whether that qualifies as a reflective pathway is again a boundary choice: are the lessons data the system consults, or part of its [system definition](./definitions/system-definition-artifact.md)?
+
+## The three gradings
+
+The boundary choice above settles only *membership* — whether the lessons are part of the system at all. Reflectivity is read off the architecture and graded, not declared: weights bind with maximal [behavioral authority](./definitions/behavioral-authority.md), yet nothing inside reads them — authority and addressability are separate fields. Since membership is cheap, a system is placed by [three independent gradings](./three-independent-gradings-place-a-self-improving-system.md) — statically they locate a system; dynamically they are the faces of the conversion by which the loop closes:
+
+- **Retention form** — operative, cumulative, or addressable; the machinery is the [reflective system](./definitions/reflective-system.md)'s causally connected self-map. Weights hold the cumulative-but-opaque grade; probes try to retrofit addressability onto it.
+- **Coverage** — [reflective coverage is graded across representational forms](./reflective-coverage-is-graded-across-representational-forms.md) — pinning a model is real but selection-grade coverage of the parametric form.
+- **Closure** — [a methodology governs its own extension only as far as it settles the meta-decisions it raises](./a-methodology-governs-its-own-extension-only-as-far-as-it-settles.md).
+
+Autonomy — who runs a pathway — is worth reporting but is not a fourth placement: under Commonplace's strictly computational boundary a reflective pathway is thereby autonomous, [since admitting a human into the boundary would only trade that precision for a separate axis](./admitting-a-human-into-the-boundary-trades-reflectivity-for-autonomy.md); non-reflective pathways are graded human-inclusive or autonomous directly. What costs is **warrant**, trusting what an unattended loop accepts: [warranted autonomy is bounded by oracle domain](./warranted-autonomy-is-bounded-by-oracle-domain.md).
 
 ## The improvement loop
 
@@ -23,35 +33,25 @@ A [self-improving system](./definitions/self-improving-system.md) makes operativ
 
 ## Closing the loop
 
-- [An improvement loop closes by converting improvised decisions into governed machinery](./an-improvement-loop-closes-by-converting-improvised-decisions.md) — the organizing thesis: a loop is more closed the fewer decisions per cycle need improvised human supply, and partial closure is the predicted state, not a way station.
+- [An improvement loop closes by converting improvised decisions into governed machinery](./an-improvement-loop-closes-by-converting-improvised-decisions.md) — the organizing thesis: a loop is more closed the fewer decisions per cycle need improvised human supply; partial closure is the predicted state.
 - [A closing improvement loop relocates human effort to the frontier instead of reducing it](./a-closing-loop-relocates-human-effort-to-the-frontier.md) — the human side: measure improvements per human judgment, not total hours.
 - [Reflection may improve sample efficiency under structured shifts](./reflection-may-improve-sample-efficiency-under-structured-shifts.md) — one payoff hypothesis, sharpened into a prediction and a test design.
-
-## The three gradings
-
-Since membership is cheap, a system is placed by [three independent gradings](./three-independent-gradings-place-a-self-improving-system.md) — read statically they locate a system; read dynamically they are the faces of the conversion by which the loop closes:
-
-- **Retention form** — operative, cumulative, or addressable; the machinery is the [reflective system](./definitions/reflective-system.md)'s causally connected self-map.
-- **Coverage** — [reflective coverage is graded across representational forms](./reflective-coverage-is-graded-across-representational-forms.md).
-- **Closure** — [a methodology governs its own extension only as far as it settles the meta-decisions it raises](./a-methodology-governs-its-own-extension-only-as-far-as-it-settles.md).
-
-Autonomy — how much of a pathway runs without a person — is worth reporting but is not a fourth placement: under Commonplace's strictly computational boundary a reflective pathway is thereby autonomous, [since admitting a human into the boundary would only trade that precision for a separate axis](./admitting-a-human-into-the-boundary-trades-reflectivity-for-autonomy.md); non-reflective pathways are graded human-inclusive or autonomous directly. What costs is **warrant**, trusting what an unattended loop accepts: [warranted autonomy is bounded by oracle domain](./warranted-autonomy-is-bounded-by-oracle-domain.md).
 
 ## Example placements
 
 - [Ashby's Homeostat](../sources/ashby-design-for-a-brain-ultrastability.md) — the floor: non-reflective, fully autonomous, nothing accumulates.
 - Parametric self-improvers (self-play policies, agents fine-tuned on their own trajectories) — compounding without addressability; the dominant paradigm and the conjecture's comparison baseline.
 - The [Gödel machine](./goedel-machines-are-a-proof-governed-case-of-self-modification.md) — reflective, autonomous, proof-gated: the strongest oracle, paid for in domain.
-- [Commonplace itself](../reference/commonplace-as-a-reflective-system.md) — pathway-mixed, part-way up the displacement ladder: reflective and autonomous where a validator or agent consults an explicit self-representation, human-inclusive where a maintainer notices what's worth fixing or judges the shape of a fix.
+- [Commonplace itself](../reference/commonplace-as-a-reflective-system.md) — pathway-mixed: reflective and autonomous where a validator or agent consults an explicit self-representation, human-inclusive where a maintainer notices what's worth fixing.
 
-Read every claim at its stated strength: the definitions are stipulated and revisable, the closing-loop thesis and its payoffs are hypotheses, and whether they hold is the open empirical question the cluster sharpens.
+Read every claim at its stated strength: the definitions are stipulated and revisable; the closing-loop thesis and its payoffs are open hypotheses.
 
 ## Further notes under the tag
 
-- [Measuring autonomy well enough to see it improve is an open problem](./measuring-autonomy-well-enough-to-see-it-improve-is-an-open-problem.md) — the per-function grading tells you where a system sits, but not whether it is getting more autonomous or how it compares to a differently-decomposed system.
+- [Measuring autonomy well enough to see it improve is an open problem](./measuring-autonomy-well-enough-to-see-it-improve-is-an-open-problem.md) — the per-function grading locates a system but cannot yet show it becoming more autonomous.
 - [Behavior-determining organization](./definitions/behavior-determining-organization.md), [operative change](./definitions/operative-change.md), [evidence bearing on an improvement objective](./definitions/evidence-bearing-on-an-improvement-objective.md) — the definition's three base terms.
 - [The definition classifies its boundary cases without ad hoc exceptions](./the-self-improving-system-definition-classifies-its-boundary-cases.md) — nine inclusion tests, from gradient learning to accidental self-modification.
-- [Improving an agentic system crosses the prose-symbolic boundary](./improving-an-agentic-system-crosses-the-prose-symbolic-boundary.md) — reliability gains move behavior between prose and code, so coverage of one form cannot carry them. The [agent-memory-system reviews](../agent-memory-systems/types/agent-memory-system-review.md) and the [comparison matrix](../agent-memory-systems/systems-table.md) run on this vocabulary.
+- [Improving an agentic system crosses the prose-symbolic boundary](./improving-an-agentic-system-crosses-the-prose-symbolic-boundary.md) — reliability gains move behavior between prose and code; the [agent-memory-system reviews](../agent-memory-systems/types/agent-memory-system-review.md) and [comparison matrix](../agent-memory-systems/systems-table.md) run on this vocabulary.
 - [Reach assessment](./definitions/reach-assessment.md) — the semantic judgment reflectivity's structural requirements do not supply; the sample-efficiency conjecture and second-order rescoping both depend on it.
 - [Formal symbolic systems assess reach only through causal and proof obligations](./formal-systems-can-assess-reach-through-causal-and-proof-obligations.md) — reach assessment isn't LLM-exclusive: proof search and causal inference give symbolic systems a formal route to it.
 


### PR DESCRIPTION
The gradings answer the definitional boundary question the orientation
poses, so they now sit directly after it. The new lead-in records the
decomposition: the data-vs-system-definition choice settles membership
only, while reflectivity is graded fact read off the architecture —
behavioral authority and addressability are separate fields (weights
bind maximally yet are unread). Bullet context phrases now route to the
graded parametric handles already in the cluster: probes as retrofitted
addressability, model pinning as selection-grade coverage. Compressed
several context phrases to stay under the tag-readme weight gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dni6ByLueqdKEX5mcVKnE4