### PR TITLE
Trim and streamline theory-mediated research program

### DIFF
--- a/kb/articles/a-research-program-for-theory-mediated-system-learning.md
+++ b/kb/articles/a-research-program-for-theory-mediated-system-learning.md
@@ -15,8 +15,11 @@ source_notes:
   - kb/notes/the-bitter-lesson-defense-portfolio-has-one-load-bearing-member.md
   - kb/notes/reflection-buys-addressability.md
   - kb/notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md
+  - kb/notes/a-retained-theory-intervention-isolates-one-explicit-theory-surface.md
+  - kb/notes/disconnected-witnesses-do-not-establish-a-full-causal-path-through-theory.md
+  - kb/notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md
+  - kb/notes/system-use-provides-evidence-of-theory-fit-not-independent-warrant.md
   - kb/notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md
-  - kb/notes/warranted-transfer-leaves-people-the-hardest-to-warrant-decisions.md
   - kb/notes/natural-language-project-state-specializes-search-heuristics.md
   - kb/notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md
   - kb/notes/open-ended-improvement-allocates-search-before-evaluation.md
@@ -26,9 +29,7 @@ source_notes:
   - kb/notes/the-bitter-lesson-selects-production-methods-not-representational.md
   - kb/notes/naur-equates-machine-execution-with-formulated-criteria.md
   - kb/notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md
-  - kb/notes/methodological-and-computational-closure-track-different-changes.md
   - kb/notes/computationally-directed-self-improvement-is-a-reallocation.md
-  - kb/notes/warranted-autonomy-is-bounded-by-oracle-domain.md
   - kb/sources/programming-as-theory-building.ingest.md
 ---
 
@@ -61,18 +62,17 @@ not report that a current system already succeeds.
 
 The [deployed system rather than the
 model](../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md) is
-the unit of learning. Model weights, prompt templates and retained prompt state,
-code, tests, schemas, tools, and runtime policy can all be learning targets. A
-change counts as learning when an [improvement
+the unit of learning. Model weights, retained prompt state, code, tests, schemas,
+tools, and runtime policy can all be learning targets. A change counts as
+learning when an [improvement
 process](../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md)
 selects and retains it from evidence so that later operation depends on it. No
 weight update is required.
 
 The path is *theory-mediated* when addressable retained theory guides proposal,
-diagnosis, evaluation, or recovery, and later consequences can revise the same
-theory state. A claim can then be inspected, cited, withheld, perturbed, or
-rescoped. A weight checkpoint can also be replaced, but normally offers much
-weaker claim-level addressability.
+diagnosis, evaluation, or recovery, and later consequences can revise that
+theory so the revision affects later work. Claim-level addressability makes the
+theory inspectable, citable, perturbable, and selectively revisable.
 
 The program uses two linked testbeds. Commonplace, the agent-operated knowledge
 base from which this article comes, is the live human-agent system. Programming
@@ -98,12 +98,13 @@ cannot detect. [Holding a program theory means sustaining coherent search under
 delayed
 feedback](../notes/program-theory-sustains-search-under-delayed-feedback.md).
 
-A program theory need not be a complete formal specification or one document. It
-may be distributed across retained explanations, architectural decisions,
-operational observations, learned competence, and code. *Program theory* names
-that wider understanding. The *retained theory state* is the addressable part
-the system can retrieve, cite, withhold, and revise. The proposed intervention
-isolates this state while holding model weights and symbolic state fixed.
+Program-relevant understanding may be distributed across explanations,
+architectural decisions, code, tests, operational state, model competence, and
+human participants. The proposed experiment varies one explicit retained theory
+surface while holding specified background components fixed. It therefore tests
+the causal contribution of that surface, not whether it exhausts the system's
+whole program theory, [as the retained-theory intervention note makes
+explicit](../notes/a-retained-theory-intervention-isolates-one-explicit-theory-surface.md).
 
 Theory matters before a correct answer is available. [Open-ended improvement
 must allocate search before decisive evaluation
@@ -112,18 +113,18 @@ Retained theory can narrow candidates, identify commitments a local fix must
 preserve, interpret unexpected results, guide rollback and recovery, and change
 what later demands cause the process to try.
 
-Some of those judgments can remain provisional. As [lightweight search
-controls](../notes/lightweight-search-control-does-not-license-adoption.md), they
-allocate work among branches or probes without licensing adoption.
-[Backtracking keeps them
+Some of those judgments can remain provisional. [Lightweight search
+controls](../notes/lightweight-search-control-does-not-license-adoption.md) can
+allocate work among branches or probes without licensing adoption, while
+[backtracking keeps them
 provisional](../notes/backtracking-keeps-lightweight-search-control-provisional.md)
 when contrary evidence arrives.
 
 Generic search can also generate, test, and discard patches. The distinction is
 causal: withholding or replacing retained theory should change proposal, branch
-allocation, diagnosis, evaluation, recovery, or later revision. One working
-mechanism is that [natural-language project state may specialize search
-heuristics already present in model
+allocation, diagnosis, evaluation, recovery, or later revision. One possible
+mechanism is that [natural-language project state specializes search heuristics
+already present in model
 weights](../notes/natural-language-project-state-specializes-search-heuristics.md).
 A theory that merely accompanies the work remains documentation.
 
@@ -135,44 +136,27 @@ does not show that any current agent passes Naur's bearer tests.
 
 ### Where the program sits
 
-Two older lineages supply different halves of the proposal. Computational
-reflection, runtime models, requirements reflection, and architecture-based
-self-adaptation make a system's own structure or goals causally available to
-guide change, but normally keep the modeling language, adaptation operators, and
-evaluation machinery supplied. Explanation-based learning and symbolic theory
-refinement let an explicit fallible theory guide inference and change after
-empirical failure, but usually model an external domain rather than the
-learner's own software organization.
-
-The program proposes to test their conjunction: an addressable theory of a
-software system's purposes and organization guides changes to the
-behavior-determining system; delayed consequences revise the same theory; and
-the revision changes later modifications while the adaptation machinery remains
-challengeable. The [positioning
+Runtime reflection and self-adaptation supply the structural lineage: a system's
+own organization or requirements become causally available to guide change.
+Theory-refinement work supplies the epistemic lineage: an explicit fallible
+theory guides inference and is revised after empirical failure. This program
+tests their conjunction while leaving the adaptation machinery itself open to
+revision. The [positioning
 note](../notes/theory-mediated-system-learning-combines-runtime-self-modeling-with-theory-refinement.md)
-develops the two lineages and the relevant experimental competitors.
+develops the comparison and relevant baselines.
 
 [Workspace
 Optimization](../sources/workspace-optimization-how-to-train-your-agent.ingest.md)
-is a close contemporary LLM-agent implementation analogue, not the overall
-closest antecedent. It combines a frozen model with editable code and text,
-routes prediction failures toward responsible artifacts, and replays earlier
-transitions. Its explicit theory primarily models an external environment within
-one run; its decomposition and adoption machinery remain fixed; and
-cross-session recurrence of a program self-theory is not shown. [Three 2026
-self-improving harnesses examined for the
-program](../notes/evidence/three-2026-harnesses-retain-rules-or-weights-not-a-revisable-theory.md)
-expose other nearby fragments.
+is a close contemporary LLM-agent implementation analogue rather than the
+overall closest antecedent. It combines a frozen model with editable code and
+text, but its explicit theory primarily models an external environment within
+one run, while its decomposition and adoption machinery remain supplied.
 
 ## Four functions that fail differently
 
-Different decompositions answer different questions. A
-[proposal-selection
-loop](../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md)
-describes update-loop anatomy; [residue
-analysis](../notes/residue-classes-need-different-mechanisms-so-architecture-is-mixed.md)
-asks why warranted automatic transfer stops. The table maps those demands onto
-the current weight-prompt-code system.
+A proposal-selection loop asks what an improvement update must contain; residue
+analysis asks why warranted automatic transfer stops. The table below instead
+asks which functional roles carry the current path and how each can fail.
 
 | Functional role | Current realization | Characteristic failure |
 |---|---|---|
@@ -181,21 +165,18 @@ the current weight-prompt-code system.
 | Independently executed symbolic operation | Code plus a runtime carrying exact transitions, scheduling, validation, installation, rollback, and later reactivation | Faithful execution of the wrong transition, frozen decomposition, incomplete coverage, or truncated horizon |
 | Independent exposure and read-back | Tests, validators, held-out tasks, decorrelated criticism, later demands, reviews, and operational consequences; for much global fit and authorization, the operator | Weak proxies, captured evaluation, viability-only gates, delayed credit assignment, unstated preferences, or exogenous selection |
 
-The functions need distinct failure surfaces, not permanently separate
-representational forms. This split makes interventions possible: withhold
+The roles need distinct failure surfaces, not permanently separate
+representational forms. That separation permits targeted interventions: withhold
 theory, perturb interpretation, replace evaluation, or truncate continuity. A
-future substrate may host several functions at once.
+future substrate may host several roles at once.
 
-The same code can be read into a prompt as evidence and later executed by a
-symbolic runtime. The distinction concerns its consumption path, not its
-authorship. Symbolic execution can be exact while implementing the wrong
-requirement. Likewise, a model can understand and apply a false theory;
-independent evidence must be able to overturn it.
+The same code may also be read into a prompt as evidence and later executed by a
+symbolic runtime. Its role follows the consumption path, not its authorship; exact
+execution does not establish that the encoded requirement or theory is correct.
 
-The table also exposes the present actor allocation without making it the
-article's second subject: the operator still supplies much of the fourth
-function. Converting recurring parts of that work into reusable machinery is a
-bootstrap target.
+The table also exposes the present actor allocation. The operator still supplies
+much of the fourth role. Moving recurring parts of that work into reusable
+machinery is therefore a bootstrap target.
 
 ## Evidence and evaluation
 
@@ -224,29 +205,30 @@ Useful partial results should not be forced into the strongest claim:
 
 A [citation at the decision point is a mediation
 trace](../notes/citing-retained-theory-at-the-decision-point-is-a-mediation-trace.md),
-not proof that the theory was load-bearing. Withholding, replacement, or
-perturbation is stronger evidence. The higher levels must also be co-indexed:
-the theory that guided the change must receive the outcome read-back, and its
-revision must be what later operation consumes. [Disconnected witnesses do not
-establish learning through
-theory](../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md).
+not proof that the theory was load-bearing; withholding, replacement, or
+perturbation is stronger evidence. The higher levels also have to belong to the
+same full causal path. Separate witnesses for theory use, outcome, revision, and
+later work do not compose automatically into evidence of theory-mediated
+learning, [because disconnected witnesses do not establish a full causal path
+through
+theory](../notes/disconnected-witnesses-do-not-establish-a-full-causal-path-through-theory.md).
 
-### Truth and theory fit are different evaluations
+### Warrant and theory fit are different evaluations
 
-A candidate claim must be evaluated both for truth, validity, or warranted scope
-and for its fit in the larger working theory. A true claim may be irrelevant,
-redundant, badly scoped, or placed at the wrong abstraction level. A false claim
-may appear useful because the current implementation already assumes it. A
-warranted contradiction may instead show that the larger theory needs revision.
+A claim can be well warranted yet irrelevant, redundant, badly scoped, or at the
+wrong abstraction level for a working theory. Conversely, a weak or false claim
+can appear to fit because the current implementation already assumes it.
+[A claim's warrant therefore does not determine its fit in a working
+theory](../notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md).
 
-No present automatic evaluator fully decides global fit. Evidence comes from
-changed search and recovery, surviving predictions, later demands, rival or
-ablated theories, repair cost, human intervention, and transfer. The live system
-can therefore serve as an [initial selection
+No present automatic evaluator fully decides global fit. The live system can
+supply evidence through changed search and recovery, surviving predictions,
+later demands, rival or ablated theories, repair cost, intervention, and
+transfer. That makes system use an [initial selection
 environment](../notes/system-use-selects-theory-fit-without-a-fixed-oracle.md),
-but not as a truth oracle. Independent factual and formal checks, preregistered
-predictions, held-out demands, and transfer tests are needed to prevent the
-working theory from becoming self-sealing.
+but not an independent warrant oracle: [system use provides evidence of theory
+fit and causal usefulness, not independent
+warrant](../notes/system-use-provides-evidence-of-theory-fit-not-independent-warrant.md).
 
 ## Current status and what evidence is missing
 
@@ -258,26 +240,24 @@ recorded prospectively enough to establish how load-bearing the theory was,
 separate computational from operator contributions cleanly, or support a
 comparative result.
 
-The next step is therefore better evidence retention, not a stronger
-retrospective claim. Consequential episodes should preserve the theory and
-symbolic state supplied to each decision, the alternatives considered, operator
-interventions, later consequences, revisions, and the later operations claimed
-to depend on them.
+Future consequential episodes should therefore preserve enough information to
+connect the relevant theory state, decision, realized change, consequence,
+revision, and later use. For nondeterministic production, omitted causal joins
+cannot reliably be reconstructed after the fact.
 
-A controlled test would vary retained theory while holding the model, code,
-tools, task, and budget fixed. At minimum, it should compare usable theory with
-theory withheld or deliberately wrong on a sequence where later demands can
-expose earlier mistakes. The relevant questions are whether theory changes
-search and recovery, whether consequences revise the same theory state, and
-whether that revision changes later work. Any result identifies only [the
-contrast it actually runs](../notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md).
-Detailed controls and measures should be fixed when the study is run, not
-presented here as completed methodology.
+The minimum controlled test varies retained theory while holding the model,
+code, tools, task, and budget fixed. It should compare usable theory with theory
+withheld or deliberately wrong on a sequence where later demands can expose
+earlier mistakes. The relevant questions are whether theory changes search and
+recovery, whether consequences revise the same theory state, and whether that
+revision changes later work. Any result identifies only [the contrast it
+actually runs](../notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md).
 
 A longitudinal Commonplace study should likewise ask whether recurring operator
 judgments become reusable search, selection, or credit-assignment machinery and
 whether named functions move from human or joint to computational supply. Until
-such records exist, these are research directions rather than results.
+such records and comparisons exist, these are research directions rather than
+results.
 
 ## The bootstrap must outgrow its hand-crafted parts
 
@@ -290,54 +270,53 @@ Search and learning can produce prompts, theories, tests, and programs as well a
 weights. That gives explicit artifacts conceptual room; it does not vindicate
 the present hand-written ones.
 
-Commonplace is already computational. Model-mediated operations perform
-retrieval, proposal, criticism, comparison, diagnosis, and editing; symbolic
-operations carry repository changes, testing, validation, scheduling, and
-retention. Human judgment remains where global fit lacks a discriminating
-evaluator. When a judgment recurs with stable scope, it should become a search
-control, test, validator, learned critic, method, schema, or program.
+The present loop is already computational. Models retrieve, propose, criticize,
+compare, diagnose, and edit; symbolic operations carry repository changes,
+testing, validation, scheduling, and retention. Human judgment remains where no
+sufficiently discriminating reusable evaluator exists. Recurring judgments are
+therefore candidates for search controls, methods, tests, validators, learned
+critics, schemas, or programs rather than evidence for a permanently protected
+human role.
 
-That transition is measured by holding the human-inclusive boundary fixed and
-recording each decision-bearing function as human, computational, or joint.
-Progress means named functions move toward computational supply. Over a declared
-task scope and horizon, the technical endpoint is reached when the same
-improvement pathway still completes after the human participants are removed.
-That actor-allocation test does not establish quality or warrant. [The decisions
-that stay human, and what would move
+Progress is measured under a fixed human-inclusive boundary: named
+decision-bearing functions move from human toward joint or computational supply.
+Over a declared task scope and horizon, the technical endpoint is reached when
+the same improvement path still completes after the human participants are
+removed. That actor-allocation test does not establish quality or warrant. [The
+decisions that stay human, and what would move
 them](./the-decisions-that-stay-human-and-what-would-move-them.md) develops the
-full fixed-boundary, contraction, closure, and warrant argument.
+full fixed-boundary and warrant argument.
 
-The system must also use its current theory and machinery to search for
-successors that replace much, possibly all, of the hand-crafted content. What
-should persist is the learning loop and its functions, not any present carrier.
-No component inside the declared revision surface is exempt because it
-implements the improvement machinery: [machinery persists by warrant, not by
-position](../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md).
-The bootstrap [fits the Bitter Lesson only if learning can outgrow
+The system must also use its present theory and machinery to search for
+successors that can replace them. What should persist is the learning loop and
+its functions, not any current carrier. No component inside the declared
+revision surface is exempt because it implements improvement machinery:
+[machinery persists by warrant, not by
+position](../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md),
+and the bootstrap [fits the Bitter Lesson only if learning can outgrow
 it](../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md).
 
 This is the first strategy being tried because global theory fit lacks a
-complete fixed evaluator, while prompts, code, and retained artifacts are
-available without a training budget. Possible payoffs include [sample efficiency
+complete fixed evaluator while prompts, code, and retained artifacts are already
+available as learning surfaces. Possible payoffs include [sample efficiency
 under structured
 shifts](../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md)
-and an inspectable learning record. These are hypotheses, not exemptions from
+and an inspectable learning record. Those are hypotheses, not exemptions from
 full cost accounting.
 
 The strategy competes with end-to-end learning, evolutionary search, self-play,
 weight updates, and stronger-model baselines. It should be abandoned or narrowed
-when retained theory makes no causal difference; system use becomes
-self-confirming; more computation increases candidate volume without improving
-search or outcomes; recurring operator judgments do not become reusable
-machinery; new domains continue to require bespoke human ontologies and oracles;
-the decomposition remains protected from revision; or another method wins at
-comparable total cost.
+when retained theory makes no causal difference, system use becomes
+self-confirming, additional computation fails to improve search or outcomes,
+recurring human judgments do not become reusable machinery, new domains still
+require bespoke human ontologies and oracles, the decomposition remains
+protected from revision, or another method wins at comparable total cost.
 
 The companion article [The Bitter Lesson does not require everything to live in
 weights](./the-bitter-lesson-does-not-require-everything-to-live-in-weights.md)
-develops the full scaling argument, direct alternatives, domain-extensibility,
-and the separate disagreement with Sutton and Javed's later requirement of
-weight updates.
+develops the scaling argument, direct alternatives, domain-extensibility, and
+the separate disagreement with Sutton and Javed's later requirement of weight
+updates.
 
 ### The invitation
 

--- a/kb/notes/system-use-selects-theory-fit-without-a-fixed-oracle.md
+++ b/kb/notes/system-use-selects-theory-fit-without-a-fixed-oracle.md
@@ -1,5 +1,5 @@
 ---
-description: "A claim can be true without fitting a working theory; the current human-agent loop already uses computation guided by retained knowledge, while live system use supplies an initial selection environment for global fit"
+description: "When no complete fixed oracle decides whether a claim belongs in a working theory, distributed consequences of live system use can provide an initial selection environment"
 type: kb/types/note.md
 traits: [title-as-claim]
 tags: [learning-theory, deploy-time-learning, evaluation]
@@ -7,204 +7,64 @@ tags: [learning-theory, deploy-time-learning, evaluation]
 
 # System use is an initial selection environment when theory fit lacks a fixed oracle
 
-The current Commonplace loop is already computational. A language model reads
-retained project artifacts, searches and synthesizes candidate claims and
-changes, compares formulations, and writes accepted revisions back into the
-knowledge base. The operator currently supplies much of the high-level selection
-signal about whether a claim fits the larger theory and intended system.
+A working theory may contain claims that are individually warranted yet still fit poorly together or fail to help the system reason, modify, or recover. [A claim's warrant does not determine its fit in a working theory](./a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md). When no complete fixed oracle decides that fit, using the theory in the live system supplies an initial selection environment: claims and formulations can earn provisional standing by changing consequential work and surviving the distributed consequences of that use.
 
-The missing capability is therefore not computation in general. It is a more
-reusable, discriminating, and increasingly computational way to select global
-theory fit and assign credit when consequences are distributed or delayed.
+For a narrow transformation, a test suite may give a compact acceptance criterion. Open-ended project theory is different. No current automatic evaluator fully decides whether a candidate claim belongs in the larger causal picture, which neighboring claims it should displace, whether its abstraction is useful, or whether it will still guide coherent modification when later demands expose consequences that were not locally visible.
 
-A theory-mediated system is built from claims, but two different questions must
-be asked about each claim:
+This does not make theory fit untestable. It changes the shape of the test. Fit is exposed through a portfolio of consequences spread across operation and time, including whether a claim:
 
-1. **Is the claim true or otherwise warranted over its stated scope?**
-2. **Does the claim fit the larger working theory well enough to improve the
-   system's operation and revision?**
+- changes proposal, diagnosis, branch allocation, or recovery rather than merely being cited;
+- yields expectations that survive later evidence;
+- helps modifications preserve relevant organization across subsequent demands;
+- helps distinguish a bad candidate from a bad underlying theory;
+- reduces search, repair, or intervention relative to rival formulations; and
+- transfers when the task changes while the structure named by the theory remains relevant.
 
-The first question may admit empirical checks, formal derivations, source
-review, contradiction tests, or bounded benchmarks. The second is relational.
-It depends on the system's objective, the other retained claims, the
-representation and decomposition in use, and the decisions the theory is meant
-to guide.
+No one item is a complete oracle. Together they can discriminate among rival theory states more strongly than static coherence alone.
 
-A true claim can be irrelevant, redundant, too weak, badly scoped, or placed at
-the wrong level of abstraction. A false or overgeneral claim can appear useful
-for a while because it happens to support the current implementation. Truth and
-fit therefore cannot be collapsed into one test.
+## Why live use can select
 
-## Global fit has no complete fixed oracle here
+The system under construction is where many consequences of theory fit become observable. A claim about architecture may change where an agent searches for a defect. A decomposition may change which artifact is revised. A theory of failure may change whether a process retries, backtracks, or revises its own assumptions. Later work can then expose whether those choices made recovery cheaper, preserved structure, or failed in a predictable way.
 
-For a narrow program transformation, a test suite may provide a useful selection
-criterion. For an open-ended project theory, no current automatic evaluator
-fully decides whether a candidate claim belongs in the larger causal picture,
-which other claims it should displace, or whether its abstraction will continue
-to guide coherent modification after later demands arrive.
+The important property is counterfactual effect. A claim that is repeatedly retrieved but never changes work has little evidence of operative fit. A claim whose withholding, replacement, or perturbation changes search or recovery has stronger mediation evidence. A claim whose use survives later demands and beats a rival formulation has stronger selection evidence still.
 
-This is not a claim that global fit is untestable. It is a claim about the form
-of the available test. Fit is exposed through a distributed and delayed set of
-consequences rather than one complete local oracle. These consequences include:
+The live system is therefore an **initial** selection environment, not a final authority. It supplies consequences against which theory can compete before a complete global evaluator exists.
 
-- whether the claim changes proposal, diagnosis, or recovery rather than merely
-  being cited;
-- whether predictions and derived expectations survive contact with evidence;
-- whether modifications guided by it preserve the system's organization across
-  later demands;
-- whether it helps distinguish a bad candidate from a bad underlying theory;
-- whether it reduces search, repair, or human intervention relative to rival
-  formulations; and
-- whether its usefulness transfers when the task or domain changes while the
-  relevant structure remains.
+## Initial selection is vulnerable to self-confirmation
 
-The live system under construction can therefore serve as an **initial selection
-environment**. A claim earns provisional standing not merely by sounding
-coherent, but by making a counterfactual difference to building, operating, or
-repairing the system and by surviving the consequences of that use.
+A system can reward its own misconceptions. Earlier design choices may already assume a claim, neighboring artifacts may encode the same error, or the current workload may never reach the claim's bad scope. Successful use can then make a mistaken claim appear indispensable.
 
-## The current loop is computational theory-guided search
+For that reason, [system use provides evidence of theory fit and causal usefulness, not independent warrant](./system-use-provides-evidence-of-theory-fit-not-independent-warrant.md). Rival formulations, withholding or perturbation, held-out demands, transfer, delayed outcomes, and independent factual or formal checks are ways to make the selection environment less self-sealing.
 
-The absence of a complete global-fit oracle does not confine computation to
-narrow regions with formal tests. Computation already carries much of the wider
-search:
+The same limitation applies to blame assignment. A failed modification may reflect a false theory, a misapplied theory, a missing premise, a bad implementation, or a weak evaluator. System use exposes the failure but does not identify its cause automatically. The theory-mediated path must retain enough structure for later read-back to assign credit or blame at the granularity the evidence supports.
 
-- language models retrieve and interpret retained project knowledge;
-- they generate competing claims, decompositions, explanations, and system
-  designs;
-- they search for evidence and counterexamples;
-- they compare formulations and identify contradictions or missing distinctions;
-- they propose experiments, ablations, and repository changes;
-- programs and tools check local consequences, references, tests, and traces;
-  and
-- accepted revisions become inputs to later computational work.
+## Why "initial" matters
 
-The [2026-08-30 Commonplace revision record](./evidence/commonplace-revision-used-theory-guided-computational-search.md)
-is a concrete example. The model read many Commonplace artifacts, synthesized a
-review and candidate revisions, received sparse operator corrections about the
-Bitter Lesson framing, revised the theory and repository, and then used the
-revised state in later turns.
+This claim does not reserve global fit for permanent human judgment. The present selection environment may be partly human-inclusive because people supply high-level criticism, comparison, and authorization where reusable evaluators are weak. Recurring judgments can later become retained methods, search controls, critics, validators, tests, or other machinery when their scope and discrimination become strong enough.
 
-At the boundary that includes the operator, model, knowledge base, and tools,
-this is a human-inclusive theory-mediated learning loop. At a boundary excluding
-the operator, global-fit selection and final acceptance remain exogenous. The
-important unresolved transition is therefore from **computational search with
-human-assisted high-level selection** toward a process in which more of that
-selection and credit assignment is supplied by reusable computational machinery.
-
-Reading the artifacts and citing them is strong mediation evidence, but it does
-not quantify how load-bearing they were. A matched run with the artifacts
-withheld, replaced, or reduced to an information-matched record would provide a
-stronger causal estimate.
-
-## Use does not replace independent truth tests
-
-"It helped build the system" is not sufficient evidence that a claim is true.
-A system can reward its own misconceptions, overfit to its present architecture,
-or make a claim appear indispensable because earlier design choices already
-assume it.
-
-The use test must therefore be paired with independent checks wherever they are
-available and with designs that can expose self-confirmation:
-
-- compare rival claims or theories rather than only accepting or rejecting one;
-- withhold, replace, or perturb the claim and observe whether the work changes;
-- record predictions before outcomes are known;
-- use held-out demands and delayed operational consequences;
-- distinguish evidence about the claim from evidence about the implementation
-  built around it; and
-- test transfer beyond the cases that shaped the current theory.
-
-System-building evidence tests **fit and causal usefulness**. Empirical, formal,
-and source evidence test **truth, validity, or warranted scope**. Neither can
-silently substitute for the other.
-
-## The bootstrap grows selection machinery, not computation from zero
-
-The bootstrap should not be described as "handcraft now, add computation
-later." Computation is already present in retrieval, interpretation, proposal,
-criticism, comparison, editing, testing, and retention. The present bottleneck is
-that the operator still supplies many sparse, project-level judgments for which
-no sufficiently discriminating reusable evaluator exists.
-
-Those judgments should be treated as evidence about missing selection machinery.
-When one recurs and its scope becomes clearer, the system can operationalize it
-as a methodology, test, validator, learned critic, search objective, episode
-schema, or program. That expands the part of the loop over which computation can
-both propose and select changes.
-
-The relevant progress measure is not whether computation appears in the loop.
-It is whether:
-
-- additional computation improves proposal, criticism, comparison, and recovery;
-- retained theory improves that computation relative to appropriate controls;
-- recurring operator corrections are captured and reused;
-- the marginal human judgment required per useful revision falls; and
-- the resulting machinery transfers beyond the cases and domains that produced
-  it.
-
-## This is a first strategy, not a uniqueness claim
-
-The argument does not establish that explicit theory-guided bootstrapping is the
-only route to a general learner. End-to-end reinforcement learning,
-evolutionary search, self-play, learned world models, or future weight-updating
-systems may discover globally useful organization without evaluating explicit
-claims one by one.
-
-The narrower conjecture is that explicit theories are a promising first working
-state when feedback is sparse or delayed, changes preserve some causal
-structure, and the evaluator cannot yet fully formalize what a coherent system
-must preserve. Addressable claims may let the process use weak evidence for
-more targeted search and revision. That possible sample-efficiency advantage
-must be tested rather than assumed.
-
-The strategy loses in a tested regime when system use becomes a self-sealing
-criterion, when retained theory makes no causal difference, when additional
-computation does not improve search or selection, when human global judgment
-does not fall, when every new domain needs a bespoke theory and evaluator, or
-when a more direct computational method achieves better results at comparable
-total cost.
+Nor does the claim say that explicit theory-guided selection is the only route. A learned evaluator, end-to-end search process, or future weight-updating system may eventually provide a better selection environment. The live-system route is useful while global evaluation is incomplete because it converts ongoing construction and operation into evidence that can improve the theory and, potentially, the machinery that evaluates it.
 
 ## Scope
 
-- The claim concerns selection among empirical and procedural claims used to
-  build a system. Objectives, commitments, and grants of authority may remain
-  externally supplied.
-- "Initial" matters. System-building consequences are a starting selection
-  environment, not a promise that human holistic judgment remains permanently
-  necessary.
-- The current loop is already computational. "Bootstrap" names the effort to
-  improve the search-and-selection process and extend its revision surface, not
-  a pre-computational phase.
-- No single scalar is assumed to capture global fit. A portfolio of causal,
-  predictive, operational, and transfer evidence may still support increasingly
-  automated selection.
-- The current absence of a complete oracle is a statement about this program's
-  state, not a proof that no general evaluator can exist.
+- The claim concerns **theory fit**, not independent warrant. The distinction is developed in the linked notes above.
+- "Initial" means a starting environment under incomplete evaluation, not a permanent architecture or a promise that human holistic judgment remains necessary.
+- No single scalar is assumed to capture theory fit. A portfolio of causal, predictive, operational, and transfer evidence may support selection.
+- The current absence of a complete fixed oracle is a statement about this research setting, not a proof that no general evaluator can exist.
+- Objectives, commitments, and grants of authority may remain externally supplied even when empirical and procedural theory selection becomes increasingly computational.
 
 ## Open Questions
 
-- Which aspects of theory fit can be operationalized now without encoding the
-  current theory as the evaluator?
-- What intervention best measures how much retained Commonplace knowledge changes
-  LLM search relative to an information-matched record?
-- Which recurring system-level judgments should be converted first into tests,
-  validators, learned critics, or search objectives?
-- How should inference-time compute, tool use, human correction, and retained
-  artifacts be accounted for in an end-to-end comparison?
-- What baselines would show that theory-guided bootstrapping uses increasing
-  computation more effectively than direct end-to-end search?
+- Which aspects of theory fit can be operationalized without encoding the incumbent theory as the evaluator?
+- Which delayed consequences discriminate among rival theories strongly enough to guide selection rather than merely report viability?
+- How should fit evidence from the system be combined when different signals disagree?
+- When does a learned or formal evaluator outperform live-system selection at comparable total cost?
 
 ---
 
 Relevant Notes:
 
-- [The bitter lesson selects production methods, not representational forms](./the-bitter-lesson-selects-production-methods-not-representational.md) — grounds: requires computational search where selection criteria permit it without imposing a weights-only representation
-- [A proposal-selection improvement loop requires search, evaluation, and operative retention](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) — grounds: states the minimum machinery required for the initial environment to produce learning
-- [Holding a program theory means sustaining coherent search under delayed feedback](./program-theory-sustains-search-under-delayed-feedback.md) — grounds: identifies the system-level consequences through which project-theory fit can become visible
-- [Theory-mediated learning may improve sample efficiency under structured shifts](./theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md) — grounds: supplies the conditional reason to try explicit theory as the first working state
-- [Learning inside a fixed decomposition inherits its mistakes](./learning-inside-a-fixed-decomposition-inherits-its-mistakes.md) — grounds: explains why the initial selection environment must eventually challenge its own representational choices
-- [Choosing what to learn requires both validity and learning-value gates](./choosing-what-to-learn-requires-both-validity-and-learning-value-gates.md) — contrasts: separates candidate validity from system-relative promotion value, a neighbouring decomposition that should not be conflated with truth versus global theory fit
-- [Use tests a decomposition locally; retained rationale is what makes transfer testable](./use-tests-a-decomposition-locally-rationale-makes-transfer-testable.md) — grounds: bounds what successful use of one whole configuration can warrant about its theory beyond the context that produced it
-- [Weakly discriminated qualities tend to be underselected](./weakly-discriminated-qualities-tend-to-be-underselected.md) — mechanism: explains why selection enriches locally checkable qualities more strongly than global coherence when their operative oracles discriminate unequally
-- [Oracle accumulation improves selection for later candidates in its maintained domain](./oracle-accumulation-improves-the-selection-environment.md) — extends: develops recurring operator corrections into maintained checks that improve later selection within calibrated domains
+- [A claim's warrant does not determine its fit in a working theory](./a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md) — grounds: separates independent warrant from relational fit
+- [System use provides evidence of theory fit and causal usefulness, not independent warrant](./system-use-provides-evidence-of-theory-fit-not-independent-warrant.md) — extends: bounds the evidential meaning of successful system use
+- [Holding a program theory means sustaining coherent search under delayed feedback](./program-theory-sustains-search-under-delayed-feedback.md) — grounds: identifies the longitudinal consequences through which program-theory fit can become visible
+- [Use tests a decomposition locally; retained rationale is what makes transfer testable](./use-tests-a-decomposition-locally-rationale-makes-transfer-testable.md) — grounds: bounds what one successful configuration can establish beyond its originating context
+- [Weakly discriminated qualities tend to be underselected](./weakly-discriminated-qualities-tend-to-be-underselected.md) — mechanism: explains why qualities with weak operative signals can disappear under selection despite sounding important


### PR DESCRIPTION
## Summary

Follow-up to the extracted theory-mediated learning notes.

### Research-program article

- replace the retained-theory-state mini-derivation with the new intervention note;
- compress related-work positioning while retaining the structural/epistemic lineage and Workspace Optimization comparison;
- clarify the role of the four-function table without introducing a new decomposition taxonomy;
- route full-causal-path evidence to the new synthesis note;
- compress warrant-versus-fit and system-use evidence to the new canonical notes;
- shorten the retrospective evidence-retention discussion;
- tighten the bootstrap while preserving its required spine: current computation, movement of human functions, challengeability of present machinery, first-strategy rationale, and abandonment conditions;
- smooth transitions and simplify repeated wording.

### System-use note

Narrow `system-use-selects-theory-fit-without-a-fixed-oracle.md` to its title claim: why distributed consequences of live use can serve as an **initial** selection environment when no complete fixed oracle decides theory fit. Remove the duplicated Commonplace-computation account, warrant/fit derivation, detailed bootstrap program, first-strategy defense, and progress metrics now owned elsewhere.

## Deliberate non-changes

- keep the four-function table and evidence ladder in the article;
- keep the compact human-inclusive progress criterion and bootstrap failure conditions;
- do not extract the decomposition crosswalk yet;
- do not alter the companion articles in this pass.