### PR TITLE
Add theory notes on methodology activation and borrowing

### DIFF
--- a/kb/notes/a-capable-agent-needs-methodology-selection-not-just-relevant-knowledge.md
+++ b/kb/notes/a-capable-agent-needs-methodology-selection-not-just-relevant-knowledge.md
@@ -1,0 +1,29 @@
+---
+description: A capable agent may know many individually relevant but mutually incompatible approaches, so task control requires selecting a governing methodology rather than merely supplying relevant knowledge
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, context-engineering, methodology]
+---
+
+# A capable agent needs methodology selection, not just relevant knowledge
+
+A capable pretrained agent does not merely contain more facts. It contains a larger repertoire of ways to approach the same task: exploratory or specification-first development, centralized planning or delegated initiative, formal proof or empirical testing, adversarial criticism or charitable interpretation. Several of these approaches may be relevant at once while recommending incompatible actions.
+
+This creates a control problem distinct from knowledge retrieval. Supplying relevant facts answers **what information should be available?** Selecting a methodology answers **which coherent way of interpreting and acting on that information should govern this task?** More capability does not remove this problem. By increasing the number of plausible approaches the model can competently execute, it can make methodology selection more consequential.
+
+A methodology cue can therefore change behavior even when it supplies almost no new domain facts. "Use Auftragstaktik" can select intent-based command, delegated choice of means, local initiative, and adaptation under constraints. The useful effect is not that the cue teaches the model those ideas from scratch, but that it makes one already learned cluster govern the task instead of neighboring alternatives.
+
+This extends [knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md). That note distinguishes knowledge that exists from knowledge that becomes action-relevant. Methodology selection is a stronger case: the problem is not only whether a relevant proposition activates, but which mutually constraining set of propositions and decision rules becomes the frame for action.
+
+The distinction matters especially for open-ended agent work. A prompt that only states the objective leaves the model to improvise a method from its repertoire. A prompt that also selects a methodology constrains many downstream decisions at once without prescribing each step. This is why greater agent competence can support less procedural instruction without implying less control: control can move from step specification toward methodology selection, mission specification, and explicit constraints.
+
+The claim is not that every task needs a named methodology. Some tasks have one overwhelmingly conventional solution, and some methodologies are too weakly represented or too ambiguous for a short cue to select them reliably. The claim is that where several coherent approaches could plausibly govern the work, methodology selection is a distinct control variable and should not be collapsed into generic relevance or capability.
+
+---
+
+Relevant Notes:
+
+- [Knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — grounds: separates stored knowledge, contextual exposure, and behavioral activation; methodology selection concerns which coherent behavioral regime becomes active
+- [Agentic systems interpret underspecified instructions](./agentic-systems-interpret-underspecified-instructions.md) — mechanism: when the governing method is not settled, capable agents must supply it through interpretation
+- [A methodology governs its own extension only as far as it settles the meta-decisions it raises](./a-methodology-governs-its-own-extension-only-as-far-as-it-settles.md) — complements: once selected, a methodology governs only the decisions its content actually settles
+- [Context efficiency is the central design concern in agent systems](./context-efficiency-is-the-central-design-concern-in-agent-systems.md) — motivates: selecting a methodology can constrain many decisions without spending context on a complete procedure

--- a/kb/notes/borrowing-can-operate-through-retained-artifacts-or-weight-activation.md
+++ b/kb/notes/borrowing-can-operate-through-retained-artifacts-or-weight-activation.md
@@ -1,0 +1,63 @@
+---
+description: Established external methodologies can become operative either by being explicitly retained in the system or by activating a model's pretrained representation; the two routes trade context economy against inspectability and revisability
+type: kb/types/note.md
+traits: [title-as-claim, has-comparison]
+tags: [foundations, methodology, context-engineering]
+---
+
+# Borrowing can operate through retained artifacts or weight activation
+
+Commonplace has treated borrowing from programming, philosophy, law, cognitive science, and other fields mainly as **artifact borrowing**: interpret an external idea, justify its transfer, adapt it to the target system, and retain the resulting claim or methodology in the KB. Pretrained agents add a second route. If an external methodology is already coherently represented in model weights, a prompt can activate it directly without first restating it in Commonplace.
+
+The two routes are:
+
+```text
+retained borrowing
+external source → adaptation → retained artifact → context → behavior
+
+weight-mediated borrowing
+external tradition → pretraining → model weights → compact cue → behavior
+```
+
+The distinction changes what it means to borrow from a mature discipline. A field can contribute not only explicit concepts that Commonplace adopts into its writable theory, but also compact names and frames that select substantial pretrained methodological structure at execution time. Established traditions therefore form part of the usable intellectual substrate of an LLM agent even when their contents are not copied into the KB.
+
+The routes have different properties:
+
+| Property | Retained artifact | Weight activation |
+|---|---|---|
+| Context cost | requires loading some explicit content | can be very low when a compact cue suffices |
+| Inspectability | high | low |
+| Selective revisability | high | low |
+| Versionability | high | model-dependent |
+| Project-specific adaptation | direct | indirect unless supplemented in context |
+| Fidelity to a canonical interpretation | can be specified | depends on the model's learned reconstruction |
+
+This means the [source-adoption policy](../reference/source-adoption-policy.md) and weight-mediated activation answer different questions. The adoption policy asks whether an idea deserves to become part of Commonplace's retained theory or methodology. Weight activation asks whether an already learned external methodology can be used as part of the current computation. A concept can be useful through the second route without passing the bar for explicit adoption, because using model competence does not make that competence a retained Commonplace commitment.
+
+The routes can also compose. When the model already contains most of a useful methodology but Commonplace needs a project-specific variation, the context can supply only the explicit delta:
+
+```text
+weight-resident baseline methodology
+        +
+retained project-specific modification
+        +
+current mission and constraints
+        ↓
+operative methodology for this task
+```
+
+For example, a task could invoke *Auftragstaktik* while adding explicit Commonplace-specific constraints on irreversible changes, evidence, or review. The weight-resident doctrine provides context-efficient background structure; retained artifacts specify the parts that must be precise, writable, auditable, or different from the conventional doctrine.
+
+This hybrid explains why the existence of broad model knowledge does not remove the need for an external KB. The model weights provide a large but opaque and effectively read-only methodological library. The KB provides the writable complement: claims and methods whose exact content the system wants to inspect, revise, version, and selectively activate. The design question is therefore not simply whether knowledge exists in weights or in artifacts, but which parts deserve explicit retention and which can safely remain a parametric dependency.
+
+The distinction also creates a new transfer risk. Artifact borrowing can be reviewed against a source and the target-side mechanism. Weight-mediated borrowing additionally depends on whether a particular model actually reconstructs the intended methodology from the cue. A familiar label may activate a distorted, underspecified, or internally mixed representation. Economical activation therefore trades context cost against methodological fidelity.
+
+---
+
+Relevant Notes:
+
+- [Source-adoption policy](../reference/source-adoption-policy.md) — contrasts: governs which borrowed ideas become retained Commonplace commitments; weight activation can use external intellectual machinery without adopting it into retained theory
+- [A borrowed pattern transfers only as far as source and target share a mechanism](./borrowed-patterns-transfer-only-over-shared-mechanism.md) — constrains: explicit adoption still requires a target-side transfer argument; pretrained familiarity does not establish valid transfer
+- [Weight-resident methodologies provide context-efficient behavioral compression](./weight-resident-methodologies-provide-context-efficient-behavioral-compression.md) — mechanism: explains why the weight-mediated route can be much cheaper in context
+- [Only explicit retention is currently durable, writable, and addressable at once](./only-explicit-retention-is-durable-writable-and-addressable.md) — distinguishes: model competence can govern behavior without becoming retained, writable project theory
+- [Knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — mechanism: both retained and parametric knowledge still require activation before they affect behavior

--- a/kb/notes/weight-resident-methodologies-provide-context-efficient-behavioral-compression.md
+++ b/kb/notes/weight-resident-methodologies-provide-context-efficient-behavioral-compression.md
@@ -1,0 +1,44 @@
+---
+description: A compact cue can activate a much larger methodology already represented in model weights, trading very low context cost for model-dependent reconstruction rather than exact retained specification
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, context-engineering, methodology]
+---
+
+# Weight-resident methodologies provide context-efficient behavioral compression
+
+When a coherent methodology is already represented in a model's weights, a small prompt cue can activate a much larger pattern of behavior. The prompt need not restate every principle and decision rule. It can transmit a compact selector such as a methodology name, while the model reconstructs the associated structure from its pretrained knowledge.
+
+The mechanism is a form of **behavioral compression**:
+
+```text
+small contextual cue
+        ↓
+weight-resident methodology
+        ↓
+many coordinated behavioral consequences
+```
+
+For example, invoking *Auftragstaktik* can bring with it commander intent, delegated choice of means, local initiative, and adaptation to changing circumstances without those elements being enumerated in the prompt. The supplied context carries little of the methodology's literal content; most of the usable structure comes from the model weights.
+
+This makes weight-resident methodologies unusually economical under [context scarcity](./context-efficiency-is-the-central-design-concern-in-agent-systems.md). Instructions, task evidence, intermediate work, and retrieved project knowledge all compete for the same context window. A compact methodological cue can preserve that scarce space while still constraining many downstream choices.
+
+The compression is not equivalent to an import from an explicit library. A methodology name is not a stable pointer to a canonical object. What becomes active is the model's learned reconstruction, which may vary by model, context, or interpretation. Weight-mediated activation is therefore context-cheap but comparatively opaque and inexact. It should not be counted as retained methodology inside Commonplace merely because it reliably affects behavior: [only explicit retention is currently durable, writable, and addressable at once](./only-explicit-retention-is-durable-writable-and-addressable.md).
+
+This gives two different ways to make methodology operative:
+
+- **Parametric activation:** use a compact cue to activate a methodology already represented in weights. Context cost can be very low, but the reconstructed content is not directly inspectable, versioned, or selectively editable.
+- **Explicit loading:** place a retained methodology, or an applicable part of it, into context. This consumes more context but gives the system an inspectable and revisable specification.
+
+The two paths should not be treated as substitutes in every case. Weight-mediated activation is attractive when the model's reconstruction is sufficiently coherent and conventional. Explicit loading matters when exact project-specific distinctions, reproducibility, revision, or auditability dominate context economy.
+
+A practical consequence follows but is not yet an instruction: methodology loading can be optimized over a spectrum from a name, through a short disambiguating gloss, to an applicable retained fragment or full artifact. The theoretical criterion is whether the representation preserves the behavioral distinctions that matter for the current task, not whether it reproduces the full exposition.
+
+---
+
+Relevant Notes:
+
+- [A capable agent needs methodology selection, not just relevant knowledge](./a-capable-agent-needs-methodology-selection-not-just-relevant-knowledge.md) — grounds: explains why selecting a coherent methodology is a distinct control problem
+- [Context efficiency is the central design concern in agent systems](./context-efficiency-is-the-central-design-concern-in-agent-systems.md) — motivates: context savings are valuable because methodology text competes with task evidence and reasoning for the same bounded resource
+- [Knowledge storage does not imply contextual activation](./knowledge-storage-does-not-imply-contextual-activation.md) — mechanism: weight-resident knowledge matters only when a cue makes it action-relevant
+- [Only explicit retention is currently durable, writable, and addressable at once](./only-explicit-retention-is-durable-writable-and-addressable.md) — constrains: behavioral activation from weights is not equivalent to explicit retained methodology


### PR DESCRIPTION
## Summary

Adds three theory notes derived from the discussion about using named methodologies such as *Auftragstaktik* to control capable agents:

1. **A capable agent needs methodology selection, not just relevant knowledge** — separates selecting a governing approach from ordinary knowledge retrieval/activation.
2. **Weight-resident methodologies provide context-efficient behavioral compression** — explains how compact cues can activate much larger pretrained methodological structures, while preserving the distinction from explicit retained methodology.
3. **Borrowing can operate through retained artifacts or weight activation** — extends Commonplace's existing cross-domain borrowing theory with a second route and the hybrid pattern of weight-resident baseline + retained project-specific delta.

The notes intentionally stay at the theory layer. They do not yet revise instructions or skills.

## Key boundary

The PR preserves the existing claim that only explicit retention is durable, writable, and addressable at once. Weight activation can affect behavior without thereby becoming retained Commonplace methodology.

## Follow-up

A subsequent pass can derive instruction/skill changes, especially around loading the smallest adequate methodology representation and using established named methodologies as context-efficient baselines when fidelity is sufficient.