### PR TITLE
Compress the theory-mediated research-program article

### DIFF
--- a/kb/articles/a-research-program-for-theory-mediated-system-learning.md
+++ b/kb/articles/a-research-program-for-theory-mediated-system-learning.md
@@ -29,24 +29,20 @@ source_notes:
 
 # A research program for theory-mediated system learning
 
-> **Draft.** This article is circulating for comments; its claims, structure, and central thesis may still change. Counterexamples, rival mechanisms, and disputed experimental controls are welcome through the repository's issue tracker.
+> **Draft.** This article is circulating for comments. Counterexamples, rival mechanisms, and disputed experimental controls are welcome through the repository's issue tracker.
 
-Suppose an endpoint is slow and a cache is put in front of the service behind
-it. The change is small, the tests pass, and the endpoint is fast. Two
+Suppose an endpoint is slow, so a cache is added in front of the service behind
+it. The change is small, its tests pass, and the endpoint becomes fast. Two
 requirements later, a feature that needs every read to reflect the preceding
-write fails in production: the service had been kept transactional for exactly that
-reason, and the reason was written down nowhere the change touched. Nothing in
-the change request, the touched files, or the local tests said the cache would
-break the program. A later demand exposed the unstated dependency.
+write fails in production. The service had been kept transactional for exactly
+that reason, but the reason appeared nowhere the change touched. A later demand
+exposed the unstated dependency.
 
-The hardest programming decisions are of this kind: not necessarily the ones
-that require the most code, but the ones for which no complete local rule or
-cheap test says what change will preserve the program's purpose and
-organization.
-
-Human programmers handle these decisions imperfectly. They use a partial theory
-of the program to choose promising changes, notice conflicts, interpret failed
-attempts, backtrack, and revise their understanding. The theory does not replace
+The hardest programming decisions are often of this kind: no complete local
+rule or cheap test says which change will preserve the program's purpose and
+organization. Human programmers handle them imperfectly. They use a partial
+theory of the program to choose promising changes, notice conflicts, interpret
+failure, backtrack, and revise their understanding. The theory does not replace
 search. It keeps search coherent until later requirements and operational
 consequences reveal what the first tests could not.
 
@@ -56,158 +52,116 @@ This article presents a research program around one question:
 > coherent under delayed feedback, and revise that theory when the consequences
 > arrive?
 
-The system in that question is not a model. It is retained artifacts, tools,
-runtime, and correction machinery alongside the model, evaluated together at a
-declared boundary. And the question is about learning, not only about editing.
+The system is not just a model. It includes retained artifacts, tools, runtime,
+and correction machinery alongside the model, evaluated together at a declared
+boundary. This is a statement of a research program, not a report of results: it
+claims that the question is well posed and testable, not that its answer is yes.
 
-This is a statement of a research program, not a report of results. It sets
-out the question, a standard for answering it, the levels at which evidence
-would count, one observational episode, and two studies that have not been
-run. What it claims is that the question is well posed and testable, not that
-its answer is yes.
-
-A change to a program, a rule, a schema, or a test is a durable change to the
-thing that determines the system's later behavior. When a retained theory
-state guides such a change, and the consequences then revise that state, the
-modification is how the system learns — no weight update required. The unit that
-learns is [the deployed system rather than the
+A change to a program, rule, schema, or test is a durable change to something
+that determines later behavior. When a retained theory state guides such a
+change, and consequences then revise that state, the system can learn through
+the modification without requiring a weight update. The unit that learns is
+[the deployed system rather than the
 model](../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md),
-and a change counts as learning when [an improvement
+and the change counts as learning when an [improvement
 process](../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md)
-uses evidence from system behavior to select and retain it, so that it affects
-later executions.
+uses evidence to select and retain it so that it affects later executions.
 
-What makes this learning path *theory-mediated* is that part of the program
-theory is retained in an addressable state the process can apply, doubt, and
-revise, rather than being compiled away into behavior. What retained artifacts buy is
-addressability at the level of claims: an individual claim can be inspected,
-cited, perturbed, withheld, or rescoped. A weight checkpoint can be swapped out
-too, but offers far weaker addressability at that level. Claim-level
-addressability is also what [three 2026 self-improving harnesses examined for
-the program turn out not to
-have](../notes/evidence/three-2026-harnesses-retain-rules-or-weights-not-a-revisable-theory.md):
-they retain rule sets or weights, not a revisable theory that guides patch
-search and gives later failures a shared target for diagnosis and revision.
+The path is *theory-mediated* when part of the program theory persists in an
+addressable state that the process can apply, doubt, and revise. An individual
+claim can then be inspected, cited, withheld, perturbed, or rescoped. A weight
+checkpoint can also be replaced, but normally offers much weaker claim-level
+addressability. [Three 2026 self-improving harnesses examined for the
+program](../notes/evidence/three-2026-harnesses-retain-rules-or-weights-not-a-revisable-theory.md)
+retain rules or weights, not a revisable theory that guides patch search and
+gives later failures a shared target for diagnosis.
 
 The closest positive neighbour is [workspace
-optimization](../sources/workspace-optimization-how-to-train-your-agent.ingest.md):
-a frozen-model agent revises the code and text around its own model calls — an
-executable model of the game it is playing, hypotheses, strategies — from
-prediction failures routed to the artifact that owns them, with recent
-transitions replayed after each edit. That is a mediation, consequence, and
-revision chain, demonstrated on 25 ARC-AGI-3 games. The differences mark this
-program's question. What that system revises is a model of an external
-environment, within one run; its own decomposition into roles, its validation,
-and its adoption policy stay fixed, and nothing is shown to survive into a
-later session. This program asks whether a retained program theory can guide
-modification of the behavior-determining system itself across later,
-initially unforeseen demands, and whether a delayed failure revises the same
-theory so that later modifications improve.
+optimization](../sources/workspace-optimization-how-to-train-your-agent.ingest.md),
+where a frozen-model agent revises code and text around its own calls from
+prediction failures and replays recent transitions after edits. The reported
+system revises a model of an external environment within one run; its role
+decomposition, validation, and adoption policy remain fixed, and persistence
+across sessions is not shown. This program asks about modification of the
+behavior-determining system itself across later, initially unforeseen demands.
 
 The program has two testbeds. Programming agents supplied with persistent
-program theory are the harder one, and still prospective. Commonplace —
-an agent-operated knowledge base, and the system this article comes from — is
-the live one, where the same mechanisms already run on parts of the system's own
-operation.
-
-In that loop a language model reads retained Commonplace artifacts, searches and
-synthesizes candidate formulations and repository changes, criticizes
-alternatives, uses tools for checks and retention, and then works from the
-revised state. What stays human is concentrated: the operator supplies most of
-the sparse selection signal about whether a candidate fits the larger theory and
-the intended system. The research problem is therefore not how to introduce
-computation, but how to make that computational search more effective and how to
-turn recurring operator judgments into reusable selection and credit-assignment
+program theory are the harder and still prospective one. Commonplace, the
+agent-operated knowledge base from which this article comes, is the live one.
+Its model already retrieves retained project knowledge, searches and criticizes
+candidate formulations and repository changes, uses tools for local checks, and
+works from the revised state. The operator supplies much of the sparse selection
+signal about global fit and intent. The immediate problem is therefore not to
+introduce computation, but to improve that computational search and turn
+recurring operator judgments into reusable selection and credit-assignment
 machinery.
-
-The rest of the article sets out the program's parts: what coherent
-modification is, the four functions the architecture separates, the levels at
-which evidence for the path is graded, the difference between a claim's truth
-and its fit, one recorded episode, the conditions under which the strategy
-should be abandoned, where the program parts company with Sutton's later
-position, and the two studies that come next.
 
 ## Holding a theory means controlling a fallible search
 
-A modification is coherent when it meets the new demand without breaking the
-purpose and organization that make the program work. This is the test Peter
-Naur set in 1985 for whoever holds a program's theory, and no checklist stands
-behind it. What the program's organization requires is not fully stated
-anywhere; a partial, fallible account of it is what the theory is. So a change
-is rarely shown coherent when it is made. It is shown incoherent later, when a
-further demand, an extension, or an operational failure reveals that it broke
-something the purpose depended on. The cache change above was incoherent, and
-nothing local to the change showed that.
+A modification is coherent when it meets a new demand without breaking the
+purpose and organization that make the program work. This is Peter Naur's test
+for whoever holds a program's theory. Because that organization is only partly
+stated, coherence is often revealed longitudinally: a later extension or
+operational failure shows that an earlier locally successful change broke
+something important.
 
-The unit judged is therefore a sequence of modifications, not one change. A
-process modifies coherently when the changes it retains keep meeting later
-demands, and when it detects and repairs the ones that turn out not to. A
-failed first candidate can meet this standard if the process recognizes the
-failure, recovers, and revises. A successful first candidate can fail it if it
-passes narrow tests while damaging the wider organization in a way the process
-cannot detect. The full argument is that [holding a program theory means
-sustaining coherent search under delayed
+The unit judged is therefore a sequence of modifications, not one patch. A
+failed first candidate can belong to coherent modification when the process
+recognizes the failure, recovers, and revises. A successful first candidate can
+fail the test when it passes narrow checks while damaging the wider organization
+in a way the process cannot detect. [Holding a program theory means sustaining
+coherent search under delayed
 feedback](../notes/program-theory-sustains-search-under-delayed-feedback.md).
 
 A program theory need not be a complete formal specification or one document.
-It may be spread across retained explanations, architectural decisions,
-operational observations, learned competence, and code. Two senses need
-separating. *Program theory* names that distributed understanding, wherever it
-lives. What the program can manipulate is the *retained theory state*: the
-addressable artifacts the system can retrieve, cite, perturb, withhold, and
-revise. Code and learned competence may embody program theory; only the
-retained state can be withheld in an experiment while the model stays fixed.
-Nor must a program theory determine a correct first change. It is needed earlier than that: [open-ended improvement
-must allocate search before decisive evaluation is
-available](../notes/open-ended-improvement-allocates-search-before-evaluation.md),
-and the theory is what makes that allocation project-specific.
+It may be distributed across retained explanations, architectural decisions,
+operational observations, learned competence, and code. *Program theory* names
+that wider understanding. The *retained theory state* is the addressable part
+the system can retrieve, cite, withhold, and revise. Code and learned competence
+may embody the theory, but only retained state can be withheld while the model
+stays fixed in the proposed experiment.
 
-A theory is doing work when it changes the modification process. It can:
+Theory matters before a correct answer is available. [Open-ended improvement
+must allocate search before decisive evaluation
+exists](../notes/open-ended-improvement-allocates-search-before-evaluation.md),
+and retained theory can make that allocation project-specific. It can:
 
-- narrow which candidates are considered;
-- identify commitments a local fix must not silently break;
-- give an unexpected result an interpretation, one that [counts as search
-  control only when it changes a later branch
-  decision](../notes/failure-explanation-changes-later-branch-decisions.md);
-- distinguish evidence against a candidate from evidence against the current
+- narrow candidates and identify commitments a local fix must preserve;
+- interpret an unexpected result and distinguish a bad candidate from a bad
   theory;
-- guide rollback and recovery; and
-- change what the process tries on the next demand.
+- guide rollback, recovery, and the choice of the next branch; and
+- revise what later demands cause the process to try.
 
-Generic search can also generate, test, and discard patches. What separates
-theory-guided search from it is causal: withholding or replacing the retained
-theory should change proposal, diagnosis, evaluation, recovery, or later
-revision. The working conjecture about the mechanism is that [natural-language
-project state specializes search heuristics already present in the model's
+Generic search can also generate, test, and discard patches. The distinction is
+causal: withholding or replacing the retained theory should change proposal,
+diagnosis, evaluation, recovery, or later revision. The working mechanism is
+that [natural-language project state may specialize search heuristics already
+present in model
 weights](../notes/natural-language-project-state-specializes-search-heuristics.md).
-A theory that merely accompanies the work is documentation, not a demonstrated
-part of the learning path.
+A theory that merely accompanies the work remains documentation rather than a
+demonstrated part of the learning path.
 
-Naur also argued that programming is theory building, and that the theory
-lives in the programmers' heads rather than in the artifacts they leave behind. The companion article [What bound Naur's theory to
-programmers](./what-bound-naurs-theory-to-programmers.md) makes one narrow
-repair: his argument relies on a crucial [premise that machine execution means
-following formulated criteria](../notes/naur-equates-machine-execution-with-formulated-criteria.md),
-so the essay does not establish in advance that only humans can hold a program
-theory. This is the program's main departure from Naur; his account of what a
-theory is, his bearer tests, and coherent modification as the decisive test
-are otherwise adopted. Removing that premise does not show any current agent
-passes his bearer tests, which stays an empirical question.
+Naur bound program theory to programmers partly through a crucial [premise that
+machine execution means following formulated
+criteria](../notes/naur-equates-machine-execution-with-formulated-criteria.md).
+Trained recognizers make that premise contestable, so his essay does not settle
+in advance that only humans can hold a program theory. The companion article
+[What bound Naur's theory to
+programmers](./what-bound-naurs-theory-to-programmers.md) develops this narrow
+departure. Naur's bearer tests and coherent modification standard otherwise
+remain the program's tests; removing the premise does not show that any current
+agent passes them.
 
 ## Four functions that fail differently
 
-Several decompositions are used in this program for different questions. The
-[proposal-selection loop](../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md)
-decomposes an improvement process into search, reject-capable evaluation, and
-operative retention. The [residue analysis](../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md)
-classifies why decisions remain outside a warranted automatic path: missing
-representation, unsettled criteria or semantic application, insufficient
-verification, or broken continuity. The table below is different again: it
-shows the current implementation roles through which those demands are carried.
-It is not a second derivation of the loop.
-
-The current architecture separates four functions because they fail in
-different ways.
+The program uses several decompositions for different questions. A
+[proposal-selection
+loop](../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md)
+requires search, reject-capable evaluation, and operative retention. [Residue
+analysis](../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md)
+asks why decisions remain outside a warranted automatic path. The table below
+instead describes the present implementation roles through which those demands
+are carried.
 
 | Function | Current realization | Failure it exposes |
 |---|---|---|
@@ -216,29 +170,20 @@ different ways.
 | Execute exact transitions and keep the path alive | Code and a persistent runtime | Faithful execution of the wrong transition, frozen decomposition, truncated horizon |
 | Correct proposals and theories, and select what is retained | Tests, validators, held-out tasks, decorrelated criticism, later demands, and operational consequences; for global fit and authorization, the operator | Weak proxies, captured evaluation, viability-only gates, delayed credit assignment, unstated preferences, exogenous selection |
 
-This is a [functionally mixed
-architecture](../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md),
-not a claim that the functions must stay in separate representational forms: a
-future learned substrate may host several at once, and stronger models may
-absorb parts of the present scaffolding. The split earns its place now because
-it makes each role [addressable](../notes/reflection-buys-addressability.md) and
-separately testable.
+The functions need distinct failure surfaces, not permanently separate
+representational forms. A future substrate may host several at once. The current
+split is useful because it makes interventions possible: withhold theory,
+perturb interpretation, replace evaluation, or truncate continuity.
 
 Interpretation and correction must remain distinct. A model can understand and
-apply a false theory. Semantic competence does not establish that the theory is
-right or that a proposed change is good. Independent or sufficiently
-decorrelated evidence must remain able to overturn the candidate's account.
-
-The fourth row contains the operator, and that is where the program's target
-lives. Tests can reject a candidate. They do not choose among several viable
-candidates for an underspecified purpose, and they do not grant authority to
-change the live system. At present those selection and authorization
-judgments are mostly human. They are the function the program aims to convert
-into reusable machinery, one recurring judgment at a time.
+apply a false theory; independent or sufficiently decorrelated evidence must be
+able to overturn it. The operator currently supplies much of the global-fit
+selection and authorization in the fourth row. Converting recurring parts of
+that work into reusable machinery is a central target of the program.
 
 ## Evidence comes in levels
 
-The full loop the program wants to observe is:
+The strongest path the program wants to observe is:
 
     retained theory
       -> theory-mediated search or decision
@@ -248,214 +193,72 @@ The full loop the program wants to observe is:
       -> retained theory-state revision
       -> changed later operation
 
-Requiring the whole chain before anything counts would discard useful partial
-results, so the program distinguishes four levels:
+Useful partial results should not be forced into the strongest claim. The
+program therefore distinguishes four levels:
 
-1. **Mediation:** changing or withholding the theory changes a proposal,
-   evaluation, diagnosis, recovery step, or intervention.
+1. **Mediation:** changing or withholding theory changes a proposal, evaluation,
+   diagnosis, recovery step, or intervention.
 2. **Empirical contact:** the intervention produces an outcome that bears on the
    theory.
 3. **Theory learning:** the outcome changes the theory's content, scope,
    confidence, status, or operational role.
-4. **Recurrence:** the updated theory state changes a later operation inside the
-   same behavior-determining path.
+4. **Recurrence:** the updated theory state changes a later operation on the same
+   behavior-determining path.
 
-[A citation at the decision point is a mediation
+A [citation at the decision point is a mediation
 trace](../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md),
-not proof that the theory was load-bearing; withholding, replacing, or
-perturbing the theory is stronger evidence. The higher levels must also chain:
-the theory that guided the change must be the object against which the outcome
-is read, and the revised theory must be the one used later. Interpretation,
-retention, and read-back [have to share one causal path, not merely one system
-boundary](../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md);
-disconnected witnesses do not establish learning through theory.
+not proof that the theory was load-bearing. Withholding, replacement, or
+perturbation is stronger evidence. The higher levels must also be co-indexed:
+the theory that guided the change must receive the outcome read-back, and its
+revision must be what later operation consumes. [Disconnected witnesses do not
+establish learning through
+theory](../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md).
 
 ## A true claim may still not fit the theory
 
-A theory-mediated system must answer two different questions about a candidate
-claim — in Commonplace a note, in a programming project the rationale a change
-is made under.
+A theory-mediated system must ask two questions about a candidate claim:
 
-First, is the claim true, valid, or otherwise warranted over its stated scope?
-Some claims admit factual checks, formal derivations, consistency tests,
-controlled experiments, or bounded benchmarks.
+1. Is it true, valid, or otherwise warranted over its stated scope?
+2. Does it fit the larger working theory and improve the system's operation and
+   revision?
 
-Second, does the claim fit the larger working theory and improve the system's
-operation and revision? That is relational. A true claim can be irrelevant,
-redundant, badly scoped, or placed at the wrong level of abstraction. A false
-claim can appear useful because the current implementation already assumes it.
-Fit is not conformity to existing doctrine. A warranted claim that contradicts
-the larger theory is evidence that the theory may need revision; fit concerns
-the claim's scope, role, and integration.
+The second question is relational. A true claim can be irrelevant, redundant,
+badly scoped, or placed at the wrong level of abstraction. A false claim can
+appear useful because the current implementation already assumes it. Fit is not
+conformity to doctrine: a warranted contradiction may show that the larger
+theory needs revision.
 
-No present automatic evaluator fully decides whether a candidate belongs in the
-larger causal picture, what it should displace, or whether it will keep guiding
-coherent modification as later demands arrive. The evidence for fit is
-distributed and delayed rather than supplied by one complete local oracle, so it
-is exposed one consequence at a time:
+No present automatic evaluator fully decides global fit. Evidence arrives
+through changed search and recovery, surviving predictions, later demands,
+rival or ablated theories, repair and human-intervention costs, and transfer.
+The live system can therefore serve as an [initial selection
+environment](../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md):
+claims earn provisional standing by affecting building, operation, or repair and
+surviving the consequences of that use.
 
-- whether the claim changes search or recovery;
-- whether its predictions survive later evidence;
-- whether modifications guided by it preserve the system's organization;
-- whether a rival or ablated theory does better;
-- whether it reduces repair and human intervention; and
-- whether it transfers beyond the case that produced it.
-
-The live system under construction can therefore serve as an [initial selection
-environment](../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md).
-Claims earn provisional standing by making a counterfactual difference to
-building, operating, or repairing the system and by surviving the consequences
-of that use.
-
-System use is not a truth oracle, since a system can reward its own
-misconceptions. The separate correction function exists to prevent a
-self-sealing theory: independent factual and formal verification, and
-predictions registered before the evidence arrives, are the checks system use
-cannot supply by itself.
+System use is not a truth oracle. It can reward misconceptions already embodied
+in the implementation. Independent factual and formal checks, preregistered
+predictions, held-out demands, and transfer tests are needed to keep the working
+theory from becoming self-sealing.
 
 ## One recorded episode, and its limits
 
-The
-[2026-08-30 Commonplace revision record](../notes/evidence/commonplace-revision-used-theory-guided-computational-search.md)
-provides one concrete human-agent episode. The model read the workshop,
-related notes, and repository state, and produced a review, candidate
-distinctions, experiments, and repository edits. The operator accepted much of
-the result but corrected the Bitter Lesson framing several times, and under
-those corrections the theory moved from a set of several defenses against the
-objection, to the account given below of the hand-written artifacts as a
-bootstrap, and then to that account's first-strategy form, in which current
-computation and residual human selection are explicitly separated. The revisions were retained and guided later turns.
+The [2026-08-30 Commonplace revision
+record](../notes/evidence/commonplace-revision-used-theory-guided-computational-search.md)
+documents one human-agent episode. The model read the workshop, related notes,
+and repository state; proposed distinctions, experiments, and edits; and
+revised them after the operator corrected the Bitter Lesson framing. The
+revisions were retained and guided later work.
 
-At the boundary including operator, model, knowledge base, and tools, the episode
-documents retained-state consumption, theory-state revision, and later reuse in
-a path consistent with mediation and recurrence. It does not estimate how
-load-bearing the retained artifacts were, because no matched replay or ablation
-was run. At a boundary excluding the operator, global-fit selection and final
-acceptance remain exogenous. That is the residue to expect: [transferring the decisions whose
-premises, criteria, and checks are available leaves people the
-hardest-to-warrant
-ones](../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md).
-
-The episode does not show how much each artifact mattered. Reading and citing
-many Commonplace artifacts is a mediation trace; the intervention that would
-measure their contribution is the experiment below.
-
-The episode also raises a boundary question the program treats separately: why
-the operator's global-fit judgments have not moved into the automatic part of
-the system. The companion article
-[The decisions that stay human, and what would move them](./the-decisions-that-stay-human-and-what-would-move-them.md)
-develops that transfer argument and separates it from [computational
-closure](../notes/methodological-and-computational-closure-track-different-changes.md),
-which states where decisions happen rather than whether they are any good.
-
-## The hand-crafted parts are a bootstrap the program expects to replace
-
-The obvious objection is that retained explicit artifacts are exactly the
-hand-built structure the Bitter Lesson tells us to stop building. The program
-cannot deny the premise. Its theories, schemas, validators, decompositions, and
-evaluators are at present written by people.
-
-The program's compatibility with the lesson rests on two arguments. The first
-is the only rebuttal to the objection that [holds
-up](../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md):
-[production method and representational form are different
-axes](../notes/the-bitter-lesson-selects-production-methods-not-representational.md).
-The lesson is against hand-crafting, not against learning in prompts and code,
-so a theory or a validator can itself be a learned product. That makes room for
-explicit artifacts. It says nothing in favour of the present hand-written ones.
-
-The second argument is that the present artifacts are a bootstrap: a
-hand-crafted starting state that the program expects learning to replace —
-much of it, possibly all of it — while the system it started continues. That
-is what makes it a bootstrap rather than a scaffold: a scaffold is discarded
-once the product stands, whereas here the running system uses its current
-theory to guide the search that produces its successors. What is meant to
-persist is the loop and its four functions, not any artifact now performing
-them. Hand-crafted names who produced the current version of an artifact, not a
-class of artifact that must stay so. No component inside the declared revision
-surface is exempt from challenge merely because it currently implements the
-improvement machinery: [machinery persists by warrant, not by its
-position](../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md),
-and the starting artifacts are as exposed to replacement as anything else in
-the loop's scope. Stated as a condition, the bootstrap [fits the Bitter Lesson
-only if learning can outgrow
-it](../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md);
-a promised path beyond hand-crafting is cheap, so the expectation has to be
-checked rather than asserted, and the abandonment conditions below are the
-check.
-
-The bootstrap is not "hand-craft now, learn later". Computation is used inside
-the loop from the start; the human judgments that remain where global fit has no
-evaluator are recorded as missing selection machinery rather than accepted as
-the permanent arrangement; and a judgment that recurs with a stable scope
-becomes a test, validator, learned critic, method, or program. The
-hand-designed vision and game-playing methods in Richard Sutton's essay put
-designer knowledge into the object-level solution and never learned to replace
-it. The present strategy differs from them only if its theories, schemas,
-validators, decompositions, and evaluators remain challengeable in practice.
-Editable files are not enough: a model may rewrite a prompt while every choice
-about what may change and how it is judged stays fixed human design. The
-companion article [The Bitter Lesson does not require everything to live in
-weights](./the-bitter-lesson-does-not-require-everything-to-live-in-weights.md)
-develops both the rebuttal and the bootstrap account.
-
-Building through a bootstrap is the first strategy being tried, for two
-reasons. The first is that global theory fit lacks a complete fixed evaluator.
-The second is access: prompts, code, and retained artifacts are the part of the
-system a researcher without a training budget can change, and this is the
-author's situation. The strategy also has payoffs beyond the reasons for
-choosing it. If the [sample-efficiency
-conjecture](../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md)
-holds, retained theory needs fewer observations where later demands preserve
-the structure it names. The retained theory state is readable: many people can test the strategy, and
-what the system has learned is open to inspection, which gives alignment
-research an audit surface. The cost advantage is a starting one: if most of the
-loop becomes computational, further gains will again cost compute.
-
-The strategy competes with end-to-end learning, evolutionary search, self-play,
-weight updates, and stronger-model baselines. Its scaling test is the research
-problem stated at the start: more computation must improve search, and
-recurring operator judgments must become reusable selection machinery. The
-bootstrap stops fitting the lesson, and the strategy should be abandoned, when:
-
-- system use becomes self-confirming;
-- retained theory makes no causal difference;
-- more computation does not improve useful search or selection;
-- human judgment grows with the corpus instead of falling;
-- each new domain needs its own ontology and oracle;
-- the current decomposition cannot be challenged, so [learning inside it
-  inherits its
-  mistakes](../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md);
-  or
-- another method does better at comparable total cost.
-
-## Compatible with the lesson, at odds with Sutton's later bet
-
-Compatibility with the 2019 essay is not agreement with what its author now
-holds. In a 2026 interview Sutton and Khurram Javed grant that context can be
-part of an agent's state and still hold weight change necessary: "So context
-can be in the state, too. It could be both, but you still need to be able to
-update the weights."
-([source](../sources/sutton-javed-why-ai-models-stop-learning.ingest.md),
-verbatim). The structuring and generation of new concepts, on their account,
-is weight learning, and an agent that stops updating its weights has stopped
-learning in the sense that matters.
-
-The program disagrees, and the disagreement is a hypothesis rather than a
-premise on either side. Whether updates to readable artifacts — theories,
-tests, schemas, programs — can supply the capabilities open-ended learning
-needs is the empirical question this program is built to test; the lesson does
-not settle it by definition, and neither does the interview. The target is the
-same on both sides: Sutton names as his lab's largest ambition a mind that
-keeps training itself while staying self-consistent and coherent, which is
-coherent modification pursued in weights. The comparative test is to hold
-objectives and evaluation fixed and vary which surfaces may update — weights,
-natural-language artifacts, symbolic artifacts, or a mixture — and see where
-capability grows.
-
-The program's disagreements are therefore few and named: with Naur, the
-machine-criteria premise just discussed; with the Bitter Lesson essay, none;
-with Sutton and Javed's later position, one hypothesis.
+At the boundary including operator, model, knowledge base, and tools, the record
+shows retained-state consumption, theory-state revision, and later reuse in a
+path consistent with mediation and recurrence. It does not estimate how
+load-bearing the artifacts were because no matched replay or ablation was run.
+At a boundary excluding the operator, global-fit selection and final acceptance
+remain exogenous. The companion article [The decisions that stay human, and
+what would move
+them](./the-decisions-that-stay-human-and-what-would-move-them.md) develops that
+transfer problem and separates it from structural computational closure.
 
 ## One experiment and one longitudinal study
 
@@ -463,82 +266,134 @@ The experiment tests whether a prepared retained theory state is load-bearing.
 Hold model, tools, repository state, inference budget, judging protocol,
 acceptance threshold, and authorization procedure fixed; compare:
 
-1. the reference theory — ground truth for a synthetic task whose generating
+1. a reference theory — ground truth for a synthetic task whose generating
    rationale is known, or the maintainers' current best account for a real
    project;
 2. a fact-matched record without synthesized theory;
 3. theory withheld; and
 4. plausible but wrong or outdated theory.
 
-The comparison [identifies only the contrasts it actually
-runs](../notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md),
-and the second condition is the contested one. A fact-matched record carries
-the same facts, decisions, and history as the theory — commit messages, issue
-threads, a changelog — flattened, with the purposes behind decisions and the
-dependencies between them removed. The match is on facts, not on information,
-since the removed purposes and dependencies are information too. If theory-level
-organization is what does the work, the record should behave like withheld
-theory. If the record cannot be matched without smuggling that organization
-back in, the two conditions collapse, and that is the disagreement the program
-most wants exposed.
+The fact-matched condition is deliberately contested. It carries the same facts,
+decisions, and history as the theory but removes their purposes and dependency
+structure. The match is therefore on facts, not information. If theory-level
+organization does the work, the flattened record should behave more like
+withheld theory. If it cannot be removed without smuggling the organization
+back in, the conditions collapse. The experiment can identify only [the
+contrasts it actually
+runs](../notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md).
 
-Each run is a sequence: an initial modification; a delayed demand that
-exposes a failure in it; diagnosis and recovery; explicit revision of the
-retained theory state; and a further, structurally related demand that can
-benefit from the revision. Without the last two stages the experiment can show
-theory-guided modification but not learning through theory. Measure candidate
-generation, preservation of architectural commitments, diagnosis, backtracking,
-recovery, collateral regressions, later-demand performance, and human
-intervention. The reference theory should help most where [the later demand preserves
-the structure it
-names](../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md)
-— in the cache case, a theory that records why the service is transactional.
-Wrong theory should produce predictable negative transfer. If the central
-conjecture is right, withholding theory should damage recovery most. The
-same-budget withheld condition is the direct-search baseline; a follow-on
-scaling study should compare retained theory against direct search at larger
+Each run is a sequence: an initial modification, a delayed demand exposing a
+failure, diagnosis and recovery, explicit theory-state revision, and a further
+structurally related demand. The final two stages distinguish theory-guided
+editing from learning through theory. Measure candidate generation,
+preservation of commitments, diagnosis, backtracking, recovery, collateral
+regressions, later-demand performance, and human intervention. Correct theory
+should help most when the later demand preserves the structure it names; wrong
+theory should produce predictable negative transfer. The withheld condition is
+the same-budget direct-search baseline, followed by comparisons at larger
 inference budgets and against stronger models.
 
-The longitudinal study instruments the current human-agent loop. Across a
-sequence of real Commonplace improvements, record which retained
-artifacts guided model search, which proposals and checks were computational,
-which global-fit and credit judgments remained human and why, whether
-additional computation was associated with a changed proposal or judgment,
-which downstream consequences bore on the
-judgment, and whether a recurring correction became a test, validator, learned
-critic, method, schema, or program. That last conversion is the one that
-compounds: a correction retained as a lesson helps only the tasks that retrieve
-it, whereas one retained as a [maintained check improves selection for every
-later candidate in its
-domain](../notes/oracle-accumulation-improves-the-selection-environment.md). A
-later episode should show whether more of the selection decisions had become
+The longitudinal study instruments real Commonplace improvements. It records
+which artifacts guided search, which proposals and checks were computational,
+which global-fit and credit judgments remained human and why, which later
+consequences bore on them, and whether recurring corrections became tests,
+validators, learned critics, methods, schemas, or programs. A lesson helps only
+tasks that retrieve it; a [maintained check improves selection for every later
+candidate in its
+domain](../notes/oracle-accumulation-improves-the-selection-environment.md).
+Later episodes should show whether more selection decisions have become
 computational.
 
-Neither study reaches two of the abandonment conditions: whether the approach
-extends to new domains, and whether another method does better. Those need a
-later cross-domain comparison against direct computational alternatives.
+Neither study tests domain-extensibility or superiority to alternative methods.
+Those require later cross-domain comparisons against direct computational
+approaches at comparable total cost.
+
+## The bootstrap must outgrow its hand-crafted parts
+
+The Bitter Lesson creates an obvious objection: the program's theories, schemas,
+validators, decompositions, and evaluators are currently written by people. The
+narrow rebuttal is that [production method and representational form are
+different
+axes](../notes/the-bitter-lesson-selects-production-methods-not-representational.md).
+Search and learning can produce prompts, theories, tests, and programs as well as
+weights. That gives explicit artifacts conceptual room; it does not vindicate
+the present hand-written ones.
+
+The broader answer is a prediction about the bootstrap. The running system must
+use its current theory and machinery to search for successors that replace much,
+possibly all, of that hand-crafted content. What should persist is the learning
+loop and the functions it performs, not any present carrier. No component inside
+the declared revision surface is exempt merely because it implements the
+improvement machinery: [machinery persists by warrant, not by
+position](../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md).
+The bootstrap [fits the Bitter Lesson only if learning can outgrow
+it](../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md).
+
+This is not "hand-craft now, learn later." Computation is already used for
+retrieval, proposal, criticism, comparison, editing, testing, and retention.
+Human judgments remain where global fit lacks a discriminating evaluator; when a
+judgment recurs with stable scope, it should become a test, validator, learned
+critic, method, or program. Editable files alone are insufficient if humans
+still fix what may change and how it is judged. The companion article [The
+Bitter Lesson does not require everything to live in
+weights](./the-bitter-lesson-does-not-require-everything-to-live-in-weights.md)
+develops the full argument.
+
+This is the first strategy being tried for two reasons. Global theory fit lacks
+a complete fixed evaluator, and prompts, code, and retained artifacts are the
+surfaces available to a researcher without a training budget. Possible further
+payoffs are [sample efficiency under structured
+shifts](../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md)
+and an inspectable learning record. These are hypotheses, not exemptions from
+full cost accounting.
+
+The strategy competes with end-to-end learning, evolutionary search, self-play,
+weight updates, and stronger-model baselines. It should be abandoned or narrowed
+when:
+
+- system use becomes self-confirming;
+- retained theory makes no causal difference;
+- additional computation does not improve useful search or selection;
+- human judgment per useful revision fails to fall as the corpus grows;
+- each new domain requires a new human-designed ontology and oracle;
+- the decomposition remains outside revision, so [learning inside it inherits
+  its mistakes](../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md);
+  or
+- another method performs better at comparable total cost.
+
+## Compatible with the lesson, at odds with Sutton's later bet
+
+Compatibility with Sutton's 2019 essay is not agreement with his later position.
+In a 2026 interview Sutton and Khurram Javed allow context to be part of an
+agent's state but still require weight change: "So context can be in the state,
+too. It could be both, but you still need to be able to update the weights."
+([source](../sources/sutton-javed-why-ai-models-stop-learning.ingest.md),
+verbatim).
+
+The program treats the necessity of weight updates as an empirical hypothesis.
+Its competing hypothesis is that updates to theories, tests, schemas, programs,
+or mixtures of representational forms can supply some capabilities needed for
+open-ended learning. The comparative test is to hold objectives and evaluation
+fixed, vary which surfaces may update, and see where capability grows. The
+program therefore parts from Naur on a machine-criteria premise, from the Bitter
+Lesson essay on none, and from Sutton and Javed's later position on one open
+hypothesis.
 
 ## The invitation
 
-The program exposes several points where disagreement can be productive. A
-researcher can:
+The program is open to disagreement at concrete points. A researcher can:
 
 - challenge the account of coherent modification;
 - propose a rival mechanism that does not require retained theory;
-- design stronger controls for the withholding intervention;
+- improve the controls for the theory intervention;
 - develop a less circular test of global theory fit;
 - identify a better first computational strategy; or
-- show that evaluator and decomposition construction keep the approach
-  permanently dependent on bespoke human judgment.
+- show that evaluator and decomposition construction remain dependent on
+  bespoke human judgment.
 
-A researcher need not begin by accepting the framing. The knowledge base can
-be [vendored read-only into another
-project](https://github.com/zby/commonplace/blob/main/INSTALL.md); an agent
-given that access, the researcher's own objection or rival mechanism, and the
-instruction to reconstruct the strongest available response and design a
-discriminating test is a way in that keeps the adversarial control with the
-researcher.
-
-The goal is not agreement with a finished theory. It is a small set of claims
-whose status can change through criticism and evidence — starting with the one
-this article is built around, which is concrete enough to turn out false.
+The knowledge base can be [vendored read-only into another
+project](https://github.com/zby/commonplace/blob/main/INSTALL.md). A researcher
+can give an agent that access together with their own objection or rival
+mechanism and ask it to reconstruct the strongest response and design a
+discriminating test. The goal is not agreement with a finished theory, but a
+small set of claims whose status can change through criticism and evidence.


### PR DESCRIPTION
This is a deliberately light editorial pass over the merged precision revision.

What changed:
- reduced the article from 544 to 399 lines (about 27%);
- removed the introductory roadmap and repeated qualifications;
- combined adjacent definitions and boundary statements;
- shortened the workspace-optimization and Commonplace-evidence discussions;
- moved the proposed experiment and longitudinal study ahead of the longer Bitter Lesson positioning;
- compressed the Bitter Lesson material to the narrow rebuttal, bootstrap prediction, reasons for trying it first, and abandonment conditions;
- shortened the invitation.

What did not change:
- the central coherent-modification question;
- the deployed-system and no-weight-update positions;
- the program-theory / retained-theory-state distinction;
- the Naur departure and Sutton/Javed disagreement;
- the four implementation roles, evidence ladder, truth-versus-fit distinction, current evidence boundary, study design, and failure criteria.

The deeper questions remain in `program-article-review-residuum-2026-08-30.md`; this PR does not try to settle them.