### PR TITLE
Compress the theory-mediated article map

### DIFF
--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -1,225 +1,98 @@
 # Article roles
 
-These are argumentative jobs, not promises to preserve the current number of
-articles, titles, or section boundaries. A rejected draft supplies candidate
-claims only after the incumbent ledger disposes them.
+This is a provisional argument map, not a commitment to article count, titles,
+or reading order. The [shared model](./shared-model.md) is the canonical compact
+synthesis. Accepted baselines may seed prose; rejected drafts may supply claims
+only after disposition in the [incumbent ledger](./incumbent-ledger.md).
 
-## Series logic
+## Argumentative modules
 
-| Order | Argumentative job | Current source |
-|---:|---|---|
-| 0 | State the research program as the series hub: the question, the leverage order, adverse selection and the residue classification, the two milestones meeting at the evaluator, the theory as the wiki's own instrument, and the same classification read as a build plan for an LLM wiki, coding agent, or agent generally | Shared model, closure–capability map, and ledger rows O1–O11 |
-| 1 | Establish that coherent programming requires a program-specific theory and that Naur's human-only binding is no longer established by his argument | Accepted Naur baseline |
-| 2 | Specify a non-degenerate mixed-representation benchmark: a capability-adequate system closes a same-theory self-change path while symbolic machinery faithfully carries long-horizon transitions; competent remote-programmer performance is the strong comparison, not a prerequisite for useful progress | Claims to reconstruct from the self-theories draft, scheduler/code correction, and closure–capability map |
-| 3 | Describe Commonplace as an already useful human–agent theory-building tool, locate its residual human work, and compare progress through leverage and bounded automation envelopes without inventing a unique autonomy scalar | Claims to reconstruct from the theory-building draft plus the operator's tool-use direction |
-| 4 | State the transition unit: what must be represented, bound, checked, executed, and recoverable for one revision decision to leave the human cut | Claims to reconstruct from the revision-decisions draft |
-| 5 | Ask when governed artifact and code revision constitutes system-level continual learning outside weights and how the same substrate extends to other LLM-wiki functions | Claims to reconstruct from the continual-learning draft and current Commonplace operations |
-| 6 | State the scaling conjecture: search and learning over mixed artifacts may increase improvement yield, while representational form alone decides nothing | Accepted Bitter Lesson baseline |
+| Module | Job | Essential content | Primary support | Open research contact |
+|---|---|---|---|---|
+| **Research-program hub** | Present the program as one research question and route readers to its component arguments | The co-indexed theory → change → evidence → theory-revision loop; the mixed architecture; Commonplace and programming agents as testbeds; what evidence would count | [Shared model](./shared-model.md), [target problems](./target-problems.md) | Rival architectures, counterexamples to the loop, and external testbeds |
+| **Bearer question** | Explain why program-specific theory matters and why Naur's argument does not settle that only humans can hold it | Retained theory is not the same as holding a theory; a composite must acquire program-specific premises, justify the parts, and modify coherently across later demands | [Accepted Naur baseline](./accepted/what-bound-naurs-theory-to-programmers.md), [Naur basis note](../../notes/naur-equates-machine-execution-with-formulated-criteria.md) | Rival readings of Naur and operational tests of theory possession |
+| **Operative theory and mixed architecture** | Explain how explicit theory can participate in operation rather than remain documentation | Retention plus interpretation; causal co-indexing; addressability without automatic correctness; distinct representation, settlement, verification, and continuity roles; mediation traces; theory/methodology fast path and fallback | [Theory-mediated self-improvement needs interpretation and retention](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [mixed architecture from residue classes](../../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md), [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md), [two-layer execution](../../notes/theory-and-methodology-form-a-two-layer-execution-system.md) | Better evidence of load-bearing theory use, alternative substrates, and failure cases for the role decomposition |
+| **Current bootstrap** | Show what Commonplace already demonstrates without presenting it as the endpoint | Useful human-agent theory work; explicit remaining human decisions; one recorded theory-mediated episode; programming agents with persistent project-specific theory as the first external testbed | [Shared model](./shared-model.md), [Commonplace as a reflective system](../../notes/evidence/commonplace-as-a-reflective-system.md), the episode record still to be normalized | Independent reproductions, comparison with adjacent systems, and evidence that retained theory changes outcomes |
+| **Progress, closure, and benchmarks** | State how progress is evaluated without collapsing usefulness, autonomy, warrant, and power | Automation envelopes and method ceilings; adverse selection of residual human work; task-scoped closure; capability and evaluator adequacy; fixed-client limits of the remote-programmer benchmark | [Task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [method ceilings](../../notes/a-method-ceiling-bounds-the-method-not-the-transfer-already-made.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Formalizations, non-degenerate task selections, evaluator tests, and measurement of displaced human work |
+| **Learning outside weights and scaling** | Frame learned artifacts as an empirical research direction rather than an exemption from the Bitter Lesson | Production method and representational form are distinct; explicit artifacts buy addressability, not default credit assignment or coherence; artifact learning must compete on end-to-end performance and cost; fixed decompositions remain revisable hypotheses | [Accepted Bitter Lesson baseline](./accepted/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md), [production-method analysis](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [reflection buys addressability](../../notes/reflection-buys-addressability.md) | Matched scaling experiments, artifact credit assignment, decomposition revision, and mixed weight/artifact learning |
 
-The likely reading order follows the table, with the hub article read first
-or directly after Naur; the other articles argue the hub's parts. The claim
-ledger may merge jobs 2–5 or split one of them. No rejected filename reserves
-a successor.
+## Minimal current grouping
 
-## Accepted anchors
+The six modules do not require six articles. The smallest coherent grouping
+supported by the present material is:
 
-### Naur
+1. **The accepted Naur article** carries the bearer question.
+2. **A new hub article** combines the research-program, operative-architecture,
+   and current-bootstrap modules, provided the result remains readable.
+3. **A focused evaluation article** carries progress, task-scoped closure, and
+   the strong benchmarks.
+4. **The accepted Bitter Lesson article** carries learning outside weights and
+   the scaling challenge.
 
-The Naur article supplies a possibility boundary, not evidence of realized
-possession. It establishes why a functioning system needs theory-mediated
-judgment for coherent modification and why trained interpretation reopens who
-or what might bear that capacity. Successors must not turn this into the claim
-that natural-language text by itself contains the theory.
+If the hub becomes overloaded, split the operative architecture or bootstrap
+from it. Do not recover the former article boundaries merely because rejected
+drafts used them.
 
-### Bitter Lesson
+## Disposition of the former seven-job map
 
-The Bitter Lesson article separates scalable production methods from the
-representational form of their outputs. It licenses search and learning over
-prose, code, schemas, and weights. It does not show that current artifact
-learning is autonomous, coherent, or more powerful.
+- The former endpoint-architecture and moving-one-decision jobs divide between
+  the operative-architecture and evaluation modules.
+- The former Commonplace article becomes the bootstrap part of the hub unless
+  the evidence grows enough to warrant a standalone case study.
+- The former continual-learning article becomes part of the Bitter Lesson and
+  scaling argument unless it develops a distinct empirical result.
+- Workshop delegation governs execution of this workshop; it is not an article
+  in the research argument.
 
-## Reconstruction constraints from the four reviews
+## Constraints shared by all modules
 
-### Endpoint architecture
+- Improvement *through theory* requires one causal path: the same theory guides
+  a change, its result bears on that theory, revision follows, and the revision
+  affects later operation.
+- Retained text alone does not hold a program theory. A bearer claim concerns
+  what an interpreter-plus-artifact composite can reliably do.
+- Explicit artifacts provide addressability and inspectability, not automatic
+  credit assignment, coherence, retrieval, correct interpretation, or
+  admission.
+- Commonplace is currently evidence about a useful human-inclusive bootstrap,
+  not independent computational possession or closure.
+- Computational closure is task-scoped and structural. Capability, warrant,
+  usefulness, and power require separate evidence.
+- Remote-programmer parity measures the worker role under a fixed client; it
+  does not establish closure over task choice, feedback, or acceptance.
+- The Bitter Lesson concerns scalable production through search and learning;
+  it neither requires weights-only representation nor proves artifact learning
+  competitive.
 
-The former self-theories draft aggregated theory mediation, reflection, and
-self-improvement anywhere inside one system boundary. That is defeated by a
-system containing three disconnected paths. A successor needs causal
-co-indexing: the same theory must guide the self-change, its outcome must test
-that theory, and the revised theory must affect later operation.
+## Cross-module questions
 
-Generic occurrence, revision-surface, and compounding tests remain useful but
-do not establish theory mediation. The evidence protocol needs an explicit
-mediation trace or intervention.
+Three interactions remain live research questions rather than settled article
+machinery:
 
-Computational closure must not be the article's success criterion by itself.
-The strong benchmark needs an independently stated capability floor, effective reach
-over consequential commitments, an adequate evaluator, and recurrence. Trivial
-closed loops and broad write surfaces with weak realization belong on the map,
-not below it on an assumed ladder.
+1. Is passing Naur's coherent-modification test equivalent to warranting the
+   hardest residual decisions, or only necessary for it?
+2. What evidence distinguishes the theory actually consumed from a retained or
+   cited theory that did not determine the decision?
+3. Search can move proposal into computation; under what conditions does an
+   evaluator also move selection and acceptance out of the human cut?
 
-### Bootstrap, tool use, and measurement
+The articles should expose these questions rather than bury candidate answers
+inside their architecture.
 
-The former theory-building draft retains an evidence-bounded allocation as a
-candidate description. It may not claim that the allocation is unique or turn
-heterogeneous judgments into a scalar percentage. The successor should record
-named functions, their decision content, their current bearers, untraced
-stages, the remaining human work, and the automation envelope of each method at
-a fixed comparison grain. It should read the remaining human work as a residue
-of warranted transfer rather than a catalogue of human capacities, and classify
-each residual decision by the reason it resisted transfer
-([warranted transfer leaves people the hardest-to-warrant decisions](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md));
-the transition article then explains what moving one such row requires.
-The bootstrap article also carries the one recorded use of the
-classify-and-route instrument on a Commonplace path as its mediation trace.
-The previously un-homed claim — proposer and judge are computational while
-direction under a fuzzy objective stays human — is the unsettled-criterion row
-of that first classification, and is homed there.
+## Source discipline
 
-The practical claim is different: the current composite can already be useful
-to people building theories and operating an LLM wiki. Evidence for that claim
-concerns task quality, reach, cost, and repeatability. It neither requires nor
-establishes computational possession of the theory. Increasing automation is
-valuable when it improves those outcomes or preserves them with less required
-intervention. Automating a bounded responsibility is genuine progress even if
-that method cannot cover the rest of the programmer's role. The ceiling limits
-the method, not the transfer already achieved. Better quality, reliability,
-coverage, latency, or resource efficiency inside a fixed envelope also counts
-as capability or yield progress, but not as transfer of a new responsibility.
+Compose bounded argumentative functions, not whole traditions. Every external
+source use remains limited by its row in the
+[match register](./match-register.md). Detailed review history and
+claim-by-claim recovery stay in the incumbent ledger and completed
+investigations; they should not be repeated here or imported wholesale into
+article prose.
 
-### Moving one decision
+Each article should make clear:
 
-The former revision-decisions draft required repository-wide addressability
-for a particular path. The review defeated that scope. A successor must be
-path-relative and distinguish:
+- what it establishes;
+- what evidence supports that result;
+- what it explicitly does not establish; and
+- which genuine questions remain open.
 
-- a required premise that is absent;
-- a record that exists but is not bound to the operation;
-- a model-realization trace that exists but may be false or untrusted;
-- admission, execution, recovery, and later revisability.
-
-### Learning outside weights
-
-The former continual-learning draft supports at most a conditional candidate
-substrate for expressible changes selected by an evidence-responsive loop. It
-does not demonstrate autonomous concept formation by a frozen interpreter.
-Explicit artifacts buy addressability; they do not by themselves supply credit
-assignment, coherence, correct retrieval, or admission.
-
-The broader LLM-wiki claim should begin with demonstrated operations rather
-than importing the stronger learning label. Different operations can share the
-artifact substrate while retaining different human cuts and evaluation
-methods.
-
-## Composition
-
-The series is a target-side construction that assigns bounded functions to
-matched mechanisms — compose functions, not traditions. Each contribution
-keeps its own conditions and non-transfer boundary from the
-[match register](./match-register.md).
-
-| Contribution | Bounded function in the argument | Conditions and non-transfer boundary |
-|---|---|---|
-| Naur, narrowed to the bearer tests | Say what holding a program's theory requires, so that a composite can be tested rather than assumed | Tests stated over capacities; the human-binding conclusion does not enter |
-| Popper, narrowed to criticism of an objective theory | Say how retained theory is consumed: consequences derived, tested, and used to find where it breaks | Acceptance and admission are target-side |
-| Argyris, narrowed to theory-in-use | Say when retained theory is operative: only through what consumes it with binding force | Double-loop *change* of governing variables is our reading |
-| Adverse selection (internal) | Say what transfer leaves behind and why the architecture is mixed | Preferential transfer condition; fixed workload and boundary |
-| Function allocation (Parasuraman et al.), narrowed to the per-function profile | Say how allocation is recorded without a scalar | No level scale; pathway functions, not task stages |
-| Sutton, narrowed to the production axis | Say what search and learning do and do not decide about representational form | Weights-only extrapolation does not enter |
-| Mission command, narrowed to intent-framed delegation and the shared interpretive function | Govern the workshop's own execution across sessions | Conjectured; Commonplace doctrine enters only through a verified binding consumption path, while military hierarchy, rank, force structure, synchronization and risk doctrine, adversarial purpose, and the label as stable guidance do not enter |
-
-Interaction checks the composition must run and record:
-
-- **Bearer tests × evaluator crux.** P1's third test (coherent modification)
-  and P2's least-warrantable decisions name the same decision class. State
-  whether passing the bearer tests is equivalent to warranting those decisions
-  or merely necessary for it. Candidate answer from the operator:
-  **equivalence, under conditions.** Naur's holders are the evaluators of
-  their own coherence; the independent check is the delayed, occasional
-  Popperian exposure — the next demand, the bug, the failed extension. A
-  composite is warranted the way a human holder is when (1) it passes the
-  bearer tests with test 3 read as track record under experimental exposure;
-  (2) the exposures can refute, their evidence not authored by the candidate;
-  (3) outcomes are read back against the retained theory and recorded (the
-  co-indexed path); (4) exposure density is matched to stakes — dense where checks are cheap,
-  and where exposure is sparse the decisive check is decorrelated criticism
-  (science mode); (5) the coherence check is plural or otherwise decorrelated
-  from the proposer, since one composite's self-judgment shares its blind
-  spots; (6) the composite recognizes the cases it cannot judge and routes
-  them to exposure or a peer, and the record shows it doing so. Human holders
-  get (4)–(6) for free — dense cheap feedback, a group of holders, knowing
-  when unsure — which is why their self-judgment mostly works; science is the
-  regime where (4) fails and (5)–(6) are institutionalized instead.
-  The repair episode is then reread: the pass was a *non-holder* judging its
-  own work, not a holder; the degenerate patterns become non-holder
-  self-assessment and holder-without-exposure, not self-assessment as such.
-  Consequences: jobs 1 and 2 merge at the crux; job 2's honest test is a
-  horizon of later demands, not per-task acceptance; the residue row "no
-  independent check" splits into no-oracle and delayed-oracle, and the
-  delayed-oracle row is the one theory-holding composites can take.
-- **Criticism × theory-in-use.** Popper's cycle operates on stated theory;
-  Argyris's self-sealing operates on consumed theory. Say which artifact the
-  mediation trace reads, and whether criticism of the stated theory can reach
-  a theory-in-use that differs from it. Candidate answer from register rows 5
-  and 6: only where the trace reads what was consumed, not what was retained;
-  the Naur repair episode is the instance.
-- **Production axis × adverse selection.** Search-selected artifacts still
-  need an evaluator; say whether selection by search moves a decision out of
-  the human cut or only changes who proposes candidates. Candidate answer
-  from the gradual-compatibility task (2026-08-29): **it splits per
-  function.** Search alone moves *proposal*: candidates a person would have
-  drafted are drafted by a generator or a model, which raises leverage (P4)
-  without changing the human cut. The *decision* moves only with the oracle:
-  acceptance leaves the human cut when a check the candidate did not author
-  can reject the candidate, which is P2's binding warrantability condition.
-  So the portion of a path the lesson governs and the portion that has left
-  the human cut coincide at the evaluator. Consequences: (1) over the
-  remainder, search changes who proposes and nothing else — run there
-  without an independent oracle it yields the captured-evaluator or
-  boundary-export pattern, not a transfer; (2) the moved portion keeps its
-  objective, evaluator, and update space supplied — in FunSearch the
-  proposer and scorer moved while the specification, evaluator, skeleton,
-  and function boundary stayed, and those are the objective and
-  unsettled-criterion rows; (3) the remainder's difficulty is predicted
-  rather than embarrassing, since it is where no oracle exists and so where
-  nothing, hand or search, can currently select; (4) P5 and P2 remain
-  orthogonal as questions — form versus who decides — while their answers
-  meet at one point. Recorded in the
-  [defense portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md)
-  and the production-method note's
-  [per-portion section](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md#compatibility-is-assessed-per-portion-of-a-path).
-- **Delegation × hand-back.** The ADR 080 hand-back returns control when a
-  change would alter a claim. Candidate answer from the shared-doctrine
-  workshop: it is the Commonplace doctrine's *gap* case — neither inherited,
-  delegated, nor irrelevant — and therefore a governed return of control, not
-  a case where the executor lacked the operator's purpose. This remains a
-  candidate until that workshop reports.
-
-## Separation rules
-
-- The strong-benchmark article says what would close the loop. The bootstrap article
-  says where the current loop is open and why the open loop can still be a
-  useful tool.
-- Closure and capability are separate coordinates. Neither unattended
-  execution nor broad syntactic writability establishes a powerful closed
-  system.
-- The bootstrap article records allocation. The transition article explains
-  what moving one row would require.
-- The continual-learning argument concerns the unit and substrate of learning.
-  It must not serve as evidence that closure or compounding has already
-  occurred.
-- Present LLM-wiki usefulness is a product and methodology claim. A measured
-  increase in accepted outcomes per human programming effort is lower-bound
-  progress, but it must not be used as evidence of closure or of reach beyond
-  the responsible mechanism's automation envelope.
-- The Bitter Lesson concerns scalable production methods and possible power.
-  It must not silently become an autonomy theorem.
-- The build-plan reading orders what to build next. It must not silently
-  become a power theorem: whether the plan yields a more powerful system is
-  measured, not derived.
-- The benchmark article names the client cut as a declared export of demand
-  choice and acceptance. It must not present the benchmark as closure over
-  those decisions.
-- Code is both execution machinery and revisable system content. No article may
-  treat the scheduler as permanently outside the target while calling the
-  result closed.
+Those openings are invitations to research exchange, not assigned work.


### PR DESCRIPTION
## Summary

- replace the accumulated seven-job article plan with six compact argumentative modules
- propose a provisional four-article grouping: the accepted Naur anchor, a new hub, a focused evaluation article, and the accepted Bitter Lesson anchor
- fold the former endpoint, bootstrap, transition, and continual-learning jobs into the modules that now own their arguments
- route detailed review history, candidate answers, and claim recovery back to the incumbent ledger, match register, durable notes, and completed investigations
- retain only the cross-article constraints and three genuinely open interactions that the article architecture must expose

## Scope

One commit changes only `kb/work/theory-mediated-self-improvement-series/article-roles.md`, reducing it from 319 changed lines to a 96-line replacement.

## Validation

The GitHub Actions `Test` workflow passed, including software tests, wheel build and installation, entry-point resolution, and temporary-project initialization and validation.