### PR TITLE
Make live package source the default implementation authority

### DIFF
--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -113,9 +113,9 @@ rg "^tags:.*my-tag" kb/notes/ kb/reference/ kb/instructions/ kb/commonplace/note
 
 The `cp-skill-*` family (`cp-skill-write`, `cp-skill-validate`, `cp-skill-connect`, etc.) is available in this agent runtime. If a Commonplace skill is unexpectedly unavailable, use `cp-skill-health-check` to diagnose the installation.
 
-### Commands
+### Commands and implementation source
 
-The `llm-commonplace` package provides `commonplace-*` CLI commands for validation, snapshots, note operations, and the review system. For the full reference, read [kb/commonplace/reference/commands.md](./kb/commonplace/reference/commands.md).
+The `llm-commonplace` package provides `commonplace-*` CLI commands for validation, snapshots, note operations, and the review system. For exact command usage, prefer the live command's `--help`. For exact implementation behavior, inspect the source of the installed package rather than relying on a prose restatement; `commonplace-source` prints the package directory for the same installation that supplies the commands. Use `kb/commonplace/reference/` for architecture boundaries, invariants, rationale, and orientation that the implementation does not itself recover.
 
 Call `commonplace-*` commands by bare name. They come from the user-level `llm-commonplace` uv tool installation; do not prepend project-venv paths or wrap them in `uv run`. If a command is missing, use `cp-skill-health-check` to distinguish a missing tool installation, a missing tool-directory `PATH` entry, or a shadowing executable.
 

--- a/kb/reference/COLLECTION.md
+++ b/kb/reference/COLLECTION.md
@@ -8,6 +8,8 @@ A reference artifact may contain supporting belief propositions without becoming
 
 Quality goal is **fidelity + economy** — say what the system actually does in minimum tokens, without omitting load-bearing details. An agent loading these docs is usually trying to act; every extra token competes with the task.
 
+**For exact implementation facts, live implementation is the default read path.** In the Commonplace source checkout, inspect `src/commonplace/`. In an installed project, `commonplace-source` prints the source directory of the same installed package that supplies the `commonplace-*` commands; use a command's `--help` for its live CLI contract. Reference prose earns a separate place when it supplies orientation, architecture boundaries, cross-component invariants, rationale, or other information the implementation does not cheaply recover. Do not create a prose copy merely to make installed code inspectable.
+
 Tests for economy. The first two ask whether a passage should exist at all,
 given that the system it describes is available for inspection:
 

--- a/kb/reference/commands.md
+++ b/kb/reference/commands.md
@@ -21,6 +21,16 @@ commonplace-init --root /path/to/project
 
 `--name` sets the project name for templates (defaults to directory name). Safe to rerun — never overwrites existing files, and reports whether preserved files already match the scaffold or differ from what the current run would generate.
 
+### commonplace-source
+
+Print the filesystem path of the `commonplace` package that supplies the running command. Use it when an exact implementation question requires reading the live installed source rather than a prose description.
+
+```bash
+commonplace-source
+```
+
+For command-line usage and options, prefer the target command's `--help`; use the source path for exact implementation behavior. Reference documentation remains the place for architecture boundaries, invariants, rationale, and other information the implementation does not cheaply recover.
+
 ## Validation and indexing
 
 ### commonplace-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ commonplace-relocate-note = "commonplace.cli.relocate_note:main"
 commonplace-review-job-list = "commonplace.cli.review.review_job_list:main"
 commonplace-resolve-criteria = "commonplace.cli.review.resolve_criteria:main"
 commonplace-review-target-selector = "commonplace.cli.review.review_target_selector:main"
+commonplace-source = "commonplace.cli.source:main"
 commonplace-validate = "commonplace.cli.validate_notes:main"
 commonplace-verify-quotes = "commonplace.cli.verify_quotes:main"
 commonplace-warn-selector = "commonplace.cli.review.warn_selector:main"
@@ -81,8 +82,6 @@ include = [
     "/kb/reference",
     "/kb/reports/types",
     "/kb/sources/types",
-    "/kb/sources/.gitignore",
-    "/kb/types",
     "/src",
     "/tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ include = [
     "/kb/reference",
     "/kb/reports/types",
     "/kb/sources/types",
+    "/kb/sources/.gitignore",
+    "/kb/types",
     "/src",
     "/tests",
 ]

--- a/src/commonplace/cli/source.py
+++ b/src/commonplace/cli/source.py
@@ -1,0 +1,24 @@
+"""Print the source directory of the installed Commonplace package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import commonplace
+
+
+def source_path() -> Path:
+    """Return the directory containing the executing Commonplace package."""
+    package_file = commonplace.__file__
+    if package_file is None:
+        raise RuntimeError("cannot locate the installed commonplace package source")
+    return Path(package_file).resolve().parent
+
+
+def main() -> int:
+    print(source_path())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/commonplace/cli/test_source.py
+++ b/tests/commonplace/cli/test_source.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import commonplace
+
+from commonplace.cli.source import main, source_path
+
+
+def test_source_path_points_at_executing_package() -> None:
+    assert source_path() == Path(commonplace.__file__).resolve().parent
+
+
+def test_main_prints_source_path(capsys) -> None:
+    assert main() == 0
+    assert capsys.readouterr().out.strip() == str(source_path())


### PR DESCRIPTION
## Summary

Make exact implementation questions default to the live source of the installed Commonplace package rather than to hand-maintained prose copies.

- add `commonplace-source`, which prints the source directory of the package supplying the running commands
- route installed-project agents to `--help` for exact CLI contracts and installed source for exact implementation behavior
- sharpen `kb/reference/` economy rules: prose should earn its place through orientation, architecture boundaries, invariants, rationale, or other content source does not cheaply recover
- add focused tests for the source locator

## Why

The documentation-disposition workshop found that source is often both more finely addressable and more authoritative than prose describing it. The remaining obstacle for downstream projects was simply locating the exact installed implementation. This PR makes that access explicit instead of introducing another generated/introspection documentation layer.

## Validation

I could not execute the tests from this environment because outbound Git clone/DNS is unavailable. The PR adds focused pytest coverage for `commonplace-source`; CI should run the repository suite.