### PR TITLE
Add Made to Stick stickiness convention; strip article type to near-e…

### DIFF
--- a/kb/articles/COLLECTION.md
+++ b/kb/articles/COLLECTION.md
@@ -4,15 +4,17 @@ Editorial [profile](../notes/definitions/text-contract.md): outward-facing artic
 
 **Audience and quality goal.** Highly technical readers with no KB context. An article must stand on its own and leave its reader knowing where in the KB to go next — self-containment is the floor, the onward path the obligation.
 
-**Spreadability.** In the sense of Jenkins, Ford, and Green: give readers material worth carrying into their own communities and make its circulation easy. Which techniques serve that is the author's call.
+**Spreadability.** In the sense of Jenkins, Ford, and Green: give readers material worth carrying into their own communities and make its circulation easy.
+
+**Stickiness.** In the sense of Heath and Heath's *Made to Stick*: shape the core idea so it survives retelling — simple, unexpected, concrete, credible, emotional, carried by stories (SUCCESs). Spreadability governs whether the piece circulates; stickiness governs whether the idea arrives intact. Which techniques serve either is the author's call.
 
 **Reader-only body.** Agent-facing structure lives in frontmatter; the body is prose for the reader — no footer link tables, link labels, or graph-traversal glosses. In-prose relative links into `kb/` are deliberate invitations to go deeper; a closing "where to go next" section is welcome.
 
 **Titles and descriptions.** Titles are headlines addressed to the reader, not claim-titles. The frontmatter `description` remains what it is everywhere in this KB — a retrieval filter for agents; the reader-facing abstract is the article's opening paragraph.
 
-**Attribution and lifecycle.** Every article carries a `byline` and a `status` (`draft`, `published`, `superseded`, `withdrawn`). Publication freezes the body: corrections happen by dated annotation, a successor article, or withdrawal — never a silent rewrite. Field-level rules live in the [type spec](./types/article.md).
+**Attribution and lifecycle.** Every article carries a `byline` and a `status` (`draft`, `published`, `superseded`, `withdrawn`). Publication freezes the body: corrections happen by dated annotation, a successor article, or withdrawal — never a silent rewrite. These are editorial conventions, not schema: the [type spec](./types/article.md) starts nearly empty and gains constraints only as failure modes are collected.
 
-**Lineage.** `source_notes` lists the repo-root paths of the notes the article distils; validation checks that each resolves. There is no freshness registration — find affected articles by search.
+**Lineage.** `source_notes` lists the repo-root paths of the notes the article distils; when present, validation checks that each resolves. There is no freshness registration — find affected articles by search.
 
 ## Types
 

--- a/kb/articles/types/article.md
+++ b/kb/articles/types/article.md
@@ -1,13 +1,13 @@
 ---
 type: kb/types/type-spec.md
 name: article
-description: Outward-facing dated article distilled from KB notes for external technical readers, with byline, lifecycle status, and validated source-note lineage
+description: Outward-facing article distilled from KB notes for external technical readers; deliberately minimal spec that gains constraints only as failure modes are collected
 schema: kb/articles/types/article.schema.yaml
 ---
 
 # Article
 
-Use `article` for outward-facing pieces published from the KB: self-contained prose for a technical reader with no KB context, distilled from notes the frontmatter records. The collection contract in [COLLECTION.md](../COLLECTION.md) owns the editorial conventions; this spec owns the structural obligations.
+Use `article` for outward-facing pieces published from the KB: self-contained prose for a technical reader with no KB context. The collection contract in [COLLECTION.md](../COLLECTION.md) owns the editorial conventions; this spec is deliberately nearly empty and gains a constraint only when a collected failure mode motivates it.
 
 ## Frontmatter
 
@@ -15,19 +15,6 @@ Use `article` for outward-facing pieces published from the KB: self-contained pr
 |---|---:|---|
 | `type` | Yes | `kb/articles/types/article.md` |
 | `description` | Yes | Retrieval filter for agents; not the reader-facing abstract. |
-| `status` | Yes | `draft`, `published`, `superseded`, or `withdrawn`. |
-| `byline` | Yes | Public attribution; the article is a first-person-committed public statement. |
-| `source_notes` | Yes | Repo-root paths of the notes the article distils; every path must resolve. |
-| `published` | When status is not `draft` | Publication date, quoted so YAML keeps it a string (`"YYYY-MM-DD"`); setting it freezes the body. |
-| `superseded_by` | When status is `superseded` | Repo-root path of the superseding article. |
+| `source_notes` | No | Repo-root paths of the notes the article distils; when present, every path must resolve. |
 
-## Lifecycle rules
-
-- `draft` is the only status under which the body may be freely rewritten.
-- Moving to `published` requires the publication date and freezes the body. Corrections after that are a dated annotation under `## Corrections`, a superseding article, or a withdrawal — never a silent rewrite.
-- `superseded` requires `superseded_by`; the frozen body stays as the historical record.
-- `withdrawn` keeps the frozen body and states the reason in a dated annotation.
-
-## Body rules
-
-The body is reader-only prose (see [COLLECTION.md](../COLLECTION.md)): no footer link tables, no link labels, no agent-facing glosses. In-prose relative links into `kb/` are the onward path and render as site links.
+Everything else (`byline`, `status`, `published`, …) is editorial convention governed by [COLLECTION.md](../COLLECTION.md), unconstrained here for now.

--- a/kb/articles/types/article.schema.yaml
+++ b/kb/articles/types/article.schema.yaml
@@ -5,47 +5,12 @@ allOf:
     properties:
       frontmatter:
         type: object
-        required:
-          - description
-          - type
-          - status
-          - byline
-          - source_notes
         properties:
           type:
             const: kb/articles/types/article.md
-          status:
-            enum: [draft, published, superseded, withdrawn]
-          byline:
-            type: string
-            minLength: 1
           source_notes:
             type: array
-            minItems: 1
             items:
               type: string
               pattern: '^kb/.+\.md$'
-          published:
-            type: string
-            format: date
-          superseded_by:
-            type: string
-            pattern: '^kb/articles/.+\.md$'
         additionalProperties: true
-        allOf:
-          - if:
-              properties:
-                status:
-                  enum: [published, superseded, withdrawn]
-              required: [status]
-            then:
-              required: [published]
-              description: a non-draft article must carry its publication date
-          - if:
-              properties:
-                status:
-                  const: superseded
-              required: [status]
-            then:
-              required: [superseded_by]
-              description: a superseded article must name its successor

--- a/tests/commonplace/lib/test_validation_article.py
+++ b/tests/commonplace/lib/test_validation_article.py
@@ -45,25 +45,17 @@ type: kb/types/note.md
     return tmp_path / "kb" / "articles"
 
 
-def article(
-    path: Path,
-    *,
-    status: str = "draft",
-    source_notes: list[str] | None = None,
-    extra: str = "",
-) -> Path:
-    notes = source_notes if source_notes is not None else ["kb/notes/existing-note.md"]
-    rendered_notes = "\n".join(f"  - {note}" for note in notes)
+def article(path: Path, *, source_notes: list[str] | None = None) -> Path:
+    lineage = ""
+    if source_notes is not None:
+        rendered = "\n".join(f"  - {note}" for note in source_notes)
+        lineage = f"source_notes:\n{rendered}\n"
     return write(
         path,
         f"""---
 description: "an outward-facing article used by the validation tests of the article type"
 type: kb/articles/types/article.md
-status: {status}
-byline: Test Author
-source_notes:
-{rendered_notes}
-{extra}---
+{lineage}---
 
 # A test article
 
@@ -72,9 +64,22 @@ Reader-facing prose.
     )
 
 
-def test_draft_with_resolving_source_notes_passes(tmp_path: Path) -> None:
+def test_minimal_article_passes(tmp_path: Path) -> None:
+    # The article type is deliberately nearly empty: description and type
+    # alone make a valid article; constraints accrue with collected failure
+    # modes.
     articles = setup_repo(tmp_path)
     path = article(articles / "test-article.md")
+    results = validate_note(path, repo_root=tmp_path)
+    assert not results.fails
+
+
+def test_resolving_source_notes_pass(tmp_path: Path) -> None:
+    articles = setup_repo(tmp_path)
+    path = article(
+        articles / "test-article.md",
+        source_notes=["kb/notes/existing-note.md"],
+    )
     results = validate_note(path, repo_root=tmp_path)
     assert not results.fails
     assert any("source_notes: all 1 paths resolve" in p for p in results.passes)
@@ -90,53 +95,3 @@ def test_unresolved_source_note_fails(tmp_path: Path) -> None:
     assert any(
         "source_notes" in f and "kb/notes/missing-note.md" in f for f in results.fails
     )
-
-
-def test_published_without_date_fails_schema(tmp_path: Path) -> None:
-    articles = setup_repo(tmp_path)
-    path = article(articles / "test-article.md", status="published")
-    results = validate_note(path, repo_root=tmp_path)
-    assert any("publication date" in f for f in results.fails)
-
-
-def test_published_with_date_passes(tmp_path: Path) -> None:
-    articles = setup_repo(tmp_path)
-    path = article(
-        articles / "test-article.md",
-        status="published",
-        extra='published: "2026-07-23"\n',
-    )
-    results = validate_note(path, repo_root=tmp_path)
-    assert not results.fails
-
-
-def test_superseded_requires_successor(tmp_path: Path) -> None:
-    articles = setup_repo(tmp_path)
-    path = article(
-        articles / "test-article.md",
-        status="superseded",
-        extra='published: "2026-07-23"\n',
-    )
-    results = validate_note(path, repo_root=tmp_path)
-    assert any("must name its successor" in f for f in results.fails)
-
-
-def test_missing_byline_fails_schema(tmp_path: Path) -> None:
-    articles = setup_repo(tmp_path)
-    path = write(
-        articles / "test-article.md",
-        """---
-description: "an outward-facing article used by the validation tests of the article type"
-type: kb/articles/types/article.md
-status: draft
-source_notes:
-  - kb/notes/existing-note.md
----
-
-# A test article
-
-Reader-facing prose.
-""",
-    )
-    results = validate_note(path, repo_root=tmp_path)
-    assert any("byline" in f for f in results.fails)


### PR DESCRIPTION
…mpty

The articles collection now names two virality methodologies: spreadability (Jenkins/Ford/Green, circulation) and stickiness (Heath & Heath's Made to Stick SUCCESs checklist, the idea surviving retelling).

The article type spec and schema are reduced to a near-empty baseline — base note fields plus an optional source_notes lineage check — so constraints are added only when a collected failure mode motivates them. Byline, status, and lifecycle rules remain editorial conventions in COLLECTION.md, no longer schema-enforced.


Claude-Session: https://claude.ai/code/session_01VzmNgtmRNHouYhePMAjm95