### PR TITLE
Add note on reversed literature contribution hierarchy

### DIFF
--- a/kb/notes/literature-reuse-can-reverse-a-papers-hierarchy-of-contributions.md
+++ b/kb/notes/literature-reuse-can-reverse-a-papers-hierarchy-of-contributions.md
@@ -11,6 +11,8 @@ Researchers often have to construct a careful ontology—a set of entities, dist
 
 A later project may value these outputs in the opposite order. The reported result may be specific to a substrate, implementation, or empirical setting that the later project does not share, while the supporting ontology still distinguishes cases that matter in its problem. The later project then reuses the machinery that made the original result expressible without treating that result as evidence for the new domain.
 
+The same reversal can occur with taxonomies, decompositions, and other conceptual frameworks. Ontologies are especially prone to it because they organize a range of possible cases, while a reported result is often confined to a narrower class of systems or observations. Their distinctions can survive changes of substrate or implementation when they capture structural relations. This transferability is strongest when the ontology makes enough commitments to discriminate relevant cases while avoiding commitments needed only by the source setting.
+
 The ontology is not independent of the original empirical or engineering work. Its value may come precisely from the range of cases and failed distinctions through which it was developed. What changes is which product of that work transfers: not necessarily the reported result, but the ontology shaped while producing it.
 
 ## Implication for literature ingestion

--- a/kb/notes/literature-reuse-can-reverse-a-papers-hierarchy-of-contributions.md
+++ b/kb/notes/literature-reuse-can-reverse-a-papers-hierarchy-of-contributions.md
@@ -1,0 +1,22 @@
+---
+description: "Explains why conceptual distinctions built to support a paper's stated result can become its most valuable reusable output in a different research context"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations]
+---
+
+# Literature reuse can reverse a paper’s hierarchy of contributions
+
+Researchers often have to construct a careful ontology—a set of entities, distinctions, relations, and boundaries for representing a domain—before they can state or test what they regard as a paper’s main contribution. They compare cases, separate cases that initially look alike, and revise distinctions that fail. The resulting ontology may appear only as definitions or framing that supports the advertised result.
+
+A later project may value these outputs in the opposite order. The reported result may be specific to a substrate, implementation, or empirical setting that the later project does not share, while the supporting ontology still distinguishes cases that matter in its problem. The later project then reuses the machinery that made the original result expressible without treating that result as evidence for the new domain.
+
+The ontology is not independent of the original empirical or engineering work. Its value may come precisely from the range of cases and failed distinctions through which it was developed. What changes is which product of that work transfers: not necessarily the reported result, but the ontology shaped while producing it.
+
+## Implication for literature ingestion
+
+Asking only what a paper presents as its main contribution can miss its most reusable content. Ingestion should also ask what distinctions the authors had to construct to formulate that contribution, which cases shaped those distinctions, and whether those distinctions discriminate cases in the receiving problem.
+
+## Scope
+
+This reversal is relative to the receiving project. It does not imply that the authors misidentified the main contribution in their own research context, or that an imported ontology applies to a new domain without being checked against its cases.


### PR DESCRIPTION
## Summary

- add a compact theory note on how literature reuse can reverse a paper's hierarchy of contributions
- distinguish reuse of an ontology shaped by empirical or engineering work from transfer of the paper's reported result
- explain why ontologies are especially prone to this reversal: they organize a range of possible cases and can retain structural distinctions across changes of substrate or implementation
- state the nearby implication for literature ingestion and bound the claim to the receiving project's needs

## Validation

- confirmed the branch is two commits ahead of `main` and not behind
- confirmed the diff changes only the new note
- the initial GitHub Actions run passed; checks for the follow-up commit may run separately
- local `commonplace-validate` was not available through the GitHub connector
