### PR TITLE
Demote cp-skill-revise-iterative to an explicit-invocation instruction

### DIFF
--- a/.agents/skills/cp-skill-revise-iterative
+++ b/.agents/skills/cp-skill-revise-iterative
@@ -1,1 +1,0 @@
-../../kb/instructions/cp-skill-revise-iterative

--- a/.claude/skills/cp-skill-revise-iterative
+++ b/.claude/skills/cp-skill-revise-iterative
@@ -1,1 +1,0 @@
-../../kb/instructions/cp-skill-revise-iterative

--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ A further family of commands drives the review system — selecting targets, que
 | `cp-skill-ingest` | Ingest an external source: snapshot → connect → classify → analyse |
 | `cp-skill-snapshot-web` | Capture a URL into `kb/sources/` |
 | `cp-skill-health-check` | Diagnose a broken Commonplace install |
-| `cp-skill-revise-iterative` | Iteratively revise a note without changing its claims |
 | `cp-skill-revise-autoreason` | Revise a note with AutoReason-style incumbent/revision/synthesis judging |
 
-**Instructions** are procedures written in Markdown, like skills, but without the auto-loading: the user or another skill invokes them explicitly. They live under `kb/instructions/`.
+**Instructions** are procedures written in Markdown, like skills, but without the auto-loading: the user or another skill invokes them explicitly. They live under `kb/instructions/`. This includes `cp-skill-revise-iterative`, an iterative note-revision procedure demoted from the promoted-skills list — its cost-to-value ratio didn't hold up, so it's available on explicit invocation only.
 
 ## Usage
 

--- a/kb/instructions/cp-skill-revise-autoreason/SKILL.md
+++ b/kb/instructions/cp-skill-revise-autoreason/SKILL.md
@@ -13,7 +13,7 @@ model: opus
 
 **Target: $ARGUMENTS** (exactly one note path or filename - if empty, ask which note)
 
-**Experimental.** This is the conservative note-revision adaptation of AutoReason, based on `related-systems/autoreason/`. Use it when you want to test the tournament workflow; prefer `cp-skill-revise-iterative` for the established revision path.
+**Experimental.** This is the conservative note-revision adaptation of AutoReason, based on `related-systems/autoreason/`. Use it when you want to test the tournament workflow. `cp-skill-revise-iterative` is demoted to an explicit-invocation instruction — invoke it directly (`kb/instructions/cp-skill-revise-iterative/`) when you want the established prose-revision path instead.
 
 This skill defaults to prose-preserving revision, but it may produce a separate substantive-revision sidecar when the revisions reveal that claim, evidence, source, or argument changes are actually needed. Keep that sidecar out of the B/AB blind tournament and never auto-apply it.
 

--- a/kb/instructions/cp-skill-revise-iterative/SKILL.md
+++ b/kb/instructions/cp-skill-revise-iterative/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cp-skill-revise-iterative
-description: Iteratively revise a note for flow, readability, and cohesion using non-interactive Claude calls. Each pass produces a numbered copy; the outer agent reviews for semantic fidelity and significance before continuing. Triggers on "/cp-skill-revise-iterative [note]".
+description: "Demoted, not auto-loaded — invoke explicitly. Iteratively revises a note for flow, readability, and cohesion via non-interactive Claude calls; each pass is a numbered copy the outer agent reviews for fidelity before continuing. Triggers on \"/cp-skill-revise-iterative [note]\"."
 type: kb/types/instruction.md
 user-invocable: true
 allowed-tools: Read, Edit, Bash, Glob, Grep
@@ -10,6 +10,8 @@ model: opus
 ---
 
 ## EXECUTE NOW
+
+**Demoted.** No longer in `promoted_skills` (see `src/commonplace/scaffold_manifest.py`) — the per-pass cost wasn't earning back enough revision quality. `commonplace-init` no longer auto-installs this into `.claude/skills/` or `.agents/skills/` for new projects, and the harness doesn't auto-load it here. Invoke it explicitly when you want this revision path.
 
 **Target: $ARGUMENTS** (exactly one note path or filename — if empty, ask which note)
 

--- a/src/commonplace/scaffold_manifest.py
+++ b/src/commonplace/scaffold_manifest.py
@@ -87,7 +87,6 @@ MANIFEST = ScaffoldManifest(
         "cp-skill-health-check",
         "cp-skill-ingest",
         "cp-skill-snapshot-web",
-        "cp-skill-revise-iterative",
         "cp-skill-revise-autoreason",
     ),
 )


### PR DESCRIPTION
Its per-pass cost isn't earning back enough revision quality. Drop it
from scaffold_manifest.py's promoted_skills so commonplace-init stops
auto-installing it as an auto-loading skill, remove this repo's own
.claude/skills and .agents/skills symlinks, and update the README skill
table and cp-skill-revise-autoreason's cross-reference accordingly. The
instruction content stays under kb/instructions/ for explicit invocation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01579wc7dLx3H3xhJCftY9t9