### PR TITLE
Integrate code as the complement to weight-prompt operations

### DIFF
--- a/kb/notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md
+++ b/kb/notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md
@@ -7,126 +7,70 @@ tags: [computational-model, learning-theory, constraining]
 
 # Code complements the weight–prompt pair with independently executed symbolic operations
 
-A prompt does not define an LLM operation by itself. Relative to fixed inference
-settings and available tools, the operation is instantiated jointly by the
-model's weights and the prompt supplied for the call. The weights provide broad
-learned competence and general behavioral tendencies. The prompt supplies the
+A prompt does not define an LLM operation by itself. Relative to fixed call
+settings, the operation is instantiated jointly by the model's weights and the
+prompt. The weights provide broad learned competence. The prompt supplies the
 current task, project state, intent, evidence, and constraints that specialize
 that competence.
 
 Code supplies a complementary operation class. Relative to a runtime, code
-assigns consequences to inputs and explicit symbolic state. Once the code has
-been selected and installed, the runtime can execute those consequences without
-asking the model to reinterpret the prompt or reconstruct the operation on every
-use.
-
-The distinction can be written schematically as:
+assigns consequences to inputs and explicit symbolic state. Once selected and
+installed, the runtime can execute those consequences without asking the model
+to reinterpret the prompt or reconstruct the operation on every use.
 
 ```text
 model-mediated operation:  weights + prompt  -> interpreted, generally stochastic behavior
 symbolic operation:        code + runtime    -> runtime-assigned state transition
 ```
 
-Neither side is independent of its execution environment. The claim is narrower:
-a symbolic operation can execute independently of model interpretation even when
-a model generated, selected, explained, or later revised the code.
+A model may generate, select, explain, or revise the code. That provenance does
+not change how the installed operation executes. "Independently" means
+independently of model interpretation at that execution step, not independently
+of the runtime, inputs, or environment.
 
-## The forms contribute different capabilities
+The weight–prompt pair is useful where an operation requires semantic
+interpretation, open-ended generation, judgment, or search. Code is useful where
+a selected behavior can be assigned precisely enough to benefit from exact state
+transitions, reliable bookkeeping, repeatability, or enforceable checks. This is
+the mechanism behind the
+[scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md):
+a model may decide what a scheduler should do or write it, while a symbolic
+runtime owns queues, counters, checkpoints, retries, and transitions.
 
-The weight–prompt pair is useful where the operation requires semantic
-interpretation, open-ended generation, judgment, or search over alternatives.
-Code is useful where the selected behavior can be assigned precisely enough to
-benefit from deterministic execution, explicit state, reliable bookkeeping,
-repeatability, or an enforceable check.
-
-This is the mechanism behind the
-[scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md).
-A model may decide what a scheduler should do or write the scheduler, while a
-symbolic runtime owns queue state, counters, checkpoints, retries, and exact
-transitions. Moving those operations into code removes repeated interpreter
-deviation relative to the implemented transition. It does not establish that
-the transition implements the right requirement, because
-[exact implementation does not validate a requirement against its objective](./exact-implementation-does-not-validate-a-requirement.md).
-
-The complement therefore is not natural language versus code. It is between two
-ways of producing behavior:
-
-- a **model-mediated operation**, whose behavior is defined by the interaction of
-  distributed-parametric weights with a call-specific prompt; and
-- a **symbolic operation**, whose behavior is assigned by code and its runtime.
-
+The complement is therefore not natural language versus code. It is between a
+model-mediated operation defined by the interaction of weights and a
+call-specific prompt, and a symbolic operation defined by code and its runtime.
 A deployed agent system composes both.
 
-## Code can be both project state and executable state
-
-The same code artifact can participate through two consumption paths.
+## One code artifact can enter both operations
 
 When code is loaded into a prompt, it is project evidence for a model-mediated
 operation. It can reveal interfaces, dependencies, invariants, current behavior,
-and possible modification points. In that path, the code helps the weight–prompt
-pair choose or interpret a change.
+and possible modification points.
 
-When the runtime imports, executes, tests, or validates the code, the artifact
+When a runtime imports, executes, tests, or validates the same code, the artifact
 has symbolic force. Its consequences no longer depend on how the model reads it.
-The artifact may therefore be both an object of semantic search and the
-independent executor of a result produced by that search.
-
-```text
-code read in a prompt
-    -> changes model-mediated search
-    -> revised code is proposed and selected
-    -> runtime executes the revised code
-    -> execution evidence enters later prompts
-```
+The code can therefore be both an object of semantic search and the independent
+executor of a result produced by that search.
 
 This dual role follows the
 [representational-form](./definitions/representational-form.md) rule that form is
 classified by an operative part and consumption path, not by file extension or
 storage substrate.
 
-## The boundary is a learning target
-
-An evidence-responsive system can learn by changing either operation class or
-the division of responsibility between them. It may revise a prompt or retained
-natural-language theory, revise target or control code, codify a stable
-model-mediated pattern into code, or relax brittle code back into semantic
-judgment.
-
-[Unified calling conventions](./unified-calling-conventions-enable-bidirectional-refactoring.md)
-can make this movement local by preserving one interface while its
-implementation changes. Governing the movement still requires coverage of both
-forms and their mapping, because
-[moving the interpretation–enforcement boundary requires cross-form coverage](./moving-the-interpretation-enforcement-boundary-requires-coverage.md).
-
-The resulting learning surface includes:
-
-1. the prompt and retained artifacts used to specialize the model;
-2. the code and symbolic state used to execute selected operations;
-3. the evidence produced by both; and
-4. the allocation rule deciding which operations remain model-mediated and
-   which become symbolic.
-
-Code is therefore not fixed infrastructure outside the learning account. It can
-be produced and selected computationally, become operative state, and later be
-revised or removed. Its complementarity to the weight–prompt pair concerns how
-it executes, not who authored it or whether it must persist.
-
 ## Scope
 
-- "Weights plus prompt" is an abstraction over a call with fixed model binding,
+- "Weights plus prompt" abstracts over a call with fixed model binding,
   inference settings, tool exposure, and protocol. Changing those can change the
   model-mediated operation too.
 - A retained natural-language artifact is not automatically a prompt. It joins
   the pair only when context assembly supplies it as model input.
-- "Independently executed" means independently of model reinterpretation at that
-  execution step. Symbolic behavior still depends on the runtime, inputs,
-  environment, and the correctness of the code.
-- Deterministic execution is valuable only where the operation can be specified
-  adequately. Judgment-heavy work may remain model-mediated, and a wrongly
-  codified proxy can be reliably wrong.
-- The claim does not rank the two operation classes globally. Their value depends
-  on semantic ambiguity, verification, cost, latency, failure consequences, and
-  the available evidence.
+- Symbolic exactness is relative to the implemented transition. It does not show
+  that the code implements the right requirement, because
+  [exact implementation does not validate a requirement against its objective](./exact-implementation-does-not-validate-a-requirement.md).
+- The claim does not rank the two operation classes globally. Judgment-heavy
+  work may remain model-mediated, while adequately specified operations may gain
+  reliability or efficiency from symbolic execution.
 
 ---
 
@@ -135,7 +79,5 @@ Relevant Notes:
 - [Natural-language project state may specialize weight-resident search heuristics](./natural-language-project-state-may-specialize-weight-resident-search-heuristics.md) — grounds: isolates how retained project information changes the prompt side of the model-mediated operation
 - [Scheduler-LLM separation exploits an error-correction asymmetry](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) — mechanism: explains why exact state transitions and bookkeeping benefit from independent symbolic execution
 - [Bounded-context orchestration model](./bounded-context-orchestration-model.md) — exemplifies: composes explicit symbolic state and transitions with bounded model calls
-- [Exact implementation does not validate a requirement against its objective](./exact-implementation-does-not-validate-a-requirement.md) — limits: symbolic exactness does not validate the upstream requirement
-- [Unified calling conventions enable bidirectional refactoring between neural and symbolic](./unified-calling-conventions-enable-bidirectional-refactoring.md) — enables: keeps the interface stable while an operation moves between model-mediated and symbolic implementations
-- [Moving the interpretation–enforcement boundary requires cross-form coverage](./moving-the-interpretation-enforcement-boundary-requires-coverage.md) — extends: states what a reflective system must cover to govern that movement
-- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — extends: places both operation classes inside one behavior-producing and revisable system
+- [Unified calling conventions enable bidirectional refactoring between neural and symbolic](./unified-calling-conventions-enable-bidirectional-refactoring.md) — extends: makes movement between the two operation classes local while preserving an interface
+- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — extends: places both operation classes inside one behavior-producing system

--- a/kb/notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md
+++ b/kb/notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md
@@ -1,0 +1,141 @@
+---
+description: "A model-mediated operation is instantiated by weights plus prompt; code complements that pair by defining operations whose consequences a symbolic runtime executes without reinterpreting the prompt"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [computational-model, learning-theory, constraining]
+---
+
+# Code complements the weight–prompt pair with independently executed symbolic operations
+
+A prompt does not define an LLM operation by itself. Relative to fixed inference
+settings and available tools, the operation is instantiated jointly by the
+model's weights and the prompt supplied for the call. The weights provide broad
+learned competence and general behavioral tendencies. The prompt supplies the
+current task, project state, intent, evidence, and constraints that specialize
+that competence.
+
+Code supplies a complementary operation class. Relative to a runtime, code
+assigns consequences to inputs and explicit symbolic state. Once the code has
+been selected and installed, the runtime can execute those consequences without
+asking the model to reinterpret the prompt or reconstruct the operation on every
+use.
+
+The distinction can be written schematically as:
+
+```text
+model-mediated operation:  weights + prompt  -> interpreted, generally stochastic behavior
+symbolic operation:        code + runtime    -> runtime-assigned state transition
+```
+
+Neither side is independent of its execution environment. The claim is narrower:
+a symbolic operation can execute independently of model interpretation even when
+a model generated, selected, explained, or later revised the code.
+
+## The forms contribute different capabilities
+
+The weight–prompt pair is useful where the operation requires semantic
+interpretation, open-ended generation, judgment, or search over alternatives.
+Code is useful where the selected behavior can be assigned precisely enough to
+benefit from deterministic execution, explicit state, reliable bookkeeping,
+repeatability, or an enforceable check.
+
+This is the mechanism behind the
+[scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md).
+A model may decide what a scheduler should do or write the scheduler, while a
+symbolic runtime owns queue state, counters, checkpoints, retries, and exact
+transitions. Moving those operations into code removes repeated interpreter
+deviation relative to the implemented transition. It does not establish that
+the transition implements the right requirement, because
+[exact implementation does not validate a requirement against its objective](./exact-implementation-does-not-validate-a-requirement.md).
+
+The complement therefore is not natural language versus code. It is between two
+ways of producing behavior:
+
+- a **model-mediated operation**, whose behavior is defined by the interaction of
+  distributed-parametric weights with a call-specific prompt; and
+- a **symbolic operation**, whose behavior is assigned by code and its runtime.
+
+A deployed agent system composes both.
+
+## Code can be both project state and executable state
+
+The same code artifact can participate through two consumption paths.
+
+When code is loaded into a prompt, it is project evidence for a model-mediated
+operation. It can reveal interfaces, dependencies, invariants, current behavior,
+and possible modification points. In that path, the code helps the weight–prompt
+pair choose or interpret a change.
+
+When the runtime imports, executes, tests, or validates the code, the artifact
+has symbolic force. Its consequences no longer depend on how the model reads it.
+The artifact may therefore be both an object of semantic search and the
+independent executor of a result produced by that search.
+
+```text
+code read in a prompt
+    -> changes model-mediated search
+    -> revised code is proposed and selected
+    -> runtime executes the revised code
+    -> execution evidence enters later prompts
+```
+
+This dual role follows the
+[representational-form](./definitions/representational-form.md) rule that form is
+classified by an operative part and consumption path, not by file extension or
+storage substrate.
+
+## The boundary is a learning target
+
+An evidence-responsive system can learn by changing either operation class or
+the division of responsibility between them. It may revise a prompt or retained
+natural-language theory, revise target or control code, codify a stable
+model-mediated pattern into code, or relax brittle code back into semantic
+judgment.
+
+[Unified calling conventions](./unified-calling-conventions-enable-bidirectional-refactoring.md)
+can make this movement local by preserving one interface while its
+implementation changes. Governing the movement still requires coverage of both
+forms and their mapping, because
+[moving the interpretation–enforcement boundary requires cross-form coverage](./moving-the-interpretation-enforcement-boundary-requires-coverage.md).
+
+The resulting learning surface includes:
+
+1. the prompt and retained artifacts used to specialize the model;
+2. the code and symbolic state used to execute selected operations;
+3. the evidence produced by both; and
+4. the allocation rule deciding which operations remain model-mediated and
+   which become symbolic.
+
+Code is therefore not fixed infrastructure outside the learning account. It can
+be produced and selected computationally, become operative state, and later be
+revised or removed. Its complementarity to the weight–prompt pair concerns how
+it executes, not who authored it or whether it must persist.
+
+## Scope
+
+- "Weights plus prompt" is an abstraction over a call with fixed model binding,
+  inference settings, tool exposure, and protocol. Changing those can change the
+  model-mediated operation too.
+- A retained natural-language artifact is not automatically a prompt. It joins
+  the pair only when context assembly supplies it as model input.
+- "Independently executed" means independently of model reinterpretation at that
+  execution step. Symbolic behavior still depends on the runtime, inputs,
+  environment, and the correctness of the code.
+- Deterministic execution is valuable only where the operation can be specified
+  adequately. Judgment-heavy work may remain model-mediated, and a wrongly
+  codified proxy can be reliably wrong.
+- The claim does not rank the two operation classes globally. Their value depends
+  on semantic ambiguity, verification, cost, latency, failure consequences, and
+  the available evidence.
+
+---
+
+Relevant Notes:
+
+- [Natural-language project state may specialize weight-resident search heuristics](./natural-language-project-state-may-specialize-weight-resident-search-heuristics.md) — grounds: isolates how retained project information changes the prompt side of the model-mediated operation
+- [Scheduler-LLM separation exploits an error-correction asymmetry](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) — mechanism: explains why exact state transitions and bookkeeping benefit from independent symbolic execution
+- [Bounded-context orchestration model](./bounded-context-orchestration-model.md) — exemplifies: composes explicit symbolic state and transitions with bounded model calls
+- [Exact implementation does not validate a requirement against its objective](./exact-implementation-does-not-validate-a-requirement.md) — limits: symbolic exactness does not validate the upstream requirement
+- [Unified calling conventions enable bidirectional refactoring between neural and symbolic](./unified-calling-conventions-enable-bidirectional-refactoring.md) — enables: keeps the interface stable while an operation moves between model-mediated and symbolic implementations
+- [Moving the interpretation–enforcement boundary requires cross-form coverage](./moving-the-interpretation-enforcement-boundary-requires-coverage.md) — extends: states what a reflective system must cover to govern that movement
+- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — extends: places both operation classes inside one behavior-producing and revisable system

--- a/kb/notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md
+++ b/kb/notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md
@@ -1,5 +1,5 @@
 ---
-description: "Project-specific natural language may specialize general search heuristics already represented in an LLM's weights by supplying the current intent, theory, branch history, and constraints"
+description: "The natural-language part of project state may specialize general search heuristics already represented in an LLM's weights by supplying current intent, theory, branch history, and constraints"
 type: kb/types/note.md
 traits: [title-as-claim]
 tags: [foundations, context-engineering, self-improving-systems]
@@ -16,10 +16,19 @@ The conjecture is that retained natural language can specialize those general
 heuristics by supplying the project's intent, working theory, prior branches,
 failures, commitments, and constraints. The language need not encode a complete
 search procedure. The weights may supply the general competence while the
-retained project state determines how it applies here.
+retained natural-language state determines how it applies here.
+
+This note isolates one part of project state, not the whole state available to
+an agent. Source code, tests, schemas, configuration, execution traces, and other
+symbolic artifacts also constrain search. The natural-language contribution
+becomes operative when context assembly places it in a prompt; the resulting
+semantic operation is instantiated jointly by that prompt and the model's
+weights. [Code complements the weight–prompt pair with independently executed
+symbolic operations](./code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md).
 
 The relevant evidence is behavioral. Withholding, replacing, or perturbing the
-project state should change branch choices and their later consequences. A
+natural-language state while holding the model, symbolic project state, tools,
+and task fixed should change branch choices and their later consequences. A
 plausible explanation that leaves search unchanged does not establish the
 conjecture.
 
@@ -27,6 +36,10 @@ conjecture.
 
 - This is an empirical conjecture, not a claim that current models already
   allocate open-ended search effectively.
+- A retained natural-language artifact is not automatically a prompt. It joins
+  the weight–prompt operation only when supplied as model input.
+- Showing that code or other project information improves search does not by
+  itself establish the distinctive contribution of theory-level organization.
 - Specializing search heuristics does not give the resulting choices acceptance
   authority.
 
@@ -34,6 +47,7 @@ conjecture.
 
 Relevant Notes:
 
+- [Code complements the weight–prompt pair with independently executed symbolic operations](./code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md) — extends: places the prompt-side specialization beside the independently executed symbolic operation class
 - [Lightweight search control allocates further search without licensing adoption](./lightweight-search-control-allocates-further-search-without-licensing-adoption.md) — grounds: identifies the limited authority of the specialized heuristics
 - [Weight-resident methodologies provide context-efficient behavioral compression](./weight-resident-methodologies-compress-behavior-in-context.md) — grounds: shows how compact language can select a larger behavioral pattern already represented in weights
 - [A capable agent needs methodology selection, not just relevant knowledge](./capable-agents-need-methodology-selection.md) — extends: distinguishes selecting a governing method from merely supplying relevant facts

--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -9,27 +9,28 @@ only after disposition in the [incumbent ledger](./incumbent-ledger.md).
 
 | Module | Job | Essential content | Primary support | Open research contact |
 |---|---|---|---|---|
-| **Research-program hub** | Present one central question and route readers to the evidence and companion arguments | Can fallible project theory keep computational search, backtracking, recovery, and revision coherent across delayed feedback? Commonplace and programming agents as linked testbeds; current computational loop and human selection; truth versus fit; evidence ladder; decisive experiments | [Shared model](./shared-model.md), [target problems](./target-problems.md), [coherent search under delayed feedback](../../notes/holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md), [conversation episode](./computational-theory-guided-conversation-episode-2026-08-30.md) | Rival accounts of coherent modification, counterexamples, external testbeds, and experimental designs |
-| **Bearer question** | Explain why program-specific theory matters and why Naur's argument does not settle that only humans can hold it | Retained theory is not the same as holding it; a holder uses partial theory to organize search and recovery across later demands rather than deducing a perfect change | [Accepted Naur baseline](./accepted/what-bound-naurs-theory-to-programmers.md), [Naur basis note](../../notes/naur-equates-machine-execution-with-formulated-criteria.md), [coherent-search claim](../../notes/holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md) | Rival readings of Naur, interventions separating theory-guided from generic search, and task distributions that expose recovery |
-| **Operative theory** | State what would show that explicit theory participates in operation rather than remaining documentation | Reflective membership; semantic interpretation; addressable retention; independent exposure and read-back; continuation; mediation, empirical contact, theory learning, and recurrence as separate evidence levels | [Interpretation, retention, and independent read-back](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md), [reflection buys addressability](../../notes/reflection-buys-addressability.md) | Better causal interventions, alternative substrates, stronger read-back, and failures of selective rescoping |
-| **Functional architecture** | Explain why current residual decisions require several functions without treating today's carrier boundaries as permanent | Representation, semantic application, verification, and continuity have distinct failure surfaces; the current retained-theory/LLM/runtime/evidence split is one inspectable realization | [Residue classes need different mechanisms](../../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md), [scheduler–LLM asymmetry](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md), [two-layer execution](../../notes/theory-and-methodology-form-a-two-layer-execution-system.md) | Architectures that combine roles, evidence that a role is unnecessary, and interventions on representational boundaries |
-| **Progress, warrant, and closure** | Evaluate movement of the human cut without collapsing structural closure, capability, warrant, usefulness, and power | Conditional adverse selection of residual work; task-scoped structural closure; evaluator adequacy for warranted non-degenerate results; fixed-client limits of the remote-programmer benchmark | [Warranted transfer](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md), [task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Before-and-after transfer studies, evaluator tests, measurement of displaced work, and non-degenerate closure declarations |
-| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the provisional strategy for improving selection machinery | Production method differs from representational form; the current loop already uses computation guided by retained Commonplace knowledge; truth differs from global theory fit; the operator supplies much high-level selection; recurring judgments should become reusable computational machinery; other computational strategies remain live | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [global-fit selection environment](../../notes/when-global-theory-fit-lacks-a-fixed-oracle-use-in-building-the-system-is-an-initial-selection-environment.md), [conditional bootstrap compatibility](../../notes/a-hand-crafted-bootstrap-fits-the-bitter-lesson-only-if-learning-can-outgrow-it.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [conversation episode](./computational-theory-guided-conversation-episode-2026-08-30.md) | Less circular fit tests, compute-scaling tests, conversion of judgment into evaluators, alternative first strategies, cross-domain transfer, and matched baselines |
-| **Prospective experiments** | Turn the central conjecture and bootstrap strategy into results that can change their status | First, matched correct-theory, information-matched, theory-withheld, and wrong-theory conditions over sequential programming demands. Second, instrument whether current computational search improves with more compute and whether recurring global judgments become reusable selection machinery | [Shared-model protocols](./shared-model.md#next-experiments), future preregistrations and results | Independent replication, alternative controls, adversarial task selection, direct-learning baselines, and failure analysis |
+| **Research-program hub** | Present one central question and route readers to the evidence and companion arguments | Can fallible project theory keep computational search, symbolic execution, backtracking, recovery, and revision coherent across delayed feedback? Weight–prompt operations and their code complement; lightweight search control; Commonplace and programming agents as linked testbeds; current human selection; truth versus fit; evidence ladder; decisive experiments | [Shared model](./shared-model.md), [target problems](./target-problems.md), [coherent search under delayed feedback](../../notes/holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md), [operation-level complement](../../notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md), [conversation episode](./computational-theory-guided-conversation-episode-2026-08-30.md) | Rival accounts of coherent modification, alternative operation decompositions, counterexamples, external testbeds, and experimental designs |
+| **Bearer question** | Explain why program-specific theory matters and why Naur's argument does not settle that only humans can hold it | Retained theory is not the same as holding it; a holder uses partial theory to specialize search, coordinate executable changes, and recover across later demands rather than deducing a perfect change | [Accepted Naur baseline](./accepted/what-bound-naurs-theory-to-programmers.md), [Naur basis note](../../notes/naur-equates-machine-execution-with-formulated-criteria.md), [coherent-search claim](../../notes/holding-a-program-theory-means-sustaining-coherent-search-under-delayed-feedback.md), [lightweight search control](../../notes/lightweight-search-control-allocates-further-search-without-licensing-adoption.md) | Rival readings of Naur, interventions separating theory-guided from generic search, and task distributions that expose recovery |
+| **Operative theory** | State what would show that explicit theory participates in operation rather than remaining documentation | Reflective membership; prompt-side mediation with weights and symbolic state held fixed; addressable retention; independent exposure and read-back; continuation; mediation, empirical contact, theory learning, and recurrence as separate evidence levels | [Interpretation, retention, and independent read-back](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md), [natural-language project-state specialization](../../notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md), [reflection buys addressability](../../notes/reflection-buys-addressability.md) | Better causal interventions, information-matched controls, alternative substrates, stronger read-back, and failures of selective rescoping |
+| **Functional architecture** | Explain the complementary operation classes without treating today's boundary as permanent | A model-mediated operation is instantiated by weights plus prompt; code plus runtime supplies independently executed symbolic operations; code may also enter prompts as project evidence; representation, semantic application, exact execution, verification, and continuity retain distinct failure surfaces | [Operation-level complement](../../notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md), [scheduler–LLM asymmetry](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md), [bounded-context orchestration](../../notes/bounded-context-orchestration-model.md), [cross-form boundary movement](../../notes/moving-the-interpretation-enforcement-boundary-requires-coverage.md) | Architectures that combine roles, evidence that independent symbolic execution is unnecessary, and interventions on operation placement |
+| **Progress, warrant, and closure** | Evaluate movement of the human cut without collapsing structural closure, capability, warrant, usefulness, and power | Conditional adverse selection of residual work; staged transfer of branch allocation, reversible symbolic execution, and adoption; task-scoped structural closure; evaluator adequacy for warranted non-degenerate results; fixed-client limits of the remote-programmer benchmark | [Warranted transfer](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md), [task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Before-and-after transfer studies, evaluator tests, measurement of displaced work, and non-degenerate closure declarations |
+| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the provisional strategy for improving the whole operation surface | Production method differs from representational form; prompts specialize weight-resident competence; code can be a computationally produced and selected symbolic complement rather than protected infrastructure; the current loop already uses both operation classes; the operator supplies much high-level selection and boundary judgment; other computational strategies remain live | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [operation-level complement](../../notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md), [global-fit selection environment](../../notes/when-global-theory-fit-lacks-a-fixed-oracle-use-in-building-the-system-is-an-initial-selection-environment.md), [conditional bootstrap compatibility](../../notes/a-hand-crafted-bootstrap-fits-the-bitter-lesson-only-if-learning-can-outgrow-it.md) | Compute-scaling tests, learned code and prompt production, operation-boundary revision, alternative first strategies, cross-domain transfer, and matched baselines |
+| **Prospective experiments** | Turn the central conjecture and bootstrap strategy into results that can change their status | First, matched correct-theory, information-matched, theory-withheld, and wrong-theory conditions with weights and symbolic state fixed. Second, compare model-mediated bookkeeping, generated or selected code, and a hybrid. Third, instrument whether later evidence changes branch allocation, code, or the boundary between them | [Shared-model protocols](./shared-model.md#next-experiments), future preregistrations and results | Independent replication, alternative controls, adversarial task selection, direct-learning baselines, and failure analysis |
 
 ## Composition
 
 The modules do not imply an article per row. The current minimum public surface
 is:
 
-1. **A compact program hub** carrying the central question, current computational
-   loop, architecture, truth-versus-fit distinction, evidence ladder, testbeds,
-   and experiments.
+1. **A compact program hub** carrying the central question, complementary
+   operation classes, lightweight search control, current computational loop,
+   truth-versus-fit distinction, evidence ladder, testbeds, and experiments.
 2. **The Naur article** carrying the bearer argument and the shift from one-shot
-   correctness to coherent search and recovery.
+   correctness to coherent search, executable modification, and recovery.
 3. **The Bitter Lesson article** carrying the narrow form-only rebuttal, the
-   already-computational human-agent loop, the high-level selection bottleneck,
-   alternatives, and failure conditions.
+   already-computational human-agent loop, the prompt/code learning surface,
+   high-level selection and operation-boundary bottlenecks, alternatives, and
+   failure conditions.
 4. **Experimental protocols and later results**, published as articles only when
    the evidence has enough substance to warrant them.
 
@@ -48,9 +49,20 @@ then it is a general layer supporting the programming and reflective cases.
 
 - Coherent modification is the center. Warranted transfer and computational
   closure describe the boundary and evaluation problem around it.
+- A prompt does not define an LLM operation alone. Relative to fixed call
+  settings, the model-mediated operation is instantiated by weights plus prompt.
+- Code complements the weight–prompt operation with runtime-assigned symbolic
+  operations that can execute without model reinterpretation, even when the
+  model generated or selected the code.
+- Code can also be read into a prompt as project evidence. Distinguish that
+  model-mediated consumption path from import, execution, testing, or validation
+  by a symbolic runtime.
 - Human theory-holders use partial, fallible theories to guide search,
-  diagnosis, backtracking, and recovery. The computational comparison is not a
-  demand for a correct first proposal.
+  diagnosis, backtracking, executable change, and recovery. The computational
+  comparison is not a demand for a correct first proposal.
+- Lightweight search control may allocate branches and probes under weaker
+  evidence than final adoption requires. Backtracking must keep those choices
+  provisional.
 - Distinguish mediation, empirical contact, theory-state revision, and recurrent
   later use. Report the strongest link established; do not redefine every
   useful theory-guided change as the full recurrent loop.
@@ -59,9 +71,11 @@ then it is a general layer supporting the programming and reflective cases.
 - Claim truth is not claim fit. System-building consequences can test causal
   usefulness and integration, but they cannot replace factual, formal, or scope
   evidence.
-- The architecture is functionally mixed. The current natural-language,
-  parametric, symbolic, and evidential carriers are provisional and may be
-  combined, absorbed, or replaced.
+- Symbolic exactness is relative to the implemented transition. It does not
+  validate the requirement, decomposition, or objective that selected the code.
+- The current natural-language, parametric, symbolic, and evidential carriers
+  are provisional. The allocation between model-mediated and symbolic
+  operations may be combined, moved, absorbed, or replaced.
 - The adverse-selection claim is conditional. Cross-sectional evaluator gaps
   are consistent with it, not a direct test of before-and-after residual
   enrichment.
@@ -74,18 +88,18 @@ then it is a general layer supporting the programming and reflective cases.
 - Only the form-only inference is rebutted under the Bitter Lesson. The
   theory-guided bootstrap is a first strategy under incomplete global
   evaluation, not a defense or a uniqueness claim.
-- The current Commonplace loop already uses computation for retrieval,
-  interpretation, search, synthesis, criticism, editing, testing, and retention.
-  The present bottleneck is high-level selection and credit assignment, not the
-  absence of computation.
-- The first strategy must measure whether more computation improves useful
-  search, make residual human fit judgments explicit, and convert recurring
-  judgments into tests, validators, learned critics, search objectives,
-  methods, schemas, or code.
+- The current Commonplace loop already uses weight–prompt operations for
+  retrieval, interpretation, search, synthesis, and criticism, and symbolic
+  operations for repository changes, testing, validation, scheduling, and
+  retention. The bottleneck is not the absence of computation.
+- The first strategy must measure whether more computation improves downstream
+  search quality, whether code earns its placement after specification and
+  maintenance costs, and whether recurring human judgments become reusable
+  search, selection, or boundary-setting machinery.
 - The recorded conversation supports mediation, theory revision, and recurrence
   at the human-inclusive boundary. It does not establish independent
   computational recurrence, closure over acceptance, scalable domain-extensible
-  artifact learning, or superiority to direct computational alternatives.
+  cross-form learning, or superiority to direct computational alternatives.
 
 ## Cross-module questions
 
@@ -95,17 +109,24 @@ The articles should expose rather than bury these questions:
    information-rich record or a plausible post-hoc citation?
 2. Which task distribution and horizon expose coherent recovery rather than
    generic search, memorization, or luck?
-3. How can delayed consequences assign credit to a theory, candidate, artifact
-   boundary, or production rule?
-4. Which parts of global theory fit can be operationalized without encoding the
+3. Does project theory change branch allocation when weights, code, tools, and
+   task are held fixed?
+4. When does independently executed code improve reliability, cost, and recovery
+   after specification, integration, validation, and maintenance are counted?
+5. Which operations should remain model-mediated, which should be codified, and
+   what evidence should trigger relaxing?
+6. How can delayed consequences assign credit among theory, prompt construction,
+   target code, control code, tests, and the operation boundary?
+7. Which parts of global theory fit can be operationalized without encoding the
    present theory into the evaluator?
-5. Does increasing inference-time computation improve theory-guided search, or
+8. Does increasing inference-time computation improve theory-guided search, or
    only increase candidate volume?
-6. Which recurring human judgments should become selection machinery first?
-7. What direct computational approach provides the strongest alternative first
-   strategy?
-8. What cross-domain sequence distinguishes a domain-extensible learning path
-   from a broad but fixed ontology?
+9. Which recurring human judgments should become lightweight search controls,
+   and which have enough warrant to become acceptance machinery?
+10. What direct computational approach provides the strongest alternative first
+    strategy?
+11. What cross-domain sequence distinguishes a domain-extensible learning path
+    from a broad but fixed ontology and operation allocation?
 
 These are invitations to criticism, independent testing, rival mechanisms, and
 new evidence. They are not assigned research roles.

--- a/kb/work/theory-mediated-self-improvement-series/shared-model.md
+++ b/kb/work/theory-mediated-self-improvement-series/shared-model.md
@@ -34,30 +34,134 @@ correctness, retrieval, credit assignment, evaluation, or continuity by itself,
 [because reflection buys addressability rather than those downstream
 capacities](../../notes/reflection-buys-addressability.md).
 
+## Complementary operation classes
+
+The programme distinguishes two operation classes inside the deployed system.
+
+A **model-mediated operation** is instantiated jointly by a model's weights and
+the prompt supplied for one call. The weights provide broad learned competence
+and general search heuristics. The prompt supplies the selected task, project
+state, intent, evidence, and constraints that specialize that competence.
+Neither component defines the operation alone.
+
+A **symbolic operation** is defined by code relative to a runtime. Once selected
+and installed, its consequences can be executed without asking the model to
+reinterpret the prompt or reconstruct the operation on every use. A model may
+generate, select, explain, or revise the code; independent symbolic execution is
+an execution property, not an authorship claim.
+
+```text
+model-mediated operation:  weights + prompt  -> interpreted, generally stochastic behavior
+symbolic operation:        code + runtime    -> runtime-assigned state transition
+```
+
+The relation is therefore not prompt versus code. Prompts complement weights by
+specializing learned competence. Code complements the resulting weight–prompt
+operation with exact state transitions, persistent bookkeeping, repeatable
+procedures, and enforceable checks. The atomic claim is
+[code complements the weight–prompt pair with independently executed symbolic
+operations](../../notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md).
+
+The project state available to the composite is mixed-form. A useful abstraction
+is:
+
+```text
+K_t = (N_t, S_t, E_t)
+```
+
+where `N_t` is retained natural-language state such as theory, intent, rationale,
+branch history, and scope; `S_t` is retained symbolic state such as target code,
+harness code, tests, schemas, configuration, dependency structure, checkpoints,
+and scheduler state; and `E_t` is observed evidence such as traces, test
+results, later demands, reviews, and operational outcomes.
+
+Context assembly selects a call-specific view of this state into a prompt. The
+model then applies weight-resident competence to that view. The
+[natural-language part of project state may specialize weight-resident search
+heuristics](../../notes/natural-language-project-state-may-specialize-weight-resident-search-heuristics.md),
+while code and other symbolic artifacts also constrain the search and can later
+execute its selected results independently.
+
+Code has two consumption paths. When read in a prompt, it is evidence for a
+model-mediated operation. When imported, executed, tested, or used as a
+validator, it has symbolic force assigned by the runtime. The same artifact can
+therefore be both an object of semantic search and an independently executed
+part of the resulting system.
+
+## Search control before decisive evaluation
+
+Open-ended improvement must allocate attention and computation before the
+strongest evidence about a branch exists. An evaluator cannot assess a useful
+candidate, proof, or experiment that search never develops. Even proof-gated
+self-modification retains a prior allocation problem, because the initial search
+must reach a proof path before the gate can act. See
+[open-ended improvement must allocate search before decisive evaluation is
+available](../../notes/open-ended-improvement-must-allocate-search-before-decisive-evaluation-is-available.md).
+
+The programme calls a judgment **lightweight search control** when its authority
+stops at allocating further work. It may select a branch, probe, continuation,
+suspension, or abandonment without licensing an operative change. This permits
+weaker and provisional evidence to guide search while stronger evaluation
+remains downstream. [Lightweight search control allocates further search without
+licensing adoption](../../notes/lightweight-search-control-allocates-further-search-without-licensing-adoption.md).
+
+The weight–prompt pair is one candidate implementation of this controller. The
+weights may contain general heuristics for anomaly detection, alternative
+generation, probe selection, persistence, and recovery. The prompt supplies the
+project-specific theory, intent, code state, branch history, and constraints
+needed to apply those heuristics here. Code can then enforce budgets, retain
+checkpoints, execute probes, run tests, and preserve return paths.
+
+Backtracking is part of the control architecture, not evidence that the theory
+was absent. It keeps a fallible branch choice provisional by restoring an earlier
+usable state and redirecting search when contrary evidence arrives. See
+[backtracking keeps lightweight search control provisional](../../notes/backtracking-keeps-lightweight-search-control-provisional.md).
+
+A controller is evaluated by the distribution of consequences produced by its
+routing decisions: valuable candidates, discriminating evidence, informative
+failures, and improved recovery under matched tasks and resources. It is not
+evaluated by treating each provisional branch judgment as an acceptance claim.
+See [a search controller is tested by what it brings to stronger
+evaluation](../../notes/a-search-controller-is-tested-by-what-it-brings-to-stronger-evaluation.md).
+
+Learning from a failure requires more than a persuasive explanation. The
+retained explanation must change a later branch decision about scope, priority,
+probing, continuation, or abandonment. Otherwise it remains commentary rather
+than operative search control. See
+[a failure explanation becomes search control only when it changes a later
+branch decision](../../notes/a-failure-explanation-becomes-search-control-only-when-it-changes-a-later-branch-decision.md).
+
 ## Functional architecture
 
-The current research architecture uses several representational forms because
-they make different roles inspectable:
+The current architecture keeps several functions distinguishable because they
+have different failure surfaces:
 
 | Functional role | Current realization | Characteristic failure |
 |---|---|---|
-| Project-specific representation | Retained natural-language and symbolic artifacts carrying premises, objectives, explanations, commitments, and scope | Omission, contradiction, drift, retrieval failure, inert documentation |
-| Semantic interpretation and theory-guided search | A language model that applies theory, proposes changes, criticizes candidates, diagnoses failure, and helps recover | Underspecification, stochastic deviation, bias, post-hoc rationale, theory ignored in practice |
-| Exact execution and continuity | Code and a symbolic runtime carrying state, scheduling, validation, installation, rollback, and later reactivation | Faithful execution of the wrong transition; frozen decomposition; truncated horizon |
-| Independent exposure and read-back | Tests, validators, held-out tasks, decorrelated criticism, later demands, and operational consequences | Weak proxies, captured evaluation, viability-only gates, incomplete coverage, delayed credit assignment |
+| Retained project state | Natural-language theory, intent, rationale, and history together with code, tests, schemas, configuration, checkpoints, and evidence records | Omission, contradiction, drift, stale mappings, retrieval failure, or an incomplete symbolic snapshot |
+| Model-mediated semantic operation | Model weights plus a call-specific prompt assembled from relevant project state | Underspecification, stochastic deviation, bias, post-hoc rationale, or project theory ignored in practice |
+| Independently executed symbolic operation | Code plus a runtime carrying exact transitions, scheduling, validation, installation, rollback, and later reactivation | Faithful execution of the wrong transition, frozen decomposition, incomplete coverage, or truncated horizon |
+| Independent exposure and read-back | Tests, validators, held-out tasks, decorrelated criticism, later demands, reviews, and operational consequences | Weak proxies, captured evaluation, viability-only gates, incomplete coverage, or delayed credit assignment |
 
-These roles are distinct because evidence for one does not establish the others.
-The architecture need not preserve their current carrier boundaries forever.
-[Each residue class needs a different function](../../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md),
+These functions are distinct because evidence for one does not establish the
+others. The architecture need not preserve their current carrier boundaries
+forever. [Each residue class needs a different function](../../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md),
 but one learned substrate may eventually host several functions. The current
-mixed-form arrangement is a provisional, intervention-friendly realization.
+split is a provisional, intervention-friendly realization.
+
+The [scheduler–LLM separation exploits an error-correction
+asymmetry](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md):
+operations with adequately specified transitions can avoid repeated model
+interpretation, while semantic work remains model-mediated. This does not make
+code authoritative about the objective. A symbolic runtime can execute the
+wrong requirement exactly.
 
 ## Evidence ladder for theory-mediated improvement
 
 The workshop distinguishes four increasingly strong claims:
 
-1. **Mediation.** The retained theory changes a proposal, evaluation, diagnosis,
-   recovery step, or realized intervention.
+1. **Mediation.** The retained theory changes a proposal, branch allocation,
+   evaluation, diagnosis, recovery step, or realized intervention.
 2. **Empirical contact.** The intervention produces an outcome that bears on the
    theory rather than merely accompanying it.
 3. **Theory learning.** The outcome changes the theory's content, scope,
@@ -68,25 +172,28 @@ The workshop distinguishes four increasingly strong claims:
 
 The strongest recurrent path is:
 
-    retained theory
-      -> theory-guided decision or search
-      -> realized change
-      -> independent or delayed consequence
-      -> read-back against the same theory state
-      -> retained theory-state revision
-      -> changed later operation
+```text
+retained mixed-form project state
+  -> theory-guided weight–prompt search
+  -> model-mediated and/or symbolic change
+  -> independent or delayed consequence
+  -> read-back against the same theory and code state
+  -> retained theory, code, or boundary revision
+  -> changed later search or execution
+```
 
-The path must be causally co-indexed: provenance must identify which theory state
-guided the change and which later state received the outcome. Co-occurrence of a
-theory, a successful change, and an unrelated revision inside one boundary is
-insufficient. The full distinction is stated in
+The path must be causally co-indexed: provenance must identify which theory and
+symbolic state guided the change and which later state received the outcome.
+Co-occurrence of a theory, successful code change, and unrelated revision inside
+one boundary is insufficient. The full distinction is stated in
 [theory-mediated self-improvement needs interpretation, retention, and
 independent read-back on one path](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md).
 
 A contemporaneous citation at the decision point is a cheap
 [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md).
-Withholding, replacing, or perturbing the theory and observing a changed
-decision is stronger evidence that the use was load-bearing.
+Withholding, replacing, or perturbing the theory while holding weights, symbolic
+state, tools, and task fixed is stronger evidence that the theory was
+load-bearing.
 
 A useful theory-guided change can reach mediation or empirical contact without
 reaching recurrence. The record should state the strongest level established
@@ -100,7 +207,8 @@ collapsed.
 - **Truth, validity, or warranted scope:** does the claim survive empirical,
   formal, source, consistency, or bounded predictive checks?
 - **Fit in the working theory:** does the claim belong in the larger causal
-  account and improve proposal, diagnosis, recovery, revision, or transfer?
+  account and improve proposal, search allocation, diagnosis, recovery,
+  revision, or transfer?
 
 A true claim can be irrelevant, redundant, badly scoped, or placed at the wrong
 abstraction level. A false claim can appear useful because the current system
@@ -108,9 +216,10 @@ already embodies it. Local truth tests therefore do not fully select a working
 theory.
 
 No current fixed evaluator fully decides global theory fit. Fit is exposed by a
-distributed and delayed portfolio of consequences: changes to decisions,
-predictions, later demands, repair cost, theory interventions, rival
-formulations, and transfer. The live system under construction is therefore an
+distributed and delayed portfolio of consequences: changed branch choices,
+predictions, later demands, repair cost, code behavior, theory interventions,
+rival formulations, and transfer. The live system under construction is
+therefore an
 [initial selection environment](../../notes/when-global-theory-fit-lacks-a-fixed-oracle-use-in-building-the-system-is-an-initial-selection-environment.md).
 
 System use cannot replace independent truth tests. It can become self-sealing.
@@ -121,15 +230,16 @@ fit evidence distinct from factual or formal warrant.
 ## The present loop is already computational
 
 Commonplace should not be described as handcrafting a theory before computation
-begins. In a typical episode, a language model retrieves multiple retained
-artifacts, interprets their claims and constraints, searches and synthesizes
-candidate formulations or changes, criticizes alternatives, uses tools to check
-local consequences, and writes accepted revisions back into the knowledge base.
-Those revisions then condition later model calls.
+begins. In a typical episode, a language model retrieves retained artifacts,
+interprets their claims and constraints, reads relevant code and tests, searches
+and synthesizes candidate formulations or changes, criticizes alternatives, and
+uses tools for local checks. Symbolic code carries repository operations,
+validation, exact bookkeeping, and retention. Accepted changes to natural
+language or code then condition later model calls and executions.
 
 The operator currently supplies much of the sparse high-level selection signal
 about global fit, blame, scope, and acceptance. At the boundary that includes the
-operator, model, knowledge base, and tools, the process is already a
+operator, model, knowledge base, code, and tools, the process is already a
 human-inclusive computational theory-mediated learning loop. At a boundary that
 excludes the operator, global selection and final acceptance remain exogenous.
 
@@ -137,11 +247,12 @@ The
 [2026-08-30 workshop conversation](./computational-theory-guided-conversation-episode-2026-08-30.md)
 records a concrete instance:
 
-1. retained Commonplace artifacts and repository state were read;
+1. retained Commonplace artifacts, code, and repository state were read;
 2. computational synthesis produced a review, candidate distinctions,
    experiments, and repository changes;
 3. the operator supplied corrections about the Bitter Lesson framing;
-4. the theory and artifacts were revised and retained; and
+4. natural-language theory and programme artifacts were revised and retained;
+   and
 5. the revised state guided later work.
 
 This supports mediation, theory-state revision, and recurrence at the
@@ -149,10 +260,10 @@ human-inclusive boundary. It does not establish how load-bearing each artifact
 was without an ablation, whether the revised claims are independently true, or
 whether more computation scales better than the alternatives.
 
-The open engineering problem is therefore not how to introduce computation. It
-is how to improve the computational search already present and how to convert
-recurring operator judgments into reusable selection and credit-assignment
-machinery.
+The open engineering problem is not how to introduce computation. It is how to
+improve the computational search already present, use symbolic operations where
+independent execution helps, and convert recurring operator judgments into
+reusable search, selection, and credit-assignment machinery.
 
 ## Coherent modification and warranted transfer
 
@@ -164,7 +275,7 @@ must carry search and recovery until later evidence arrives.
 The two problems still ask different questions:
 
 - **Coherent modification:** can the composite use project theory to sustain
-  program-specific search, diagnosis, backtracking, and revision?
+  program-specific search, diagnosis, backtracking, execution, and revision?
 - **Warranted transfer:** are the premises, authority, correction, and continuity
   needed for that process inside the declared boundary strongly enough that the
   decision can leave the human cut with warrant?
@@ -178,10 +289,10 @@ test needs before-and-after transfer histories.
 
 An evaluator is necessary for correction but does not replace theory-guided
 search or credit assignment. A strong oracle can reject a bad candidate without
-identifying which premise, theory, artifact boundary, or production method
-should change. The program therefore studies both sides: theory organizes and
-interprets search; consequences correct the theory and the changes made through
-it.
+identifying which premise, theory, code unit, artifact boundary, or production
+method should change. The programme therefore studies both sides: theory
+organizes and interprets search; symbolic operations carry exact transitions;
+and consequences correct both the theory and the changes made through it.
 
 ## Closure, capability, warrant, and power
 
@@ -216,21 +327,28 @@ different axes. That does not defend the present hand-crafted artifacts.
 
 Theory-guided bootstrapping is the first strategy being tried under incomplete
 global evaluation. It uses the already-computational Commonplace loop as a live
-environment in which retained theory guides search, claims make causal
-differences, and delayed consequences can expose poor fit.
+environment in which retained theory guides weight–prompt search, code executes
+selected symbolic operations, and delayed consequences can expose poor fit in
+either.
 
-The strategy should improve the use of computation along two fronts:
+The strategy should improve the use of computation along three connected
+surfaces:
 
-- **Search:** better retrieval, rival generation, criticism, decomposition
-  search, evidence and counterexample search, experiment design, ablation, trace
-  analysis, and bounded artifact optimization.
-- **Selection:** progressively turn recurring operator judgments into
-  methodologies, tests, validators, learned critics, search objectives, episode
-  schemas, or programs.
+- **Model-mediated search:** better retrieval, prompt construction, rival
+  generation, criticism, decomposition search, evidence and counterexample
+  search, experiment design, and diagnosis.
+- **Symbolic operation:** better target code, schedulers, tools, tests,
+  validators, schemas, checkpoints, and deterministic transformations.
+- **Boundary and selection:** progressively decide which behavior should remain
+  model-mediated, which should be codified, which code should be relaxed, and
+  which recurring operator judgments should become reusable search controls,
+  critics, tests, methods, or programs.
 
-The distinction is not computation versus no computation. It is computational
-search with human-assisted high-level selection versus a process whose search,
-selection, and credit assignment are increasingly reusable and computational.
+The distinction is not computation versus no computation. It is a current
+composition of computational weight–prompt operations, symbolic operations, and
+human-assisted high-level selection versus a process whose search, operation
+allocation, selection, and credit assignment become increasingly reusable and
+computational.
 
 [A hand-crafted bootstrap fits the Bitter Lesson only if learning can outgrow
 it](../../notes/a-hand-crafted-bootstrap-fits-the-bitter-lesson-only-if-learning-can-outgrow-it.md).
@@ -239,23 +357,26 @@ claim. End-to-end learning, evolutionary search, self-play, weight updates, and
 other direct computational methods remain live alternatives.
 
 The long-run challenge is domain-extensibility. The process must eventually
-construct the project-specific theory, representations, methods, and checks
-needed for domains not enumerated by the designers; reduce the marginal human
-share of fit assessment, evaluator construction, and repair; and permit
-consequential parts of its own decomposition and update machinery to be
-challenged.
+construct the project-specific theory, prompts, code, methods, and checks needed
+for domains not enumerated by the designers; reduce the marginal human share of
+fit assessment, evaluator construction, and repair; and permit consequential
+parts of its own decomposition and operation boundary to be challenged.
 
-No carrier receives permanent protection. Natural-language theory, symbolic
-machinery, and current evaluators may be absorbed or replaced. The strategy
-succeeds when increasing computation improves the production and selection path
-at competitive total cost, not when today's files survive.
+No carrier or operation allocation receives permanent protection. Natural-language
+theory, prompts, code, symbolic machinery, and current evaluators may be revised,
+absorbed, or replaced. The strategy succeeds when increasing computation
+improves the production and selection path at competitive total cost, not when
+today's files or boundaries survive.
 
 ## Current testbeds
 
 Commonplace is a human-inclusive reflective testbed. It retains and routes
-project theory, supports criticism and revision, and can turn some theory into
-operative instructions, validators, schemas, and code. The model already carries
-substantial retrieval, interpretation, synthesis, criticism, and editing work.
+project theory, reads and changes code, supports criticism and revision, and can
+turn some theory or recurring behavior into operative instructions, validators,
+schemas, and programs. The model carries substantial retrieval, interpretation,
+synthesis, criticism, and editing work; code carries exact repository
+operations, validation, scheduling, and retained behavior.
+
 Humans still choose objectives, supply unrecorded premises, judge much global
 fit, assign blame, authorize consequential changes, interpret ambiguous
 evidence, and repair paths beyond represented coverage.
@@ -263,22 +384,23 @@ evidence, and repair paths beyond represented coverage.
 Programming agents with persistent project-specific theory are the first
 demanding external testbed. They isolate the bearer question without requiring
 the target program to be the agent itself. Commonplace then provides the
-reflective environment in which the same mechanism can be applied to parts of
-the system's own operation.
+reflective environment in which the same mechanism can be applied to the
+system's own prompts, code, tests, schemas, and operation boundary.
 
 Current evidence supports useful human-agent theory work, computationally guided
-search, inspectable mechanism traces, and an initial environment for testing the
-strategy. It does not establish independent computational theory possession,
-computational closure over selection, domain-extensible artifact learning, or
-superiority to more direct computational approaches.
+search, independently executed symbolic operations, inspectable mechanism
+traces, and an initial environment for testing the strategy. It does not
+establish independent computational theory possession, computational closure
+over selection, domain-extensible cross-form learning, or superiority to more
+direct computational approaches.
 
 ## Next experiments
 
 ### Theory intervention
 
 Test whether prepared project theory is load-bearing on sequential program
-modifications. Use the same model, tools, repository state, budget, and
-acceptance process under matched conditions:
+modifications. Hold the model weights, target code, control code, tests, runtime,
+tools, repository state, budget, and acceptance process fixed while varying:
 
 1. correct project theory;
 2. an information-matched record without synthesized theory-level organization;
@@ -287,40 +409,66 @@ acceptance process under matched conditions:
 
 Each sequence should contain an initial modification and a later demand or
 delayed test that exposes whether the first change preserved the program's
-organization. Measure candidate generation, architectural preservation,
-backtracking, diagnosis, recovery, collateral regressions, later-demand
-performance, human intervention, and whether outcome read-back changes a later
-episode.
+organization. Record the live or sampled branches, which branch received more
+computation, which retained claim or intent controlled that allocation, and what
+stronger evaluation the branch reached. Measure candidate generation,
+architectural preservation, backtracking, diagnosis, recovery, collateral
+regressions, later-demand performance, human intervention, and whether outcome
+read-back changes a later branch decision.
 
-The diagnostic prediction is an interaction: correct theory should help when
-the later shift preserves the structure it names; wrong theory should cause
-predictable negative transfer; theory withholding should especially damage
-recovery and follow-on coherence; and the advantage should shrink where a
-complete specification and cheap oracle already settle the task.
+The diagnostic prediction is an interaction: correct theory should route a
+fixed budget toward better downstream evidence and outcomes when the later shift
+preserves the structure it names; wrong theory should cause predictable negative
+transfer; theory withholding should especially damage recovery and follow-on
+coherence; and the advantage should shrink where a complete specification and
+cheap oracle already settle the task.
 
-### Selection-environment bootstrap
+### Symbolic-complement intervention
+
+Test when independently executed code improves a weight–prompt operation. Hold
+the model, task, objective, and semantic policy as fixed as the comparison
+allows, and compare:
+
+1. model-mediated control flow and bookkeeping retained in context;
+2. model-generated or model-selected code that performs those operations under
+   a symbolic runtime; and
+3. a hybrid in which code owns exact state and transitions while the model owns
+   semantic branch judgments.
+
+Measure task success, accumulated execution errors, context use, latency, cost,
+state continuity, backtracking reliability, debugging effort, and collateral
+failures. The comparison should also record specification and maintenance costs:
+code may execute exactly while encoding the wrong operation.
+
+### Search-control and operation-boundary bootstrap
 
 Instrument a sequence of real Commonplace improvements. For each consequential
-claim or method, record:
+branch, claim, or method, record:
 
-1. which retained artifacts guided the model's search;
-2. which candidates, comparisons, and local checks were computational;
-3. which judgment of global fit or credit remained human and why;
-4. which downstream system consequences bore on that judgment;
-5. whether rival or ablated claims changed the result;
-6. whether a recurring judgment became a test, validator, critic, method,
-   schema, or program;
-7. whether additional computation improved the result; and
-8. how the marginal human and computational shares changed on a later episode.
+1. which natural-language and symbolic artifacts entered project state and the
+   prompt;
+2. which model-mediated candidates, comparisons, and judgments were produced;
+3. which symbolic operations executed probes, checks, state transitions, and
+   retention;
+4. which judgment of global fit, credit, or operation placement remained human
+   and why;
+5. which downstream consequences bore on that judgment;
+6. whether rival or ablated theories, prompts, or code changed the result;
+7. whether a recurring judgment became a lightweight search control, test,
+   validator, critic, method, schema, or program;
+8. whether an operation moved between model-mediated and symbolic execution;
+9. whether additional computation improved the result; and
+10. how the marginal human and computational shares changed on a later episode.
 
 This is a nearer test of the bootstrap strategy than demanding immediate
-cross-domain autonomy. It can show whether computational search and selection
-are improving or whether "bootstrap" merely renames continued bespoke human
-correction.
+cross-domain autonomy. It can show whether computational search, symbolic
+execution, and selection are improving or whether "bootstrap" merely renames
+continued bespoke human correction.
 
 A later cross-domain test should compare this process with direct computational
-baselines and ask whether it constructs new theory and evaluation machinery
-without a bespoke human-built ontology for each domain.
+baselines and ask whether it constructs new theory, prompts, code, and evaluation
+machinery without a bespoke human-built ontology and operation allocation for
+each domain.
 
 ## Minimum episode record
 
@@ -328,43 +476,57 @@ A useful episode record should identify:
 
 1. the selected task, objective, boundary, horizon, resources, and starting
    human cut;
-2. the retained artifacts read and the theory state claimed to guide the work;
-3. which retrieval, search, synthesis, criticism, testing, and editing operations
-   were computational;
-4. evidence for the truth, validity, or scope of the claims used;
-5. which high-level selection and credit judgments came from the operator;
-6. the realized change and acceptance mechanism;
-7. the independent or delayed outcome and its read-back against the theory;
-8. any theory-state or machinery revision, including rejection, rescoping,
-   changed confidence, explicit retention, or deferral;
-9. whether the revision changed a later operation;
-10. whether a recurring human judgment became reusable selection machinery; and
-11. which dimension moved and which decisions remain human.
+2. the retained natural-language, symbolic, and evidential project state;
+3. the prompt assembled for each consequential model call and the theory state
+   claimed to guide it;
+4. which operations were model-mediated and which were independently symbolic;
+5. which live branches were considered and what controlled their allocation;
+6. evidence for the truth, validity, or scope of the claims used;
+7. which high-level selection, credit, and operation-placement judgments came
+   from the operator;
+8. the realized theory, prompt, code, test, schema, or runtime change and its
+   acceptance mechanism;
+9. the independent or delayed outcome and its read-back against the same theory
+   and symbolic state;
+10. any theory, code, or operation-boundary revision, including rejection,
+    rescoping, rollback, codification, relaxing, or deferral;
+11. whether the revision changed a later branch decision or execution;
+12. whether a recurring human judgment became reusable search or selection
+    machinery; and
+13. which dimension moved and which decisions remain human.
 
 The record should state the strongest evidence level reached. Without a
-same-theory trace, it may show a useful change but not theory mediation. Without
-later use, it may show theory learning but not recurrence. Without an
-intervention, it cannot quantify how load-bearing the retained theory was.
-Without growth in selection machinery or better results from additional
-computation, it does not support the scaling strategy.
+same-theory and same-state trace, it may show a useful change but not theory
+mediation. Without later use, it may show theory learning but not recurrence.
+Without an intervention, it cannot quantify how load-bearing retained theory
+was. Without better downstream results from changed branch allocation, it does
+not support the search-controller claim. Without growth in reusable selection
+machinery or better results from additional computation, it does not support the
+scaling strategy.
 
 ## Open questions
 
 - What task distribution and horizon distinguish coherent theory-guided search
   from luck, memorization, or generic search with a permissive evaluator?
-- Can project theory improve sample efficiency, recovery, or revision cost after
+- Can project theory improve search allocation, recovery, or revision cost after
   accounting for retrieval, maintenance, and evaluation?
-- How much does retained Commonplace knowledge change LLM search relative to an
-  information-matched record?
+- How much does retained natural-language theory change weight–prompt search
+  relative to the same code and an information-matched record?
+- Which code should be read as project evidence, and which symbolic state can be
+  summarized without losing the constraints that matter?
+- Which operations should remain model-mediated, which should be codified, and
+  what evidence should trigger relaxing in the reverse direction?
+- Does independently executed code improve reliability and cost after counting
+  specification, integration, validation, and maintenance work?
 - Which parts of global theory fit can be operationalized without encoding the
   present theory into the evaluator?
-- How can delayed consequences receive credit when several changes and theory
-  revisions intervene?
-- Which recurring human judgments should be converted first into tests,
-  validators, learned critics, search objectives, or episode schemas?
-- How should inference-time compute, tool use, human correction, and retained
-  artifacts be accounted for in an end-to-end comparison?
+- How can delayed consequences assign credit among theory, prompt construction,
+  target code, control code, tests, and the operation boundary?
+- Which recurring human judgments should first become lightweight search
+  controls rather than acceptance gates?
+- How should inference-time compute, symbolic execution, human correction, and
+  retained artifacts be accounted for in an end-to-end comparison?
 - What direct computational baseline provides the strongest alternative first
   strategy?
-- What cross-domain sequence would demonstrate domain-extensibility rather than
-  a broad but fixed ontology?
+- What cross-domain sequence would demonstrate domain-extensible coevolution
+  rather than a broad but fixed ontology and operation allocation?

--- a/kb/work/theory-mediated-self-improvement-series/target-problems.md
+++ b/kb/work/theory-mediated-self-improvement-series/target-problems.md
@@ -8,64 +8,92 @@ problem and what each match licenses.
 
 | ID | Problem | Optimization target | Feedback | Information structure | Characteristic failure |
 |---|---|---|---|---|---|
-| P1 | **Coherent modification.** Can a computational composite use a fallible, project-specific theory to keep search, backtracking, recovery, and revision coherent across novel programming demands and delayed feedback? | Changes that preserve or deliberately revise the program's purpose and organization across a sequence of demands | Immediate checks, later requirements, maintenance failures, operational outcomes, and recovery quality | The theory is partial; some premises are unrecorded; no local rule uniquely determines the right change | A locally successful patch damages the wider organization, or the process cannot diagnose and recover when delayed evidence exposes the damage |
-| P2 | **Warranted transfer.** On a declared path, how does a decision leave the human cut with warrant, and how does the composition of the remaining work change? | Fewer required human decisions at fixed or better warrant and utility | Before-and-after classification of transferred and residual decisions; later outcome evidence | Transfer may preferentially select decisions with represented premises, settled criteria, and checkable outcomes | Apparent transfer through a captured evaluator, viability-only gate, boundary export, displaced review, or degraded residual judgment |
-| P3 | **Operative theory.** How does retained theory causally guide a proposal, diagnosis, evaluation, or recovery step; receive outcome read-back; and affect later operation? | Increasingly strong evidence from mediation through recurrence | Theory interventions, mediation traces, independent consequences, theory-state revisions, and later use | Retention, interpretation, evaluation, and continuity are distinct functions that may be supplied by different substrates | Inert documentation, post-hoc rationale, self-sealing evaluation, wholesale replacement without traceable revision, or disconnected witnesses inside one boundary |
-| P4 | **Evaluation and comparison.** How are usefulness, computational autonomy, warrant, and power compared without collapsing them into one scalar? | Measurements that detect a real change in the human cut, accepted outcomes, correction quality, and total human effort | Declared task selection, capability floors, evaluator tests, outcome records, and residual-decision records | Functions differ in stakes and grain; hours confound allocation with ambition; closure is structural while warrant is evidential | Percentages of autonomy, activity counts, self-scored prose, or an evaluator treated as the definition of closure |
-| P5 | **Selection-environment bootstrapping.** Can an already-computational theory-guided human-agent loop improve its search through retained project knowledge, use downstream consequences and sparse human feedback for provisional judgments of global theory fit, and convert recurring judgments into reusable computational selection and credit-assignment machinery? | Better useful search from additional computation, a growing computational selection surface, falling marginal human judgment per accepted improvement, transfer beyond anticipated domains, and competitive total cost | Truth and validity checks, theory interventions, rival formulations, operator corrections, delayed system consequences, evaluator conversions, cross-domain transfer, and direct-learning baselines | The model already performs retrieval, interpretation, synthesis, criticism, and editing, while global fit and credit remain relational, distributed, delayed, and substantially selected by the operator | Computation produces more candidates without improving search; retained knowledge makes no causal difference; human fit judgments do not fall; every domain needs a bespoke ontology and evaluator; or a more direct method performs better |
+| P1 | **Coherent modification.** Can a computational composite use a fallible, project-specific theory to keep model-mediated search, independently executed symbolic operations, backtracking, recovery, and revision coherent across novel programming demands and delayed feedback? | Changes that preserve or deliberately revise the program's purpose and organization across a sequence of demands | Branch choices, immediate checks, later requirements, code execution, maintenance failures, operational outcomes, and recovery quality | The model-mediated operation is instantiated by weights plus a prompt assembled from mixed project state; code supplies runtime-assigned operations; the theory is partial and no local rule uniquely determines the right change | Weight–prompt search and symbolic execution drift apart; a locally successful patch damages the wider organization; or the process cannot diagnose and recover when delayed evidence exposes the damage |
+| P2 | **Warranted transfer.** On a declared path, how does a decision leave the human cut with warrant, and how does the composition of the remaining work change? | Fewer required human decisions at fixed or better warrant and utility, including staged transfer of search allocation, reversible execution, and adoption authority | Before-and-after classification of transferred and residual decisions; later outcome evidence | Transfer may preferentially select decisions with represented premises, settled criteria, independently executable transitions, and checkable outcomes | Apparent transfer through a captured evaluator, viability-only gate, boundary export, displaced review, irreversible trial, or degraded residual judgment |
+| P3 | **Operative theory.** How does retained theory causally change a weight–prompt proposal, branch allocation, diagnosis, evaluation, recovery step, or symbolic revision; receive outcome read-back; and affect later operation? | Increasingly strong evidence from mediation through recurrence, including changed later search or execution | Theory interventions with weights and symbolic state held fixed, mediation traces, independent consequences, theory and code revisions, and later use | Natural-language theory, symbolic project state, prompt assembly, model interpretation, runtime execution, evaluation, and continuity are distinct functions that may be coupled through one path | Inert documentation, code-only success misattributed to theory, post-hoc rationale, self-sealing evaluation, wholesale replacement without traceable revision, or disconnected witnesses inside one boundary |
+| P4 | **Evaluation and comparison.** How are search-controller quality, symbolic-complement value, usefulness, computational autonomy, warrant, and power compared without collapsing them into one scalar? | Measurements that detect better branch allocation, reliable execution, a real change in the human cut, accepted outcomes, correction quality, and total human effort | Matched search budgets, downstream branch consequences, model-mediated versus symbolic comparisons, declared task selection, capability floors, evaluator tests, outcome records, and residual-decision records | Search judgments and acceptance judgments have different authority; code may execute exactly while implementing a bad requirement; functions differ in stakes and grain; closure is structural while warrant is evidential | Candidate volume mistaken for search quality, code exactness mistaken for objective validity, percentages of autonomy, activity counts, self-scored prose, or an evaluator treated as the definition of closure |
+| P5 | **Search-control and operation-boundary bootstrapping.** Can an already-computational theory-guided human-agent loop improve weight–prompt search through retained project state, use code for independently executed symbolic operations, learn which responsibilities belong on each side, and convert recurring judgments into reusable computational search, selection, and credit-assignment machinery? | Better downstream results from additional computation, reliable and economical symbolic complements, a revisable operation boundary, falling marginal human judgment per accepted improvement, transfer beyond anticipated domains, and competitive total cost | Truth and validity checks, theory interventions, branch-routing comparisons, symbolic-complement experiments, operator corrections, delayed system consequences, codification and relaxing events, evaluator conversions, cross-domain transfer, and direct-learning baselines | Weights provide general competence; prompts specialize it from natural-language, symbolic, and evidential project state; code plus runtime executes selected operations independently of model reinterpretation; global fit, credit, and operation placement remain distributed and partly human-selected | More computation only generates candidates; retained theory makes no causal difference; code is treated as fixed infrastructure or codifies bad proxies; model-mediated bookkeeping remains unreliable; human fit and boundary judgments do not fall; every domain needs a bespoke ontology and operation allocation; or a direct method performs better |
 
 ## Relations among the problems
 
 P1 is the scientific center. It asks whether a computational bearer can do what
 human programmers do with partial theory: use it to control search and recovery
-when no complete specification or cheap oracle settles the modification.
+while coordinating exact executable changes when no complete specification or
+cheap oracle settles the modification.
+
+The leading operation-level model is that prompts do not define semantic
+operations alone. A call's behavior is instantiated by the model's weights plus
+its prompt, while code complements that pair with operations whose consequences
+are assigned and executed by a symbolic runtime. See
+[code complements the weight–prompt pair with independently executed symbolic
+operations](../../notes/code-complements-the-weight-prompt-pair-with-independently-executed-symbolic-operations.md).
 
 P2 meets P1 at the same hard modification decisions but asks a different
 question. P1 concerns the capability to sustain coherent modification. P2
-concerns whether enough premises, authority, correction, and continuity lie
-inside the declared boundary for the decision to move with warrant. A system can
-be computationally closed and still fail P2 because its evaluator is weak.
+concerns whether enough premises, authority, correction, continuity, and
+reversibility lie inside the declared boundary for a decision to move with
+warrant. Lightweight branch allocation, reversible symbolic execution, and
+final adoption can move at different times. A system can be computationally
+closed and still fail P2 because its evaluator or requirement is weak.
 
 P3 supplies the attribution test for P1. A stored theory does not count merely
-because it accompanies a successful change. The program distinguishes mediation,
-empirical contact, theory-state revision, and recurrent later use.
+because it accompanies a successful code change. The programme distinguishes
+mediation, empirical contact, theory-state revision, and recurrent later use.
+The clean theory intervention holds weights, code, runtime, tools, and task
+fixed while changing the natural-language theory supplied through the prompt.
+Longitudinal episodes may then let theory, code, and their allocation coevolve.
 
-P4 is evaluation infrastructure for P1–P3. It keeps structural closure,
-capability, warrant, usefulness, and power separate while permitting explicit
-comparisons on each coordinate.
+P4 is evaluation infrastructure for P1–P3. It separately asks whether a search
+controller routes limited resources toward stronger downstream consequences,
+whether moving an operation into code improves reliability and cost after
+specification and maintenance are counted, and whether an accepted change is
+adequately warranted. It keeps structural closure, capability, warrant,
+usefulness, and power separate.
 
 P5 is the first construction strategy under the Bitter Lesson's scaling
 pressure, not a defense of hand-crafted artifacts and not a uniqueness claim.
 The narrow rebuttal says only that learned results need not all live in weights.
-P5 begins from the fact that the current Commonplace loop already uses
-computation: the model retrieves and interprets retained artifacts, searches and
-synthesizes candidates, criticizes alternatives, proposes edits, and uses tools
-for checks and retention. The operator currently supplies much of the sparse
-high-level selection signal about global fit and credit.
+P5 begins from the fact that the current Commonplace loop already composes both
+operation classes: weights plus prompts perform retrieval, interpretation,
+search, synthesis, criticism, and semantic judgment; code plus runtime performs
+repository transitions, tests, validation, scheduling, state retention, and
+other independently executed operations. The operator currently supplies much
+of the sparse high-level selection, credit, and operation-placement signal.
 
-P5 asks whether this live system can serve as an initial selection environment
-while the computational search improves and recurring operator judgments become
-tests, validators, learned critics, search objectives, methods, schemas, or
-code. It succeeds only if additional computation improves useful search, the
-marginal human share falls, the selection machinery itself remains
-challengeable, and the process eventually transfers beyond domains and
-decompositions anticipated by its designers. End-to-end, evolutionary,
-parametric, and other computational approaches remain comparison strategies.
+P5 asks whether the live system can improve all three connected surfaces:
+
+1. model-mediated search over project theory and code;
+2. symbolic operations that execute selected behavior and improve the later
+   selection environment; and
+3. the boundary deciding which behavior should be model-mediated, codified,
+   relaxed, or retained as a provisional search control.
+
+It succeeds only if additional computation improves downstream search quality,
+not merely candidate volume; symbolic operations earn their placement through
+measured reliability, cost, and scope; the marginal human share falls; the
+boundary and selection machinery remain challengeable; and the process
+transfers beyond domains and decompositions anticipated by its designers.
+End-to-end, evolutionary, parametric, and other computational approaches remain
+comparison strategies.
 
 ## What is deliberately not a target problem here
 
 - Whether a current system qualifies as “self-improving” by category membership;
   the definitions already classify that, and category membership is not the
   research result.
-- Whether computation has begun. The current human-agent loop is already
-  computational; the problem is improving search and extending reusable
-  selection and credit assignment.
+- Whether computation has begun. The current human-agent loop already composes
+  computational model-mediated and symbolic operations; the problem is improving
+  search, execution, selection, credit assignment, and their allocation.
+- Whether a prompt alone defines an LLM operation. The programme treats the
+  operation as instantiated by the weight–prompt pair under fixed call settings.
+- Whether code or the model is globally superior. They provide complementary
+  operation classes whose appropriate scope must be learned and tested.
 - Whether theory-guided bootstrapping is the only possible route. It is the first
-  strategy being tested because global theory fit currently lacks a complete
-  fixed evaluator.
+  strategy being tested because global theory fit and operation placement lack
+  complete fixed evaluators.
 - Whether natural-language, symbolic, and parametric carriers must remain
-  permanently separate. The program currently tests a mixed-form realization;
-  the durable claim concerns distinct functions and failure surfaces.
+  permanently separate. The current realization keeps their roles inspectable;
+  the durable claim concerns complementary functions and failure surfaces.
 - Whether structural computational closure guarantees correctness or value. It
   says where required decisions and transitions occur; capability and warrant
   need separate evidence.


### PR DESCRIPTION
## Summary

- add the atomic claim that a model-mediated operation is instantiated by weights plus prompt, while code plus runtime supplies a complementary operation class whose consequences execute without model reinterpretation;
- clarify that natural-language project state is only the prompt-side part of mixed project state, alongside source code, tests, schemas, configuration, and evidence;
- revise the shared model around complementary model-mediated and symbolic operations;
- integrate pre-decisive lightweight search control, backtracking, and downstream controller evaluation into that operation model;
- revise the target problems so coherent modification coordinates theory-guided weight-prompt search with independently executed symbolic changes;
- make operation placement itself part of the bootstrap: the system may revise prompts, code, or the boundary between model-mediated and symbolic execution;
- add separate theory-intervention, symbolic-complement, and longitudinal boundary-learning experiments;
- align the article map without adding another article.

## Central distinction

A prompt does not define an LLM operation alone. Relative to fixed call settings, model-mediated behavior is instantiated by the model's weights together with the prompt. Code complements that pair: relative to a runtime, it defines symbolic operations that can execute without reconstructing their meaning through the model on every use.

Code may still be generated, selected, explained, or revised by the model. It can also be loaded into a prompt as project evidence. The distinction concerns its consumption path at one operation: model interpretation versus runtime-assigned execution.

## Research consequence

The learning surface includes the prompt-side project theory, target and control code, tests and validators, and the allocation of responsibility between the two operation classes. The theory intervention holds weights and symbolic state fixed. A separate symbolic-complement experiment compares model-mediated bookkeeping, model-generated or selected code, and a hybrid. Longitudinal episodes test whether evidence changes later branch allocation, code, or the operation boundary.

Workshop: `kb/work/theory-mediated-self-improvement-series`

Model: GPT-5.6 Pro