### PR TITLE
Clarify the research-program article's role

### DIFF
--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -63,13 +63,13 @@ The program statement is the entry point, not the container for every supporting
 argument. It may summarize a companion's result when that summary is required
 to state the program, but it should not reproduce the companion's derivation.
 
-The boundary between the program statement and the progress article is exact.
+The boundary between the program statement and the decisions companion is exact.
 The program statement may state two boundary facts: current Commonplace evidence
 is human-inclusive, and the research direction is to move named
 decision-bearing functions toward computational supply. The fixed-boundary
 derivation, human/computational/joint allocation profile, cut-set endpoint,
 boundary contraction, structural closure, capability, and warrant belong to
-the progress article. If the program statement names the cut-set endpoint, it
+the decisions companion. If the program statement names the cut-set endpoint, it
 does so only in its bootstrap section and links out rather than teaching the
 formalism.
 
@@ -129,7 +129,7 @@ units:
 The operator therefore appears in two places for two different reasons. The
 opening discloses the evidential boundary. The bootstrap section explains why
 the remaining human contribution is the next learning target. The full
-fixed-boundary and cut-set argument stays in the progress companion.
+fixed-boundary and cut-set argument stays in the decisions companion.
 
 Related-system comparisons should follow enough of the proposed mechanism for
 the contrast to be intelligible. The Naur exegesis, cut-set derivation, closure
@@ -147,7 +147,7 @@ boundaries; it should not default to rewriting the full article.
   closure describe the boundary and evaluation problem around it.
 - The program statement discloses the human-inclusive evidence boundary early,
   but reserves the reallocation, cut-set, contraction, closure, and warrant
-  argument for the bootstrap location and the progress companion.
+  argument for the bootstrap location and the decisions companion.
 - A prompt does not define an LLM operation alone. Relative to fixed call
   settings, the model-mediated operation is instantiated by weights plus prompt.
 - Code complements the weight–prompt operation with runtime-assigned symbolic

--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -20,9 +20,9 @@ only after disposition in the [incumbent ledger](./incumbent-ledger.md).
 ## Composition
 
 The modules do not imply an article per row. One article may carry several
-modules, but each full supporting argument should have one canonical article. Other
-articles repeat only enough to remain self-contained and link to that article.
-This limits synchronization cost and makes bounded agent edits possible.
+modules, but each full supporting argument should have one canonical article.
+Other articles repeat only enough to remain self-contained and link to that
+article. This limits synchronization cost and makes bounded agent edits possible.
 
 No article carries the series' routing: `kb/articles/README.md` is the rendered
 collection landing and the reader's entry point, and the articles collection
@@ -63,10 +63,10 @@ The program statement is the entry point, not the container for every supporting
 argument. It may summarize a companion's result when that summary is required
 to state the program, but it should not reproduce the companion's derivation.
 
-The division between the program statement and the decisions companion should be explicit.
-The program statement may state two boundary facts: current Commonplace evidence
-is human-inclusive, and the research direction is to move named
-decision-bearing functions toward computational supply. The fixed-boundary
+The division between the program statement and the decisions companion should
+be explicit. The program statement may state two boundary facts: current
+Commonplace evidence is human-inclusive, and the research direction is to move
+named decision-bearing functions toward computational supply. The fixed-boundary
 derivation, human/computational/joint allocation profile, cut-set endpoint,
 boundary contraction, structural closure, capability, and warrant belong to
 the decisions companion. If the program statement names the cut-set endpoint, it
@@ -133,8 +133,9 @@ fixed-boundary and cut-set argument stays in the decisions companion.
 
 Related-system comparisons should follow enough of the proposed mechanism for
 the contrast to be intelligible. The Naur exegesis, cut-set derivation, closure
-and warrant theory, full Bitter Lesson and bootstrap argument, and Sutton comparison are not
-independent top-level movements of the program statement.
+and warrant theory, the full Bitter Lesson and bootstrap argument, and the
+Sutton comparison are not independent top-level movements of the program
+statement.
 
 An agent edit should normally target one of these six units and name the modules
 it is not changing. A later integration pass checks the central question,
@@ -244,8 +245,8 @@ reproduce their process.
 
 For broad article work, name the target unit from the research-program contract
 and its excluded modules before editing. Afterward, run a bounded integration
-check for duplicated full arguments, inconsistent evidence claims, and
-broken companion links rather than rewriting the article globally.
+check for duplicated full arguments, inconsistent evidence claims, and broken
+companion links rather than rewriting the article globally.
 
 Each article should make clear:
 

--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -14,14 +14,14 @@ only after disposition in the [incumbent ledger](./incumbent-ledger.md).
 | **Operative theory** | State what would show that explicit theory participates in operation rather than remaining documentation | Reflective membership; prompt-side mediation with weights and symbolic state held fixed; addressable retention; independent exposure and read-back; continuation; mediation, empirical contact, theory learning, and recurrence as separate evidence levels | [Interpretation, retention, and independent read-back](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md), [natural-language project-state specialization](../../notes/natural-language-project-state-specializes-search-heuristics.md), [reflection buys addressability](../../notes/reflection-buys-addressability.md) | Better causal interventions, information-matched controls, alternative substrates, stronger read-back, and failures of selective rescoping |
 | **Functional architecture** | Explain the complementary operation classes without treating today's boundary as permanent | A model-mediated operation is instantiated by weights plus prompt; code plus runtime supplies independently executed symbolic operations; code may also enter prompts as project evidence; representation, semantic application, exact execution, verification, and continuity retain distinct failure surfaces | [Operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [scheduler–LLM asymmetry](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md), [bounded-context orchestration](../../notes/bounded-context-orchestration-model.md), [cross-form boundary movement](../../notes/moving-the-interpretation-enforcement-boundary-requires-coverage.md) | Architectures that combine roles, evidence that independent symbolic execution is unnecessary, and interventions on operation placement |
 | **Progress, warrant, and closure** | Explain movement of the human cut under a fixed boundary while keeping actor allocation separate from capability, warrant, usefulness, and power | Human-inclusive membership is cheap; decision-bearing functions are recorded as human, computational, or joint under a fixed boundary, objective, scope, and horizon; the cut-set and boundary-contraction endpoint; conditional adverse selection of residual work; staged transfer of branch allocation, reversible symbolic execution, and adoption; task-scoped structural closure; evaluator adequacy for warranted non-degenerate results; fixed-client limits of the remote-programmer benchmark | [Fixed-boundary reallocation](../../notes/computationally-directed-self-improvement-is-a-reallocation.md), [warranted transfer](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md), [task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Before-and-after transfer studies, cut-set and contraction tests, evaluator tests, measurement of displaced work, and non-degenerate closure declarations |
-| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the full provisional bootstrap strategy and the conditions under which that strategy should be retained or abandoned | Production method differs from representational form; the current loop already uses model-mediated and symbolic computation; high-level operator selection is a missing-machinery description rather than protected intelligence; recurring judgments should become reusable search, selection, and credit-assignment machinery; present theories, code, evaluators, decompositions, and operation boundaries remain challengeable; domain-extensibility, compute scaling, direct alternatives, Sutton's later weight-update bet, and abandonment conditions | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [global-fit selection environment](../../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md), [conditional bootstrap compatibility](../../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md) | Compute-scaling tests, learned code and prompt production, operation-boundary revision, alternative first strategies, cross-domain transfer, and matched baselines |
+| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the full provisional bootstrap strategy and the conditions under which that strategy should be retained or abandoned | Production method differs from representational form; the current loop already uses model-mediated and symbolic computation; high-level operator selection is a missing-machinery description rather than protected intelligence; recurring judgments should become reusable search, selection, and credit-assignment machinery; present theories, code, evaluators, decompositions, and operation boundaries remain challengeable; domain-extensibility, compute scaling, direct alternatives, Sutton's later weight-update bet, and abandonment conditions | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [global-fit selection environment](../../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md), [Sutton–Javed source](../../sources/sutton-javed-why-ai-models-stop-learning.ingest.md), [conditional bootstrap compatibility](../../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md) | Compute-scaling tests, learned code and prompt production, operation-boundary revision, alternative first strategies, cross-domain transfer, and matched baselines |
 | **Prospective experiments** | Turn the central conjecture and bootstrap strategy into results that can change their status | First, matched correct-theory, information-matched, theory-withheld, and wrong-theory conditions with weights and symbolic state fixed. Second, compare model-mediated bookkeeping, generated or selected code, and a hybrid. Third, instrument whether later evidence changes branch allocation, code, or the boundary between them | [Shared-model protocols](./shared-model.md#next-experiments), future preregistrations and results | Independent replication, alternative controls, adversarial task selection, direct-learning baselines, and failure analysis |
 
 ## Composition
 
 The modules do not imply an article per row. One article may carry several
-modules, but each full supporting argument should have one public owner. Other
-articles repeat only enough to remain self-contained and link to that owner.
+modules, but each full supporting argument should have one canonical article. Other
+articles repeat only enough to remain self-contained and link to that article.
 This limits synchronization cost and makes bounded agent edits possible.
 
 No article carries the series' routing: `kb/articles/README.md` is the rendered
@@ -63,7 +63,7 @@ The program statement is the entry point, not the container for every supporting
 argument. It may summarize a companion's result when that summary is required
 to state the program, but it should not reproduce the companion's derivation.
 
-The boundary between the program statement and the decisions companion is exact.
+The division between the program statement and the decisions companion should be explicit.
 The program statement may state two boundary facts: current Commonplace evidence
 is human-inclusive, and the research direction is to move named
 decision-bearing functions toward computational supply. The fixed-boundary
@@ -73,7 +73,7 @@ the decisions companion. If the program statement names the cut-set endpoint, it
 does so only in its bootstrap section and links out rather than teaching the
 formalism.
 
-The boundary between the program statement and the Bitter Lesson article is
+The division between the program statement and the Bitter Lesson article is
 likewise asymmetric. The program statement retains the narrow
 production-method/representational-form distinction, why this human-agent loop
 is the first strategy being tried, the requirement that present machinery remain
@@ -133,7 +133,7 @@ fixed-boundary and cut-set argument stays in the decisions companion.
 
 Related-system comparisons should follow enough of the proposed mechanism for
 the contrast to be intelligible. The Naur exegesis, cut-set derivation, closure
-and warrant theory, full Bitter Lesson defense, and Sutton comparison are not
+and warrant theory, full Bitter Lesson and bootstrap argument, and Sutton comparison are not
 independent top-level movements of the program statement.
 
 An agent edit should normally target one of these six units and name the modules
@@ -244,7 +244,7 @@ reproduce their process.
 
 For broad article work, name the target unit from the research-program contract
 and its excluded modules before editing. Afterward, run a bounded integration
-check for duplicated argument ownership, inconsistent evidence claims, and
+check for duplicated full arguments, inconsistent evidence claims, and
 broken companion links rather than rewriting the article globally.
 
 Each article should make clear:

--- a/kb/work/theory-mediated-self-improvement-series/article-roles.md
+++ b/kb/work/theory-mediated-self-improvement-series/article-roles.md
@@ -9,50 +9,81 @@ only after disposition in the [incumbent ledger](./incumbent-ledger.md).
 
 | Module | Job | Essential content | Primary support | Open research contact |
 |---|---|---|---|---|
-| **Research-program statement** | State one central question, the evidence standard that would answer it, and the experiments that would change its status | Can fallible project theory keep computational search, symbolic execution, backtracking, recovery, and revision coherent across delayed feedback? Weight–prompt operations and their code complement; lightweight search control; Commonplace and programming agents as linked testbeds; current human selection; truth versus fit; evidence ladder; decisive experiments | [Shared model](./shared-model.md), [target problems](./target-problems.md), [coherent search under delayed feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [revision evidence](../../notes/evidence/commonplace-revision-used-theory-guided-computational-search.md) | Rival accounts of coherent modification, alternative operation decompositions, counterexamples, external testbeds, and experimental designs |
+| **Research-program statement** | State one central question, the proposed mechanism, the evidence standard, the current evidential position, and the studies that would change its status. Disclose present human dependence without turning the article into a general account of autonomy, closure, or warrant. | Can fallible project theory keep computational search, symbolic execution, backtracking, recovery, and revision coherent across delayed feedback? Weight–prompt operations and their code complement; lightweight search control; Commonplace and programming agents as linked testbeds; an early disclosure that current Commonplace evidence is human-inclusive; truth versus fit inside the evaluation problem; the evidence ladder; one bounded episode; the decisive experiment and longitudinal study; and a compact bridge to the bootstrap strategy and its failure conditions. | [Shared model](./shared-model.md), [target problems](./target-problems.md), [coherent search under delayed feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [revision evidence](../../notes/evidence/commonplace-revision-used-theory-guided-computational-search.md) | Rival accounts of coherent modification, alternative operation decompositions, counterexamples, external testbeds, and experimental designs |
 | **Bearer question** | Explain why program-specific theory matters and why Naur's argument does not settle that only humans can hold it | Retained theory is not the same as holding it; a holder uses partial theory to specialize search, coordinate executable changes, and recover across later demands rather than deducing a perfect change | [Accepted Naur baseline](./accepted/what-bound-naurs-theory-to-programmers.md), [Naur basis note](../../notes/naur-equates-machine-execution-with-formulated-criteria.md), [coherent-search claim](../../notes/program-theory-sustains-search-under-delayed-feedback.md), [lightweight search control](../../notes/lightweight-search-control-does-not-license-adoption.md) | Rival readings of Naur, interventions separating theory-guided from generic search, and task distributions that expose recovery |
 | **Operative theory** | State what would show that explicit theory participates in operation rather than remaining documentation | Reflective membership; prompt-side mediation with weights and symbolic state held fixed; addressable retention; independent exposure and read-back; continuation; mediation, empirical contact, theory learning, and recurrence as separate evidence levels | [Interpretation, retention, and independent read-back](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [mediation trace](../../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md), [natural-language project-state specialization](../../notes/natural-language-project-state-specializes-search-heuristics.md), [reflection buys addressability](../../notes/reflection-buys-addressability.md) | Better causal interventions, information-matched controls, alternative substrates, stronger read-back, and failures of selective rescoping |
 | **Functional architecture** | Explain the complementary operation classes without treating today's boundary as permanent | A model-mediated operation is instantiated by weights plus prompt; code plus runtime supplies independently executed symbolic operations; code may also enter prompts as project evidence; representation, semantic application, exact execution, verification, and continuity retain distinct failure surfaces | [Operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [scheduler–LLM asymmetry](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md), [bounded-context orchestration](../../notes/bounded-context-orchestration-model.md), [cross-form boundary movement](../../notes/moving-the-interpretation-enforcement-boundary-requires-coverage.md) | Architectures that combine roles, evidence that independent symbolic execution is unnecessary, and interventions on operation placement |
-| **Progress, warrant, and closure** | Evaluate movement of the human cut without collapsing structural closure, capability, warrant, usefulness, and power | Conditional adverse selection of residual work; staged transfer of branch allocation, reversible symbolic execution, and adoption; task-scoped structural closure; evaluator adequacy for warranted non-degenerate results; fixed-client limits of the remote-programmer benchmark | [Warranted transfer](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md), [task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Before-and-after transfer studies, evaluator tests, measurement of displaced work, and non-degenerate closure declarations |
-| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the provisional strategy for improving the whole operation surface | Production method differs from representational form; prompts specialize weight-resident competence; code can be a computationally produced and selected symbolic complement rather than protected infrastructure; the current loop already uses both operation classes; the operator supplies much high-level selection and boundary judgment; other computational strategies remain live | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [global-fit selection environment](../../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md), [conditional bootstrap compatibility](../../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md) | Compute-scaling tests, learned code and prompt production, operation-boundary revision, alternative first strategies, cross-domain transfer, and matched baselines |
+| **Progress, warrant, and closure** | Explain movement of the human cut under a fixed boundary while keeping actor allocation separate from capability, warrant, usefulness, and power | Human-inclusive membership is cheap; decision-bearing functions are recorded as human, computational, or joint under a fixed boundary, objective, scope, and horizon; the cut-set and boundary-contraction endpoint; conditional adverse selection of residual work; staged transfer of branch allocation, reversible symbolic execution, and adoption; task-scoped structural closure; evaluator adequacy for warranted non-degenerate results; fixed-client limits of the remote-programmer benchmark | [Fixed-boundary reallocation](../../notes/computationally-directed-self-improvement-is-a-reallocation.md), [warranted transfer](../../notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md), [task-scoped closure](./task-scoped-computational-closure.md), [closure-capability map](./closure-capability-map.md), [separate progress dimensions](../../notes/usefulness-autonomy-warrant-and-power-are-separate-dimensions.md), [fixed-client benchmark](../../notes/holding-the-client-fixed-exports-the-least-warrantable-decisions.md) | Before-and-after transfer studies, cut-set and contraction tests, evaluator tests, measurement of displaced work, and non-degenerate closure declarations |
+| **Bitter Lesson and first strategy** | Separate the narrow weights-only rebuttal from the full provisional bootstrap strategy and the conditions under which that strategy should be retained or abandoned | Production method differs from representational form; the current loop already uses model-mediated and symbolic computation; high-level operator selection is a missing-machinery description rather than protected intelligence; recurring judgments should become reusable search, selection, and credit-assignment machinery; present theories, code, evaluators, decompositions, and operation boundaries remain challengeable; domain-extensibility, compute scaling, direct alternatives, Sutton's later weight-update bet, and abandonment conditions | [Response portfolio](../../notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md), [production method versus form](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), [operation-level complement](../../notes/code-complements-weight-prompt-with-symbolic-operations.md), [global-fit selection environment](../../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md), [conditional bootstrap compatibility](../../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md) | Compute-scaling tests, learned code and prompt production, operation-boundary revision, alternative first strategies, cross-domain transfer, and matched baselines |
 | **Prospective experiments** | Turn the central conjecture and bootstrap strategy into results that can change their status | First, matched correct-theory, information-matched, theory-withheld, and wrong-theory conditions with weights and symbolic state fixed. Second, compare model-mediated bookkeeping, generated or selected code, and a hybrid. Third, instrument whether later evidence changes branch allocation, code, or the boundary between them | [Shared-model protocols](./shared-model.md#next-experiments), future preregistrations and results | Independent replication, alternative controls, adversarial task selection, direct-learning baselines, and failure analysis |
 
 ## Composition
 
-The modules do not imply an article per row. No article carries the series'
-routing: `kb/articles/README.md` is the rendered collection landing and the
-reader's entry point, and the articles collection forbids in-prose links into
-`kb/work/`, so an article cannot route to the shared model, target problems, or
-closure map in any case. Each article stands on its own and links only the
-companions a reader actually needs next.
+The modules do not imply an article per row. One article may carry several
+modules, but each full supporting argument should have one public owner. Other
+articles repeat only enough to remain self-contained and link to that owner.
+This limits synchronization cost and makes bounded agent edits possible.
+
+No article carries the series' routing: `kb/articles/README.md` is the rendered
+collection landing and the reader's entry point, and the articles collection
+forbids in-prose links into `kb/work/`, so an article cannot route to the shared
+model, target problems, or closure map in any case. Each article stands on its
+own and links only the companions a reader actually needs next.
 
 The current minimum public surface is:
 
 1. **[A research program for theory-mediated system
    learning](../../articles/a-research-program-for-theory-mediated-system-learning.md)**
-   carrying the central question, complementary operation classes, lightweight
-   search control, current computational loop, truth-versus-fit distinction,
-   evidence ladder, testbeds, and experiments. This is the article the workshop
-   is now expanding.
+   carrying the central question, fallible longitudinal search, complementary
+   operation classes, lightweight search control, the evidence ladder,
+   truth-versus-fit inside the evaluation problem, the two testbeds, the bounded
+   Commonplace episode, and the studies that would change the program's status.
+   It discloses early that the current path is human-inclusive and later gives
+   only the compact bootstrap bridge needed to explain why the operator's
+   remaining judgments are research targets.
 2. **[The decisions that stay human, and what would move
    them](../../articles/the-decisions-that-stay-human-and-what-would-move-them.md)**
-   carrying the conditional adverse-selection argument, the residual-class table
-   of what would have to grow, structural closure versus evaluator quality, and
-   the fixed-client limit of the remote-programmer benchmark.
+   carrying fixed-boundary function allocation, the human cut-set and
+   boundary-contraction endpoint, the conditional adverse-selection argument,
+   the residual-class table of what would have to grow, structural closure
+   versus evaluator quality, and the fixed-client limit of the remote-programmer
+   benchmark.
 3. **The Naur article** carrying the bearer argument and the shift from one-shot
    correctness to coherent search, executable modification, and recovery.
 4. **The Bitter Lesson article** carrying the narrow form-only rebuttal, the
    already-computational human-agent loop, the prompt/code learning surface,
-   high-level selection and operation-boundary bottlenecks, alternatives, and
-   failure conditions.
+   conversion of recurring operator judgments into selection machinery,
+   challengeability of the present decomposition and operation boundary,
+   domain-extensibility, Sutton's later weight-update position, direct
+   alternatives, and failure conditions.
 5. **Experimental protocols and later results**, published as articles only when
    the evidence has enough substance to warrant them.
 
-Progress, closure, and warrant left the program statement on 2026-08-30 because
-they were displacing the central question, not because they acquired their own
-result; that split was an exposition decision and the transfer article's claims
-are still conditional. Functional architecture stays in the program statement
-while it can be explained there without the same crowding. Split out a further
+The program statement is the entry point, not the container for every supporting
+argument. It may summarize a companion's result when that summary is required
+to state the program, but it should not reproduce the companion's derivation.
+
+The boundary between the program statement and the progress article is exact.
+The program statement may state two boundary facts: current Commonplace evidence
+is human-inclusive, and the research direction is to move named
+decision-bearing functions toward computational supply. The fixed-boundary
+derivation, human/computational/joint allocation profile, cut-set endpoint,
+boundary contraction, structural closure, capability, and warrant belong to
+the progress article. If the program statement names the cut-set endpoint, it
+does so only in its bootstrap section and links out rather than teaching the
+formalism.
+
+The boundary between the program statement and the Bitter Lesson article is
+likewise asymmetric. The program statement retains the narrow
+production-method/representational-form distinction, why this human-agent loop
+is the first strategy being tried, the requirement that present machinery remain
+challengeable, and concise abandonment conditions. The companion owns the full
+scaling argument, the account of computation already in the loop, conversion of
+operator judgments into machinery, domain-extensibility, the Sutton comparison,
+and the detailed alternatives.
+
+Functional architecture stays in the program statement while it can be
+explained there without displacing the central question. Split out a further
 evaluation article only when it carries a distinct formalism, dataset, or
 empirical result. Do not restore former article boundaries merely because
 rejected drafts used them.
@@ -65,10 +96,58 @@ experiment becomes a distinct result. Title that article on the result, not on
 the phrase *theory-mediated system learning*, which the program statement now
 uses in its general sense.
 
+## Research-program statement contract
+
+The program statement should remain editable as six bounded argumentative
+units:
+
+1. **Question, learning unit, and testbeds.** Open from Naur's problem, define the
+   deployed-system learning unit and theory mediation, introduce Commonplace and
+   programming agents, and disclose that the current Commonplace path includes
+   an operator who supplies much global-fit selection and final authorization.
+   Do not introduce cut-set or closure machinery here.
+2. **Fallible longitudinal search.** Explain coherent modification across
+   proposal, backtracking, recovery, and delayed feedback; distinguish
+   theory-guided search from a correct first-shot deduction; state the causal
+   theory intervention.
+3. **Functional architecture.** Give the distinct failure surfaces for retained
+   project state, model-mediated semantic operation, independently executed
+   symbolic operation, and independent exposure and read-back.
+4. **Evidence and evaluation.** Present mediation, empirical contact, theory
+   learning, and recurrence; treat claim truth and theory fit as two evaluation
+   questions inside this section rather than as a second article spine.
+5. **Current status and studies.** State what the recorded Commonplace episode
+   establishes and does not establish, then present the theory intervention and
+   longitudinal study that could change the program's status.
+6. **Bootstrap pressure and invitation.** State the narrow Bitter Lesson
+   compatibility, explain why the human-inclusive computational loop is the
+   first strategy, identify recurring operator judgments as targets for
+   reusable machinery, give only the compact progress criterion and failure
+   conditions needed here, link to the two companions, and invite rival
+   mechanisms and discriminating tests.
+
+The operator therefore appears in two places for two different reasons. The
+opening discloses the evidential boundary. The bootstrap section explains why
+the remaining human contribution is the next learning target. The full
+fixed-boundary and cut-set argument stays in the progress companion.
+
+Related-system comparisons should follow enough of the proposed mechanism for
+the contrast to be intelligible. The Naur exegesis, cut-set derivation, closure
+and warrant theory, full Bitter Lesson defense, and Sutton comparison are not
+independent top-level movements of the program statement.
+
+An agent edit should normally target one of these six units and name the modules
+it is not changing. A later integration pass checks the central question,
+evidence levels, current actor allocation, experimental controls, and companion
+boundaries; it should not default to rewriting the full article.
+
 ## Shared constraints
 
 - Coherent modification is the center. Warranted transfer and computational
   closure describe the boundary and evaluation problem around it.
+- The program statement discloses the human-inclusive evidence boundary early,
+  but reserves the reallocation, cut-set, contraction, closure, and warrant
+  argument for the bootstrap location and the progress companion.
 - A prompt does not define an LLM operation alone. Relative to fixed call
   settings, the model-mediated operation is instantiated by weights plus prompt.
 - Code complements the weight–prompt operation with runtime-assigned symbolic
@@ -108,6 +187,9 @@ uses in its general sense.
 - Only the form-only inference is rebutted under the Bitter Lesson. The
   theory-guided bootstrap is a first strategy under incomplete global
   evaluation, not a defense or a uniqueness claim.
+- The program statement summarizes that bootstrap only far enough to constrain
+  the research program; the full scaling argument and Sutton comparison belong
+  to the Bitter Lesson companion.
 - The current Commonplace loop already uses weight–prompt operations for
   retrieval, interpretation, search, synthesis, and criticism, and symbolic
   operations for repository changes, testing, validation, scheduling, and
@@ -159,6 +241,11 @@ source use remains limited by its row in the
 claim-by-claim recovery stay in the incumbent ledger and completed
 investigations; article prose should use their durable conclusions rather than
 reproduce their process.
+
+For broad article work, name the target unit from the research-program contract
+and its excluded modules before editing. Afterward, run a bounded integration
+check for duplicated argument ownership, inconsistent evidence claims, and
+broken companion links rather than rewriting the article globally.
 
 Each article should make clear:
 


### PR DESCRIPTION
## Summary

- narrows the research-program statement to its central question, proposed mechanism, evidence standard, current evidential position, and decisive studies;
- splits the operator material into an early disclosure of the human-inclusive boundary and a later bootstrap discussion;
- assigns the full fixed-boundary, cut-set, boundary-contraction, closure, and warrant argument to *The decisions that stay human, and what would move them*;
- assigns the full bootstrap scaling argument, domain-extensibility, Sutton comparison, alternatives, and failure conditions to the Bitter Lesson companion;
- adds a six-unit editorial contract so agents can edit bounded argumentative sections and use a separate integration pass.

## Motivation

The program article currently repeats substantial parts of its companions and introduces the operator-allocation formalism before the bootstrap problem has been established. This makes the article harder to follow and creates synchronization risk for agent edits.

This PR changes only `article-roles.md`. It establishes the intended division before any prose is moved or shortened in the articles themselves.