### PR TITLE
Add minimal-by-default beat to derivation-size note

### DIFF
--- a/kb/notes/information-value-is-observer-relative.md
+++ b/kb/notes/information-value-is-observer-relative.md
@@ -36,9 +36,7 @@ Observer-relativity also determines resolution. The minimum required content of 
 - **A connection the consumer will not reliably make:** a relation, recognition condition, or operation that activates otherwise familiar knowledge.
 - **What reconstruction cannot preserve:** warrant, provenance, exact wording or membership, a governing version, or an authoritative local choice.
 
-Reconstructability and activation are separate tests because [knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md). A model may explain a framework perfectly when asked yet fail to recognize the present situation as an instance of it. When its name reliably activates the framework, the artifact can retain the problem mapping rather than a tutorial; when exactness, evidence, or authority matters, the full content must remain or be reliably loadable.
-
-For agent consumers, test resolution behaviorally: compare a bare name, a name plus recognition condition, and fuller content, then retain the least detail that preserves the intended effect. The result depends on the consumer population. A cue that resolves for one model may fail for another, while a compact agent-facing note may be opaque to a first-time human. Self-containedness therefore means supplying what intended consumers need, not reproducing everything relevant to the topic.
+Reconstructability and activation are separate tests because [knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — a model may explain a framework perfectly when asked yet fail to recognize the present situation as an instance of it. Where the boundary falls — when a framework name plus a recognition condition suffices, and when tutorial, warrant, or exact content must remain — is developed in [the framework is often larger than the durable contribution](./the-framework-is-often-larger-than-the-durable-contribution.md), together with a behavioral test for it. The result depends on the consumer population: a cue that resolves for one model may fail for another, and a compact agent-facing note may be opaque to a first-time human. Self-containedness therefore means supplying what intended consumers need, not reproducing everything relevant to the topic.
 
 ### How to present
 
@@ -67,6 +65,7 @@ More broadly, reshaping knowledge for a specific observer creates value. In info
 
 Relevant Notes:
 
+- [the framework is often larger than the durable contribution](./the-framework-is-often-larger-than-the-durable-contribution.md) — extends: develops the resolution question for the framework-activation case, with the recognition rule and the behavioral boundary test
 - [theory and methodology form a two-layer execution system](./theory-and-methodology-form-a-two-layer-execution-system.md) — instance: a task-facing layer can make source structure more accessible to a bounded observer
 - [conjecture is seeing the particular as an instance of the general](./conjecture-is-seeing-the-particular-as-an-instance-of-the-general.md) — instance: recognition cost scales with abstraction depth
 - [reverse-compression is the failure mode where LLM output expands without adding information](./reverse-compression-is-when-llm-output-expands-without-adding.md) — instance: expansion that adds tokens without making more structure accessible

--- a/kb/notes/the-derivation-is-often-larger-than-the-durable-contribution.md
+++ b/kb/notes/the-derivation-is-often-larger-than-the-durable-contribution.md
@@ -1,5 +1,5 @@
 ---
-description: "Why an authoring agent may need a familiar framework to discover a connection even when future consumers need only the recognition rule or local consequence"
+description: "Why an authoring agent may need a familiar framework to discover a connection when consumers need only the recognition rule; the default is minimal prose plus a framework link, grown on demand"
 type: kb/types/note.md
 traits: [title-as-claim]
 tags: [context-engineering]
@@ -17,9 +17,17 @@ When discovery applies a familiar framework to an unfamiliar case, the durable c
 
 > When **this observable condition** occurs, treat **this apparent task** as **this named kind of problem**, and use the corresponding framework to **perform this operation**.
 
-The framework name addresses knowledge the consumer can reconstruct; the condition, mapping, and operation preserve what it did not reliably supply. Repeating the framework adds value only when it provides needed accessibility, disambiguation, warrant, or fidelity.
+The framework name addresses knowledge the consumer can reconstruct; the condition, mapping, and operation preserve what it did not reliably supply. Repeating the framework adds value only when it supplies something the name cannot: accessibility, disambiguation, warrant, or fidelity.
 
-The derivation must also remain when it is itself evidence, when the consumer cannot reconstruct it, or when a particular version or interpretation has authority. Participating in discovery does not make every part of the reasoning path part of the discovery, but neither does reconstructability make warrant or exactness expendable.
+By that same measure, the derivation itself must remain wherever it carries one of those values — when it is evidence the consumer must be able to check, when the consumer cannot reconstruct it, or when a particular version or interpretation has authority. Stripping a derivation always trades away auditability: a claim without its reasoning must be taken on trust. Participating in discovery does not make every part of the reasoning path part of the discovery, but reconstructability alone does not make warrant or exactness expendable.
+
+## Minimal by default, grown on demand
+
+Reconstructability is not the only reason to compress. A note records one case, and what the case contributes is the recognition — the cue, the mapping, the local fact. The framework behind it is shared across many notes, so it belongs in an artifact of its own, linked rather than re-taught inline, since [short composable notes maximize combinatorial discovery](./short-composable-notes-maximize-combinatorial-discovery.md). The write-time default is therefore minimal prose with a link standing where the framework recap would have gone: the graph carries the reconstructable load structurally, so no single note has to.
+
+Minimal means minimal background, not minimal anchor. The dangerous compression cuts in the wrong direction: it drops the condition, mapping, or local fact — the case's actual contribution — while framework prose survives, or it drops the framework link entirely. The link matters because [knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md): the name and cue are what trigger the consumer's reconstruction, and without them it fails silently. The anchor — framework name, link, and recognition condition — costs one line and is non-negotiable; the tutorial is what gets cut.
+
+The default is also the cheaper one to correct. Adding a missing warrant or example when a consumer demonstrably misses it — a failed behavioral test, a real miss in use — is cheap and targeted. Trimming a bloated note later is expensive: it means re-deriving the boundary between scaffolding and load-bearing material, the judgment the behavioral test below exists to settle. And at write time the consumer population is unknown: over-retention bakes in an assumption about a weak reader who may never arrive, while minimal-plus-linked defers the decision to read time, when the actual consumer is present. Grow on demand, not on imagination.
 
 ## Examples
 
@@ -53,3 +61,4 @@ Relevant Notes:
 - [Knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — grounds: retrievable knowledge may still require a situation-specific cue before it affects action
 - [System-definition artifacts are crystallized reasoning under context scarcity](./system-definition-artifacts-are-crystallized-reasoning-under-context.md) — mechanism: generic guidance can be reconstructed at read time while the artifact carries the task-specific result of prior reasoning
 - [Conjecture is seeing the particular as an instance of the general](./conjecture-is-seeing-the-particular-as-an-instance-of-the-general.md) — mechanism: the discovery may be the instance relation rather than either already-known endpoint
+- [Short composable notes maximize combinatorial discovery](./short-composable-notes-maximize-combinatorial-discovery.md) — grounds: shared frameworks live as their own composable artifacts, so each note carries only its case's contribution

--- a/kb/notes/the-framework-is-often-larger-than-the-durable-contribution.md
+++ b/kb/notes/the-framework-is-often-larger-than-the-durable-contribution.md
@@ -57,7 +57,7 @@ The boundary varies with the model, task, and consumer population. The test esta
 
 Relevant Notes:
 
-- [Information value is observer-relative](./information-value-is-observer-relative.md) — grounds: consumer knowledge, capacity, tools, and goals determine which parts of a derivation add value when retained
+- [Information value is observer-relative](./information-value-is-observer-relative.md) — grounds: consumer knowledge, capacity, tools, and goals determine which parts of the active framework add value when retained
 - [Knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — grounds: retrievable knowledge may still require a situation-specific cue before it affects action
 - [System-definition artifacts are crystallized reasoning under context scarcity](./system-definition-artifacts-are-crystallized-reasoning-under-context.md) — mechanism: generic guidance can be reconstructed at read time while the artifact carries the task-specific result of prior reasoning
 - [Conjecture is seeing the particular as an instance of the general](./conjecture-is-seeing-the-particular-as-an-instance-of-the-general.md) — mechanism: the discovery may be the instance relation rather than either already-known endpoint

--- a/kb/notes/the-framework-is-often-larger-than-the-durable-contribution.md
+++ b/kb/notes/the-framework-is-often-larger-than-the-durable-contribution.md
@@ -1,25 +1,25 @@
 ---
-description: "Why an authoring agent may need a familiar framework to discover a connection when consumers need only the recognition rule; the default is minimal prose plus a framework link, grown on demand"
+description: "Agents reproduce active framework content, but the durable contribution is usually the recognition that the situation fits the framework; default to minimal prose plus a framework link"
 type: kb/types/note.md
 traits: [title-as-claim]
 tags: [context-engineering]
 ---
 
-# The derivation is often larger than the durable contribution
+# The framework is often larger than the durable contribution
 
-An authoring agent may use a large body of familiar knowledge to discover a small durable contribution. Because that knowledge was active during generation, the agent tends to reproduce it in the resulting artifact. But a future consumer with access to the same parametric knowledge can reconstruct the background; what changed was the recognition that a particular problem is an instance of it.
+An agent writing about a situation that fits a familiar framework has that framework active — loaded into context or activated in weights — and active knowledge tends to leak into the artifact. The strongest case is discovery: an authoring agent uses a large body of familiar knowledge to derive a small contribution and reproduces the derivation. But no derivation is required; an agent that merely names framework X tends to pad the artifact with X's details. Either way, a future consumer with access to the same parametric knowledge can reconstruct the framework; what changed was the recognition that this situation is an instance of it.
 
-Derivation size is therefore a poor guide to retained size. The reasoning path explains how the author reached the contribution, but only the parts future consumers cannot reliably reconstruct or activate must survive. Which parts those are remains [observer-relative](./information-value-is-observer-relative.md).
+The size of what was active during writing is therefore a poor guide to retained size. The framework content explains what the author drew on, but only the parts future consumers cannot reliably reconstruct or activate must survive. Which parts those are remains [observer-relative](./information-value-is-observer-relative.md).
 
 ## Recognition can be the durable contribution
 
-When discovery applies a familiar framework to an unfamiliar case, the durable contribution may be only:
+When an artifact applies a familiar framework to a particular case, the durable contribution may be only:
 
 > When **this observable condition** occurs, treat **this apparent task** as **this named kind of problem**, and use the corresponding framework to **perform this operation**.
 
 The framework name addresses knowledge the consumer can reconstruct; the condition, mapping, and operation preserve what it did not reliably supply. Repeating the framework adds value only when it supplies something the name cannot: accessibility, disambiguation, warrant, or fidelity.
 
-By that same measure, the derivation itself must remain wherever it carries one of those values — when it is evidence the consumer must be able to check, when the consumer cannot reconstruct it, or when a particular version or interpretation has authority. Stripping a derivation always trades away auditability: a claim without its reasoning must be taken on trust. Participating in discovery does not make every part of the reasoning path part of the discovery, but reconstructability alone does not make warrant or exactness expendable.
+By that same measure, framework content — or the derivation that produced the contribution — must remain wherever it carries one of those values — when it is evidence the consumer must be able to check, when the consumer cannot reconstruct it, or when a particular version or interpretation has authority. Stripping a derivation always trades away auditability: a claim without its reasoning must be taken on trust. Participating in discovery does not make every part of the reasoning path part of the discovery, but reconstructability alone does not make warrant or exactness expendable.
 
 ## Minimal by default, grown on demand
 
@@ -49,7 +49,7 @@ Suppose two systems use different terminology but both precompute a stable part 
 
 ## Test the retained boundary behaviorally
 
-For an agent consumer, semantic inspection cannot establish whether a framework name is an adequate address. Compare representative behavior with the name alone, the name plus a recognition condition, and the fuller derivation. If a smaller form preserves the contribution's effect, the removed material was derivation scaffolding; if behavior degrades, the missing explanation, example, or warrant belongs in the retained result.
+For an agent consumer, semantic inspection cannot establish whether a framework name is an adequate address. Compare representative behavior with the name alone, the name plus a recognition condition, and the fuller framework restatement or derivation. If a smaller form preserves the contribution's effect, the removed material was scaffolding; if behavior degrades, the missing explanation, example, or warrant belongs in the retained result.
 
 The boundary varies with the model, task, and consumer population. The test establishes a validity window, not a timeless compression.
 


### PR DESCRIPTION
Extend the compression argument beyond reconstructability: a note is
one case, so shared frameworks belong in their own linked artifacts
(graph-over-essay); guard the anchor (name + link + recognition
condition) as non-negotiable while the tutorial gets cut; frame the
retain-vs-grow asymmetry as grow-on-demand. Expand the warrant
carve-out with the auditability trade-off and link the
short-composable-notes neighbor.