### PR TITLE
Extract reusable theory-mediated learning claims

### DIFF
--- a/kb/notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md
+++ b/kb/notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md
@@ -1,0 +1,35 @@
+---
+description: "Independent warrant and fit in a working theory answer different questions: a warranted claim may fit poorly, while apparent fit may be produced by an unwarranted or already-assumed claim"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [learning-theory, evaluation]
+---
+
+# A claim's warrant does not determine its fit in a working theory
+
+A claim used in a working theory faces at least two different evaluations. One asks whether the claim is true, formally valid, source-supported, or otherwise warranted over its stated scope. The other asks whether the claim belongs in this working theory in a form that improves explanation, search, prediction, modification, or revision. Evidence for one question does not settle the other.
+
+A warranted claim may fit poorly. It can be irrelevant to the theory's purpose, duplicate a claim already present, state the right fact at the wrong abstraction level, use a scope that does not match the decisions the theory must guide, or add detail that increases maintenance without changing any relevant inference. Independent warrant does not imply that retaining the claim improves the working theory.
+
+Apparent fit does not imply warrant either. A false, overgeneral, or weakly supported claim may integrate smoothly because the current implementation, vocabulary, or neighboring claims already assume it. It may even improve local search or repair while encoding a misconception that later evidence exposes. System coherence around a claim can therefore be evidence about integration without being independent evidence that the claim is warranted.
+
+The distinction also changes how contradiction should be interpreted. When a warranted new claim conflicts with the working theory, rejecting the claim is not the only possible repair. The contradiction may identify a defect in another claim, a scope boundary, a bad decomposition, or a larger theory that needs revision. Theory fit is therefore relational: it concerns how warranted claims compose into an operative explanatory structure, not whether each claim passes its independent warrant test in isolation.
+
+## The evaluations can inform but not substitute for each other
+
+Fit evidence can expose warrant problems. A claim that repeatedly fails to predict, guide recovery, transfer, or survive later demands may deserve renewed factual or formal scrutiny. Warrant evidence can likewise force a fit revision: a newly established result may require restructuring the working theory even when that restructuring initially makes the theory less convenient.
+
+The prohibition is substitution. "This claim helped the system" cannot silently become evidence that the claim is true, and "this claim is true" cannot silently become evidence that it deserves a retained role in this theory. The two evaluations may exchange evidence while retaining different questions and failure conditions.
+
+## Scope
+
+- **Warrant** is used broadly here because claims in the knowledge base may be empirical, formal, source-derived, or procedural. Literal factual truth is not the only relevant independent standard.
+- **Fit** is intentionally not given a complete scalar definition. Relevance, non-redundancy, scope, abstraction level, explanatory integration, and operational usefulness may contribute differently in different working theories.
+- Objectives, commitments, and grants of authority can affect whether a claim belongs in an operative theory without themselves being settled by empirical truth tests.
+- The claim does not imply that warrant and fit are statistically independent. It says neither evaluation determines the other.
+
+---
+
+Relevant Notes:
+
+- [System use is an initial selection environment when theory fit lacks a fixed oracle](./system-use-selects-theory-fit-without-a-fixed-oracle.md) — context: develops how a live system can expose theory fit when no complete fixed oracle decides it

--- a/kb/notes/a-retained-theory-intervention-isolates-one-explicit-theory-surface.md
+++ b/kb/notes/a-retained-theory-intervention-isolates-one-explicit-theory-surface.md
@@ -1,0 +1,40 @@
+---
+description: "Varying declared retained theory while holding weights and symbolic state fixed estimates the causal contribution of that explicit theory surface, not possession of the composite's whole program theory"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, self-improving-systems, evaluation]
+---
+
+# A retained-theory intervention isolates one explicit theory surface, not the system's whole program theory
+
+A system may carry program-relevant understanding across several places at once: explicit explanations, architectural decisions, code, tests, operational state, model competence, and human participants inside the declared boundary. A **retained-theory intervention** varies a declared explicit theory state while holding specified background components fixed. Its result therefore identifies the causal contribution of that theory surface under the intervention; it does not remove every theory-bearing influence from the composite or test whether the composite possesses a complete program theory.
+
+This distinction matters because explicit retained theory is unusually convenient to manipulate. Its claims can be retrieved, cited, withheld, replaced, perturbed, or selectively revised, [since only explicit retention is currently durable, writable, and addressable at once](./only-explicit-retention-is-durable-writable-and-addressable.md). But addressability does not make that surface exhaustive. Code and tests may encode related commitments symbolically, model weights may supply learned competence that reconstructs similar judgments, and an operator may carry relevant understanding that was never externalized.
+
+## What the intervention identifies
+
+Suppose two runs hold the model, symbolic state, tools, task, and budget fixed while varying only the retained theory supplied to the model-mediated decision process. A difference in proposal, branch allocation, diagnosis, evaluation, recovery, or later revision is evidence that the varied theory surface mediated that difference. Withholding, replacement, or targeted perturbation is stronger evidence than merely observing that the theory was retrieved or cited, [because citing retained theory at the decision point is only a mediation trace](./citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md).
+
+The identified contrast remains local to the treatment. If the withheld theory can be reconstructed from code, tests, task wording, model competence, or another retained artifact, a null result does not show that program theory is useless. It shows that varying this declared surface under these background conditions did not change the measured operation. Conversely, a large effect does not show that the surface contains the whole program theory; it shows that the information or organization varied there was causally important in this comparison, [since an experiment identifies only the contrast it actually runs](./an-experiment-identifies-only-the-contrast-it-actually-runs.md).
+
+## Retained theory state is an experimental object
+
+For an intervention, **retained theory state** should name the versioned, claim-bearing theory input designated as part of the treatment. That is narrower than all retained project state and narrower than everything the composite may in a dispositional sense know about the program. The distinction makes the treatment reproducible enough to state: a protocol can name which theory version was supplied, which components were fixed, and which outcomes were compared.
+
+This experimental object also differs from the wider [deployed-system learning unit](./the-deployed-system-not-the-model-is-the-unit-of-learning.md). The deployed system can learn by changing prompts, code, tests, schemas, tools, runtime policy, or other retained state. A retained-theory intervention asks a narrower causal question inside that larger learning surface: what difference does this addressable theory state make to the improvement path?
+
+## Scope
+
+- The claim concerns causal interpretation of interventions on explicit retained theory. It does not define all forms in which a system may possess or reconstruct program-relevant understanding.
+- Holding symbolic state fixed is a protocol choice for isolating the theory surface, not a claim that symbolic artifacts cannot themselves encode theory-bearing commitments.
+- Information-matched controls may be needed to distinguish the effect of theory organization from the effect of supplying additional task-relevant information.
+- A null result against one retained-theory surface does not establish that generic search and theory-guided search are equivalent under other representations or task distributions.
+
+---
+
+Relevant Notes:
+
+- [Only explicit retention is currently durable, writable, and addressable at once](./only-explicit-retention-is-durable-writable-and-addressable.md) — grounds: explains why explicit retained theory supplies a convenient manipulable surface without making it exhaustive
+- [Citing retained theory at the decision point is a mediation trace](./citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md) — grounds: separates observed consumption from the stronger causal evidence supplied by intervention
+- [An experiment identifies only the contrast it actually runs](./an-experiment-identifies-only-the-contrast-it-actually-runs.md) — grounds: bounds inference from withholding, replacement, and perturbation conditions
+- [The deployed system, not the model, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — contrasts: supplies the wider learning surface within which the retained-theory treatment is one experimental object

--- a/kb/notes/disconnected-witnesses-do-not-establish-a-full-causal-path-through-theory.md
+++ b/kb/notes/disconnected-witnesses-do-not-establish-a-full-causal-path-through-theory.md
@@ -1,0 +1,57 @@
+---
+description: "Theory use, outcome, theory revision, and later use establish theory-mediated learning only when their witnesses identify the joins of the same full causal path"
+type: kb/types/note.md
+traits: [title-as-claim, synthesis]
+tags: [foundations, self-improving-systems, evaluation]
+---
+
+# Disconnected witnesses do not establish a full causal path through theory
+
+Theory-mediated learning is a claim about a connected causal path, not a checklist of events that happened somewhere in the same project. Evidence that a theory existed, a decision occurred, an outcome followed, the theory later changed, and a later operation used some retained state does not by itself show that learning proceeded through that theory. The witnesses must identify the joins that make those events one full causal path.
+
+The strongest path has this shape:
+
+```text
+theory state T0
+  -> theory-mediated decision or search
+  -> realized change
+  -> independent or delayed consequence
+  -> read-back against T0
+  -> revised theory state T1
+  -> later operation consuming T1
+```
+
+This shape composes three existing requirements. [Theory-mediated self-improvement needs interpretation, retention, and independent read-back](./theory-mediated-self-improvement-needs-interpretation-and-retention.md): the functions must share a causally integrated, co-indexed path even when they use different substrates. [Citing retained theory at the decision point is a mediation trace](./citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md): a contemporaneous record can identify which retained theory a decision claims to have consumed, but citation alone does not establish load-bearing use or outcome read-back. And [history has one chance to become checkable](./history-has-one-chance-to-become-checkable.md): when a nondeterministic production path cannot be re-derived, transient facts needed to identify its joins must be converted into carried records while they remain available.
+
+## Each join supports a different inference
+
+The first join identifies **mediation**: which theory state entered the decision whose behavior is being attributed to theory. A retrieval log or later citation to a generally relevant theory is weaker because it need not identify what governed the decision. Withholding, replacement, or perturbation can provide stronger causal evidence for this link.
+
+The middle joins identify **empirical contact and theory learning**: which realized change produced the consequence, and whether that consequence was read back against the theory state that helped guide the change. A failure followed by an unrelated theory edit is not evidence that the failure revised that theory. Likewise, an accepted change does not by itself verify the theory that motivated it.
+
+The final join identifies **recurrence**: whether the revised theory state, rather than merely a descendant repository state, affected a later operation. Git ancestry can establish that later work descended from an earlier commit. It cannot by itself establish which retained theory the later decision consumed or whether the relevant revision was load-bearing.
+
+The evidence levels therefore compose only when their identities compose. Separate demonstrations of mediation, an empirical outcome, a theory edit, and later work can each be valid partial results while failing to establish the full recurrent theory-mediated path.
+
+## Recording follows from the evidential shape
+
+The required record is determined by the claim rather than by a universal logging schema. To support a record-based full-path claim, the retained evidence must let a reviewer associate the relevant episode, supplied theory-state version, decision or search branch, realized change, consequence, theory-state revision, and later claimed use. Actor or operator interventions must be retained where they determine one of those joins.
+
+For deterministic or otherwise re-derivable operations, some joins may be reconstructed by replay. For nondeterministic LLM production, omitted prompts, supplied theory components, rejected alternatives, or operator interventions generally cannot be recovered from the final artifact. Production-time recording is therefore a consequence of the full-path evidence requirement in those cases, not the theory claim itself.
+
+The exact event schema is an operational choice. This note establishes only what a record must make identifiable if it is later used as evidence for the full causal claim.
+
+## Scope
+
+- A full path is the strongest recurrent theory-mediated-learning claim, not the minimum evidence for every useful theory-guided change. Mediation, empirical contact, and theory revision remain reportable partial results at their recorded strength.
+- Co-indexing establishes identity across witnesses; it does not by itself establish that every link is causal. Interventions, independent exposure, and appropriate controls are still needed for the causal strength claimed.
+- The path may cross model-mediated, symbolic, environmental, and human components. Full-path identity does not imply one substrate or an autonomous technical subsystem.
+- The required identifiers depend on the contrast and inference. Recording more fields cannot repair an experiment that never ran the relevant contrast.
+
+---
+
+Relevant Notes:
+
+- [Theory-mediated self-improvement needs interpretation, retention, and independent read-back](./theory-mediated-self-improvement-needs-interpretation-and-retention.md) — grounds: supplies the distinct functions, evidence ladder, and requirement that they share a co-indexed causal path
+- [Citing retained theory at the decision point is a mediation trace](./citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md) — grounds: supplies the observable theory-to-decision edge and bounds what a citation establishes
+- [History has one chance to become checkable](./history-has-one-chance-to-become-checkable.md) — grounds: explains why non-re-derivable joins must be converted into carried evidence while available

--- a/kb/notes/system-use-provides-evidence-of-theory-fit-not-independent-warrant.md
+++ b/kb/notes/system-use-provides-evidence-of-theory-fit-not-independent-warrant.md
@@ -1,0 +1,38 @@
+---
+description: "Consequences of using a claim in a live system can test its integration and causal usefulness, but independent factual, formal, source, or scope evidence is still needed for its warrant"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [learning-theory, deploy-time-learning, evaluation]
+---
+
+# System use provides evidence of theory fit and causal usefulness, not independent warrant
+
+Putting a claim to work in a live system creates evidence that static inspection cannot supply. If the claim changes proposal, diagnosis, branch allocation, modification, recovery, transfer, or later operation, and those changes survive consequential use, the result bears on whether the claim is integrated into the working theory and causally useful there. It does not by itself establish that the claim is independently warranted.
+
+The distinction follows because [a claim's warrant does not determine its fit in a working theory](./a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md). System use primarily exposes the relational side. A claim that sounds coherent but never changes behavior has weak evidence of operative fit. A claim that changes search, helps distinguish rival repairs, reduces later repair, or transfers to a new case has stronger evidence that it participates usefully in the theory's operation.
+
+But the live system can reward its own misconceptions. Earlier implementation choices may already assume the claim; neighboring retained claims may make it appear indispensable; an evaluator may share the same error; or the current task distribution may never expose the claim's bad scope. Successful use can therefore be self-confirming.
+
+Independent factual, formal, source, and scope evidence must remain able to overturn the claim. Depending on the claim, that may include empirical observation, derivation, source review, contradiction tests, preregistered predictions, held-out demands, or transfer outside the cases that shaped the current theory. These checks test warrant at the strength their own evidence licenses rather than inheriting authority from the system's success.
+
+## The evidence can run in both directions
+
+System use is not merely positive evidence. A claim may fit poorly when it repeatedly fails to affect decisions, increases search or repair cost, breaks under later demands, or loses to a rival formulation under a controlled comparison. Those outcomes can motivate rescoping or removal even when the claim remains independently warranted.
+
+Conversely, system failure can expose a warrant problem without identifying one automatically. A failed modification may reveal that the guiding claim was false, that its scope was wrong, that another premise was missing, that the interpreter misapplied it, or that the evaluator accepted the wrong candidate. Read-back must assign the failure at the granularity the evidence supports rather than treating every bad outcome as a refutation of the theory.
+
+The useful division is therefore not "system evidence versus real evidence." System-building consequences are real evidence for integration and causal usefulness. They become evidence for truth, validity, or warranted scope only through an additional argument connecting the observed consequence to that claim.
+
+## Scope
+
+- The claim concerns evidence produced by operating or modifying a system with a working theory. It does not require that the system itself perform the independent warrant assessment.
+- Causal usefulness is relative to an objective, task distribution, horizon, and comparison. A useful claim under one regime need not fit another.
+- Independent warrant can itself depend on operational evidence when the claim predicts system behavior. The requirement is an explicit evidential connection, not separation by data source.
+- The note does not define a complete oracle for theory fit. It only separates what system-use evidence establishes directly from what requires further warrant.
+
+---
+
+Relevant Notes:
+
+- [A claim's warrant does not determine its fit in a working theory](./a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md) — grounds: supplies the distinction between independent warrant and relational theory fit
+- [System use is an initial selection environment when theory fit lacks a fixed oracle](./system-use-selects-theory-fit-without-a-fixed-oracle.md) — extends: develops why distributed and delayed live-system consequences can serve as an initial selection environment


### PR DESCRIPTION
## Summary

Extract four reusable notes from the research-program argument without trimming the article yet:

- a retained-theory intervention isolates one explicit theory surface rather than the composite's whole program theory;
- disconnected witnesses do not establish a **full causal path** through theory, as a synthesis of the existing co-indexing, mediation-trace, and production-history claims;
- a claim's warrant does not determine its fit in a working theory;
- system use provides evidence of theory fit and causal usefulness, not independent warrant.

## Scope

This PR deliberately does **not** shorten the research-program article or decompose the existing `system-use-selects-theory-fit-without-a-fixed-oracle.md` note. Those integration and trimming changes can follow after these canonical homes exist.

The full-causal-path note is marked `synthesis`: its contribution is the composition of three existing premises into the evidential shape the article needs, rather than a new production-time-recording theorem.