### PR TITLE
Add atomic foundations for pre-decisive search control

### DIFF
--- a/kb/notes/a-failure-explanation-becomes-search-control-only-when-it-changes-a-later-branch-decision.md
+++ b/kb/notes/a-failure-explanation-becomes-search-control-only-when-it-changes-a-later-branch-decision.md
@@ -1,0 +1,36 @@
+---
+description: "An explanation of a failed branch becomes operative search control only when its retention changes a later choice about scope, priority, probing, continuation, or abandonment"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, learning-theory, self-improving-systems]
+---
+
+# A failure explanation becomes search control only when it changes a later branch decision
+
+An explanation produced after a failed or disappointing branch may be correct
+yet inert. It becomes part of search control only when it is retained and later
+changes a branch decision: what is tried, how the idea is scoped or prioritized,
+which probe is selected, or when the branch is continued, suspended, or
+abandoned.
+
+Rejecting the original idea is not required. An explanation can preserve it by
+narrowing its applicability or identifying a different test. That counts as an
+update when the narrower account predicts a different later choice.
+
+An explanation that leaves every later branch decision unchanged has not yet
+improved search control. It may still be useful commentary, but it does not
+separate learning from rationalization.
+
+## Scope
+
+- The later choice may occur in the same episode or a later one, provided the
+  retained explanation is part of the causal path.
+- Changing wording or confidence without changing a branch decision does not
+  satisfy the claim.
+
+---
+
+Relevant Notes:
+
+- [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — grounds: identifies the branch decisions an explanation can change
+- [Theory-mediated self-improvement needs interpretation and retention](./theory-mediated-self-improvement-needs-interpretation-and-retention.md) — extends: supplies the stronger requirement that a retained theory-state change affect later operation

--- a/kb/notes/a-search-controller-is-tested-by-what-it-brings-to-stronger-evaluation.md
+++ b/kb/notes/a-search-controller-is-tested-by-what-it-brings-to-stronger-evaluation.md
@@ -1,0 +1,37 @@
+---
+description: "A search controller should be evaluated by the branches and probes it routes into stronger evaluation, not by treating every provisional judgment as an acceptance claim"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, evaluation, self-improving-systems]
+---
+
+# A search controller is tested by what it brings to stronger evaluation
+
+A search controller decides which branches or probes receive further work. It
+does not itself establish that those branches are correct or worth adopting.
+Its evaluation should therefore follow what it routes into stronger evaluation.
+
+A useful controller brings forward branches that later produce valuable
+candidates, discriminating evidence, informative failures, or improved
+recovery. A false lead does not individually refute it, just as one successful
+branch does not establish it. The comparison concerns the distribution of
+consequences produced by its routing decisions.
+
+The controller can be compared with alternatives under matched tasks,
+resources, and downstream evaluation. This does not require knowing the best
+branch in the full counterfactual search space, which is normally unavailable
+in the open-ended setting.
+
+## Scope
+
+- Stronger evaluation may be immediate, delayed, empirical, or formal. The
+  claim does not select one evaluator.
+- Search-controller quality does not establish that any accepted result was
+  adequately warranted; acceptance remains a separate judgment.
+
+---
+
+Relevant Notes:
+
+- [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — grounds: supplies the limited-authority controller whose output is being evaluated
+- [Open-ended improvement must allocate search before decisive evaluation is available](./open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md) — grounds: explains why comparison cannot assume exhaustive evaluation of every branch

--- a/kb/notes/backtracking-keeps-lightweight-search-control-provisional.md
+++ b/kb/notes/backtracking-keeps-lightweight-search-control-provisional.md
@@ -1,0 +1,38 @@
+---
+description: "Backtracking preserves the provisional status of a heuristic branch choice by restoring an earlier usable state and redirecting search after contrary evidence"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# Backtracking keeps lightweight search control provisional
+
+A branch chosen by
+[lightweight search control](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md)
+may be wrong. Backtracking keeps that choice provisional when the process can
+preserve an earlier usable state, recognize evidence against the current
+branch, return to that state, and redirect search.
+
+Without an operative return path, a trial can become a de facto commitment.
+Later work may depend on it, the prior state may become costly to recover, and a
+judgment that was meant only to allocate search may acquire the consequences of
+acceptance.
+
+Backtracking does not show that the original heuristic was good. It also does
+not recover spent effort or guarantee that contrary evidence will be noticed.
+Its narrower function is to keep branch selection from becoming final merely
+because the branch was tried.
+
+## Scope
+
+- Backtracking may restore an artifact, a plan, a theory state, or another
+  search position; it is not limited to reverting code.
+- A reversible branch can still cause irreversible external effects. The claim
+  applies only to the state the process can actually restore.
+
+---
+
+Relevant Notes:
+
+- [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — grounds: supplies the provisional branch choice
+- [Holding a program theory means sustaining coherent search under delayed feedback](./holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md) — extends: places backtracking inside longitudinal program modification and recovery

--- a/kb/notes/intent-controls-a-local-choice-only-when-it-distinguishes-its-live-alternatives.md
+++ b/kb/notes/intent-controls-a-local-choice-only-when-it-distinguishes-its-live-alternatives.md
@@ -1,0 +1,35 @@
+---
+description: "A stated intent controls a local choice only when it changes which live alternatives are admissible, preferred, worth further search, or sufficient to stop"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, methodology, planning]
+---
+
+# Intent controls a local choice only when it distinguishes its live alternatives
+
+A stated intent can control a local choice only if, directly or through an
+intermediate intent or constraint, it changes which live alternatives are
+admissible, preferred, worth further search, or sufficient to stop.
+
+When removing or replacing the intent would leave the local alternatives and
+their ordering unchanged, the intent did not control that choice. It may still
+explain the wider project or govern another decision.
+
+A distant intent can acquire local force through a bridge that derives a more
+specific purpose, priority, role, or constraint. The bridge matters because a
+high-level purpose compatible with every live local option cannot select among
+them by itself.
+
+## Scope
+
+- Intent need not exclude an option to discriminate; changing its priority or
+  stopping condition is enough.
+- Discrimination is necessary, not sufficient. The executor may still
+  misunderstand or ignore the intent.
+
+---
+
+Relevant Notes:
+
+- [Intent-framed delegation is a control regime; prompt length does not establish it](./intent-framed-delegation-is-a-control-regime-not-a-short-prompt.md) — grounds: locates intent inside a broader allocation of information, authority, and evidence
+- [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — extends: local intent can rank branches without authorizing their final adoption

--- a/kb/notes/lightweight-search-control-allocates-further-search-without-licensing-adoption.md
+++ b/kb/notes/lightweight-search-control-allocates-further-search-without-licensing-adoption.md
@@ -1,0 +1,39 @@
+---
+description: "A search judgment is lightweight when its authority stops at allocating further investigation, probing, continuation, suspension, or abandonment rather than licensing an operative change"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# Lightweight search control allocates further search without licensing adoption
+
+[Open-ended improvement must allocate search before decisive evaluation is
+available](./open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md).
+Call a judgment **lightweight search control** when its authorized consequence
+is limited to changing which branch receives further search. It may make a
+question worth investigating, select a probe, continue or suspend a branch, or
+redirect effort elsewhere.
+
+The same judgment does not by itself license an operative change. "Worth
+investigating" and "warranted to adopt" are different conclusions. The first
+may rely on evidence too weak for the second because the selected branch remains
+subject to stronger evaluation before adoption.
+
+"Lightweight" names the judgment's authority, not its cost, formality, or
+confidence. A costly analysis can remain lightweight when it only allocates
+further search. A cheap rule can be an acceptance control when passing it makes
+a change operative.
+
+## Scope
+
+- Lightweight control can still waste resources or systematically miss valuable
+  branches. Limited authority does not make the controller effective.
+- The claim does not specify how search should be allocated or what evidence is
+  sufficient for adoption.
+
+---
+
+Relevant Notes:
+
+- [Open-ended improvement must allocate search before decisive evaluation is available](./open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md) — grounds: establishes the prior allocation problem this control addresses
+- [A proposal-selection improvement loop requires search, evaluation, and operative retention](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) — grounds: separates bringing a candidate into consideration from accepting it

--- a/kb/notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md
+++ b/kb/notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md
@@ -1,0 +1,39 @@
+---
+description: "Project-specific natural language may specialize general search heuristics already represented in an LLM's weights by supplying the current intent, theory, branch history, and constraints"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, context-engineering, self-improving-systems]
+---
+
+# Natural-language project state may specialize weight-resident search heuristics
+
+A pretrained language model may already contain general heuristics for noticing
+anomalies, generating alternatives, ranking promising directions, selecting
+probes, persisting, and backtracking. It does not already contain the current
+state of a particular project.
+
+The conjecture is that retained natural language can specialize those general
+heuristics by supplying the project's intent, working theory, prior branches,
+failures, commitments, and constraints. The language need not encode a complete
+search procedure. The weights may supply the general competence while the
+retained project state determines how it applies here.
+
+The relevant evidence is behavioral. Withholding, replacing, or perturbing the
+project state should change branch choices and their later consequences. A
+plausible explanation that leaves search unchanged does not establish the
+conjecture.
+
+## Scope
+
+- This is an empirical conjecture, not a claim that current models already
+  allocate open-ended search effectively.
+- Specializing search heuristics does not give the resulting choices acceptance
+  authority.
+
+---
+
+Relevant Notes:
+
+- [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — grounds: identifies the limited authority of the specialized heuristics
+- [Weight-resident methodologies provide context-efficient behavioral compression](./weight-resident-methodologies-compress-behavior-in-context.md) — grounds: shows how compact language can select a larger behavioral pattern already represented in weights
+- [A capable agent needs methodology selection, not just relevant knowledge](./capable-agents-need-methodology-selection.md) — extends: distinguishes selecting a governing method from merely supplying relevant facts

--- a/kb/notes/open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md
+++ b/kb/notes/open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md
@@ -1,0 +1,115 @@
+---
+description: "Open-ended improvement must choose which questions, candidates, experiments, or proof paths to develop before decisive evidence about them is available; even a Gödel machine's proof gate retains this prior search problem"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# Open-ended improvement must allocate search before decisive evaluation is available
+
+A decisive evaluator can govern only a branch that is concrete enough to
+assess. Open-ended improvement starts before that point. It must decide which
+anomaly to investigate, candidate to formulate, experiment to run, or proof path
+to pursue while the evidence that could decisively judge those branches is not
+yet available.
+
+Here, **decisive evaluation** means evidence strong enough to license adoption
+under the declared criterion. It need not establish absolute truth. The claim is
+that even this criterion-relative evidence often becomes available only after
+search has selected and developed a branch.
+
+This is not merely an economic constraint. Evaluation may be expensive, but it
+may also be impossible before a candidate has been formulated, depend on an
+intervention that has not been performed, arrive only through later demands, or
+require a proof that the current formal system cannot derive. More resources do
+not remove the need to choose a direction that makes the candidate and its
+evaluation problem available.
+
+## Search precedes its strongest evidence
+
+In a
+[proposal-selection improvement loop](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md),
+search brings a possible change into consideration and evaluation determines
+whether it may be accepted. The functions are distinct because an evaluator
+cannot accept or reject a candidate that search never reaches.
+
+Open-ended improvement makes the separation consequential. Its branch set is
+not a finished list supplied in advance. Search can discover new questions,
+representations, methods, experiments, and evaluators while it proceeds. The
+process therefore needs some prior allocation of attention and computation
+across branches before it has the strongest evidence about their value.
+
+A perfect acceptance rule over every candidate presented to it would not by
+itself make the overall process effective. The process could still fail to
+formulate a useful candidate, pursue the wrong proof direction, or never build
+the observation that would expose a better branch. Acceptance quality bounds
+what survives after search; search allocation bounds what gets the opportunity
+to survive.
+
+## The Gödel machine retains the prior search problem
+
+The Gödel machine is the proof-governed limit case. A self-rewrite may execute
+only after the machine proves that switching now has higher expected utility
+than continuing its current search, relative to its axioms and utility
+function. The proof gate therefore supplies decisive acceptance within the
+formalization.
+
+The gate still acts only after proof search reaches a proof technique that
+produces a candidate rewrite and proves the target theorem. The initial proof
+searcher must allocate computation across proof techniques according to a
+supplied bias. The machine's global-optimality result is relative to whichever
+initial proof searcher was chosen, and beneficial rewrites outside what the
+formal system can prove remain unreachable. See
+[Gödel machines are a proof-governed case of reflective self-modification](./goedel-machines-are-a-proof-governed-case-of-self-modification.md).
+
+The machine may later rewrite its proof searcher, but it must find and justify
+that rewrite through the searcher it already has. Self-revision moves search
+allocation inside the revisable system; it does not eliminate the bootstrap
+allocation. Even the strongest acceptance regime in this comparison therefore
+retains a prior question: which proof directions receive enough search to reach
+the gate?
+
+## What follows
+
+Open-ended improvement needs a search-allocation process whose decisions precede
+decisive evaluation of the selected branches. The evidence available to that
+process can be weaker than the evidence required for final adoption without
+becoming irrelevant: it controls which branches receive further work, not which
+changes are finally warranted.
+
+This does not establish which search-allocation method works. It also does not
+show that every candidate must be evaluated separately. A proof, abstraction,
+or experiment may dispose of a whole class of candidates at once. Choosing to
+construct that proof, abstraction, or experiment is itself part of the prior
+search problem.
+
+## Scope
+
+- The claim concerns open-ended improvement, where consequential branches are
+  generated or elaborated during the process. In a finite task with a supplied
+  candidate list and cheap exhaustive evaluation, search allocation may be
+  trivial.
+- "Before" names a causal dependency, not a rigid execution order. Evaluation
+  of earlier branches can guide later search, but it cannot retroactively choose
+  which first branch made that evidence available.
+- Decisive evaluation remains relative to a criterion and formalization. A
+  proof can be decisive within wrong axioms, and an empirical gate can be
+  decisive for a weak proxy.
+- The note does not identify a successful search-control mechanism or show that
+  any current agent allocates open-ended search well.
+
+## Open Questions
+
+- How can a search-allocation policy be evaluated without requiring the
+  exhaustive counterfactual search that the policy exists to avoid?
+- What evidence should revise the search-allocation process itself rather than
+  only the candidate it happened to reach?
+
+---
+
+Relevant Notes:
+
+- [A proposal-selection improvement loop requires search, evaluation, and operative retention](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) — grounds: separates candidate production from reject-capable acceptance and states that evaluation cannot select an unreached candidate
+- [Gödel machines are a proof-governed case of reflective self-modification](./goedel-machines-are-a-proof-governed-case-of-self-modification.md) — exemplifies: the proof-gated limit case still begins from a supplied proof-search bias and excludes beneficial but unprovable rewrites
+- [The boundary of automation is the boundary of verification](./the-boundary-of-automation-is-the-boundary-of-verification.md) — contrasts: verification bounds what can be accepted with warrant, while this note isolates the prior bound on what reaches evaluation
+- [Holding a program theory means sustaining coherent search under delayed feedback](./holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md) — extends: develops one candidate account of how open-ended program search can remain coherent before delayed evidence arrives


### PR DESCRIPTION
## Summary

Add a small dependency chain for the control problem that appears before decisive evaluation in open-ended improvement.

The foundational note states:

> Open-ended improvement must allocate search before decisive evaluation is available.

Six deliberately bare successor notes then separate:

1. lightweight search control from adoption authority;
2. backtracking as the mechanism that keeps a branch choice provisional;
3. operative learning from failure from inert explanation or rationalization;
4. natural-language project state as a possible way to specialize weight-resident search heuristics;
5. the condition under which intent can control a local choice; and
6. downstream evaluation of a search controller by what it routes into stronger evaluation.

## Atomicity

Each note carries one claim, a short argument, explicit scope, and only the links needed to establish its immediate dependencies. The PR deliberately does not yet synthesize intuition, curiosity, Auftragstaktik, or a full lightweight-control architecture. Those are left for later revision and connection work.

## Gödel-machine connection

The foundational note uses the Gödel machine as the proof-gated limit case. Its target-theorem gate governs adoption relative to its formalization, but the machine still begins with a supplied proof-search bias and may revise that searcher only through the searcher it already has.

## Validation

The branch differs from `main` by seven Markdown notes. Repository CI is the available automated check; the notes were also reviewed for frontmatter, file-path collisions, and internal-link targets.

Workshop: `kb/work/theory-mediated-self-improvement-series`
Model: `gpt-5.6-pro`