### PR TITLE
Relax and shorten kb/articles/COLLECTION.md

### DIFF
--- a/kb/articles/COLLECTION.md
+++ b/kb/articles/COLLECTION.md
@@ -1,16 +1,16 @@
 # Writing conventions for kb/articles/ (editorial profile)
 
-Editorial [profile](../notes/definitions/text-contract.md): outward-facing articles distilled from the KB, published on the [documentation site](../reference/documentation-site.md) for readers outside the project. Worked case of the [external articles collection proposal](../reference/proposals/external-articles-collection.md); not yet promoted to the shared [profile catalogue](../reference/text-contract-profiles.md).
+Editorial [profile](../notes/definitions/text-contract.md): outward-facing articles distilled from the KB and published on the [documentation site](../reference/documentation-site.md). Worked case of the [external articles collection proposal](../reference/proposals/external-articles-collection.md); not yet promoted to the shared [profile catalogue](../reference/text-contract-profiles.md).
 
-**Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave the reader knowing where in the KB to go next — self-containment is the floor, the onward path is the obligation.
+**Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave its reader knowing where in the KB to go next — self-containment is the floor, the onward path the obligation.
 
-**Spreadability is an editorial obligation.** In the sense of Jenkins, Ford, and Green, give readers material worth carrying into their own communities and make its circulation easy. Which techniques serve that is the author's call.
+**Spreadability.** In the sense of Jenkins, Ford, and Green: give readers material worth carrying into their own communities and make its circulation easy. Which techniques serve that is the author's call.
 
-**Reader-only body.** Agent-facing structure lives in frontmatter; the body is prose for the reader — no footer link tables, link labels, or graph-traversal glosses. In-prose relative links into `kb/` are deliberate invitations to go deeper, and a closing "where to go next" section is welcome.
+**Reader-only body.** Agent-facing structure lives in frontmatter; the body is prose for the reader — no footer link tables, link labels, or graph-traversal glosses. In-prose relative links into `kb/` are deliberate invitations to go deeper; a closing "where to go next" section is welcome.
 
-**Titles and descriptions.** Titles are headlines addressed to the reader, not claim-titles. The frontmatter `description` stays what it is everywhere in this KB: a retrieval filter for agents; the human-facing abstract is the article's opening paragraph.
+**Titles and descriptions.** Titles are headlines addressed to the reader, not claim-titles. The frontmatter `description` remains what it is everywhere in this KB — a retrieval filter for agents; the reader-facing abstract is the article's opening paragraph.
 
-**Attribution and lifecycle.** Every article carries a `byline` and a `status` (`draft`, `published`, `superseded`, `withdrawn`). A published article is a dated record: the body freezes, and corrections happen by dated annotation, a successor article, or withdrawal — never a silent rewrite. Field-level rules live in the [type spec](./types/article.md).
+**Attribution and lifecycle.** Every article carries a `byline` and a `status` (`draft`, `published`, `superseded`, `withdrawn`). Publication freezes the body: corrections happen by dated annotation, a successor article, or withdrawal — never a silent rewrite. Field-level rules live in the [type spec](./types/article.md).
 
 **Lineage.** `source_notes` lists the repo-root paths of the notes the article distils; validation checks that each resolves. There is no freshness registration — find affected articles by search.
 

--- a/kb/articles/COLLECTION.md
+++ b/kb/articles/COLLECTION.md
@@ -2,7 +2,9 @@
 
 Editorial [profile](../notes/definitions/text-contract.md): outward-facing articles distilled from the KB, published on the [documentation site](../reference/documentation-site.md) for readers outside the project. Worked case of the [external articles collection proposal](../reference/proposals/external-articles-collection.md); not yet promoted to the shared [profile catalogue](../reference/text-contract-profiles.md).
 
-**Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave the reader knowing where in the KB to go next — self-containment is the floor, the onward path is the obligation. Give readers material worth carrying into their own communities; which techniques serve that is the author's call.
+**Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave the reader knowing where in the KB to go next — self-containment is the floor, the onward path is the obligation.
+
+**Spreadability is an editorial obligation.** In the sense of Jenkins, Ford, and Green, give readers material worth carrying into their own communities and make its circulation easy. Which techniques serve that is the author's call.
 
 **Reader-only body.** Agent-facing structure lives in frontmatter; the body is prose for the reader — no footer link tables, link labels, or graph-traversal glosses. In-prose relative links into `kb/` are deliberate invitations to go deeper, and a closing "where to go next" section is welcome.
 

--- a/kb/articles/COLLECTION.md
+++ b/kb/articles/COLLECTION.md
@@ -1,44 +1,16 @@
 # Writing conventions for kb/articles/ (editorial profile)
 
-## Text contract and the onward path
+Editorial [profile](../notes/definitions/text-contract.md): outward-facing articles distilled from the KB, published on the [documentation site](../reference/documentation-site.md) for readers outside the project. Worked case of the [external articles collection proposal](../reference/proposals/external-articles-collection.md); not yet promoted to the shared [profile catalogue](../reference/text-contract-profiles.md).
 
-Editorial (expository) [profile](../notes/definitions/text-contract.md): outward-facing articles distilled from the KB, published on the [documentation site](../reference/documentation-site.md) for readers outside the project. This profile is being exercised as the worked case of the [external articles collection proposal](../reference/proposals/external-articles-collection.md); it is not yet promoted to the shared [profile catalogue](../reference/text-contract-profiles.md).
+**Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave the reader knowing where in the KB to go next — self-containment is the floor, the onward path is the obligation. Give readers material worth carrying into their own communities; which techniques serve that is the author's call.
 
-**Audience: highly technical** — researchers and builders of agent and knowledge systems. Self-contained means "no KB context assumed", never "simplified"; articles carry full technical weight.
+**Reader-only body.** Agent-facing structure lives in frontmatter; the body is prose for the reader — no footer link tables, link labels, or graph-traversal glosses. In-prose relative links into `kb/` are deliberate invitations to go deeper, and a closing "where to go next" section is welcome.
 
-**Quality goal: clarity plus a clear onward path.** An article must stand on its own for a reader with no KB context, and leave that reader knowing where in the KB to go next. Self-containment is the floor, not the ceiling: an article that reads well but strands its reader has failed the contract. The onward path is an editorial obligation, not a claim about conversion or analytics.
+**Titles and descriptions.** Titles are headlines addressed to the reader, not claim-titles. The frontmatter `description` stays what it is everywhere in this KB: a retrieval filter for agents; the human-facing abstract is the article's opening paragraph.
 
-**Spreadability is an editorial obligation.** In the sense of Jenkins, Ford, and Green, give readers material worth carrying into their own communities and make its circulation easy. The editing agent chooses the techniques that fit the piece; the contract does not prescribe a checklist or promise that an article will spread.
+**Attribution and lifecycle.** Every article carries a `byline` and a `status` (`draft`, `published`, `superseded`, `withdrawn`). A published article is a dated record: the body freezes, and corrections happen by dated annotation, a successor article, or withdrawal — never a silent rewrite. Field-level rules live in the [type spec](./types/article.md).
 
-**Orientation: every article is an entry point into the KB.** Its job is to lead the reader in, not to replace what the KB establishes.
-
-## Reader-only body
-
-All agent-facing structure lives in frontmatter; the body is reader-only prose.
-
-- No footer link tables, no `Relevant Notes` sections, no link labels.
-- No first-use glosses aimed at graph traversal; define terms inline where a technical reader needs them.
-- In-prose links into `kb/` are deliberate invitations to go deeper — the onward path — not leakage. Use relative paths; the site renders them as working links. A closing "where to go next" section in prose is encouraged.
-- Lineage lives in `source_notes` frontmatter (not rendered), never in the body.
-
-## Title and description conventions
-
-Titles are headlines or topical, addressed to the reader — not claim-titles. The frontmatter `description` stays what it is everywhere in this KB: a retrieval filter for agents. The human-facing abstract is the article's opening paragraph; the two are different texts.
-
-## Attribution and lifecycle
-
-An article carries a `byline` and is a first-person-committed public statement. `status` is one of:
-
-- `draft` — in progress. The page renders with its status visible in the metadata badge; while the collection's published face is small, drafts may sit in the collection root.
-- `published` — dated (`published: YYYY-MM-DD`); the body is frozen. Corrections become a dated annotation under a `## Corrections` heading, a superseding article, or a withdrawal — never a silent rewrite.
-- `superseded` — set `superseded_by` to the successor's repo-root path; the body stays frozen.
-- `withdrawn` — the body stays frozen; state why in a dated annotation.
-
-Maintenance semantics: a published article is a dated record. When its source notes evolve, the question is "would we still say this?" and the remedy is a follow-up article, not an in-place edit.
-
-## Lineage
-
-`source_notes` lists the repo-root paths of the notes and reference documents the article distils. Validation checks that each path resolves. Discovery of affected articles after a note changes is by search (`rg "source_notes" kb/articles/`); there is no freshness registration.
+**Lineage.** `source_notes` lists the repo-root paths of the notes the article distils; validation checks that each resolves. There is no freshness registration — find affected articles by search.
 
 ## Types
 


### PR DESCRIPTION
Compress the editorial contract to its load-bearing points and defer
lifecycle field mechanics to the article type spec. Drop prescriptive
detail (spreadability framing, per-status bullet list, draft-placement
rule) in favor of shorter, more flexible guidance.