### PR TITLE
Contain premature software-factory framing in public articles

### DIFF
--- a/kb/articles/a-research-program-for-theory-mediated-system-learning.md
+++ b/kb/articles/a-research-program-for-theory-mediated-system-learning.md
@@ -185,7 +185,7 @@ theory](../notes/disconnected-witnesses-do-not-establish-a-full-causal-path-thro
 ### Warrant and theory fit are different evaluations
 
 A well-warranted claim can still fit a working theory poorly. Conversely, a weak
-claim can appear useful because the current implementation already assumes it.
+claim can appear to fit because the current implementation already assumes it.
 [A claim's warrant therefore does not determine its fit in a working
 theory](../notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md).
 

--- a/kb/articles/a-research-program-for-theory-mediated-system-learning.md
+++ b/kb/articles/a-research-program-for-theory-mediated-system-learning.md
@@ -25,10 +25,6 @@ source_notes:
   - kb/notes/the-bitter-lesson-selects-production-methods-not-representational.md
   - kb/notes/naur-equates-machine-execution-with-formulated-criteria.md
   - kb/notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md
-  - kb/notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md
-  - kb/notes/a-closed-factory-learning-transition-produces-a-successor-factory.md
-  - kb/notes/operative-succession-turns-meta-factory-construction-into-learning.md
-  - kb/notes/domain-extensibility-not-closure-determines-factory-reach.md
   - kb/sources/programming-as-theory-building.ingest.md
 ---
 
@@ -36,7 +32,7 @@ source_notes:
 
 > **Draft.** Comments and counterexamples are welcome through the repository's issue tracker.
 
-> **TL;DR.** A conventional software factory is lifecycle production machinery specialized for a product family. When production evidence computationally changes that machinery and the retained result governs later work, a computationally closed factory-learning occurrence produces a successor factory. Recursive factory construction is prior art; the open question is whether the same process can acquire the specialization needed for previously unanticipated demands. That is a domain-extensibility claim, not a promise of unrestricted universality or universal self-modification.
+> **TL;DR.** This program asks whether an agentic software-development system can retain a fallible project theory, use it to guide modifications, revise it when later consequences expose mistakes, and let the revision change subsequent work. Commonplace is the live human-agent testbed; a controlled programming-agent test will compare usable theory with theory withheld or deliberately wrong.
 
 ## The question and the two testbeds
 
@@ -85,51 +81,6 @@ persistent fallible theory about a software project and a sequence of
 modifications whose later demands can expose earlier mistakes. Matched runs will
 vary that theory while holding the rest of the system fixed, testing whether it
 changes search, recovery, and coherent modification.
-
-## Computationally closed factory learning produces successor factories
-
-A Greenfield-style [software
-factory](../notes/definitions/software-factory.md) is configured,
-family-specific machinery for producing and sustaining software through its
-lifecycle work products. Its schema, assets, tools, methods, and runtime support
-encode production knowledge for a declared product family. The term is narrower
-than a generic coding agent or harness, and the detailed [historical ontology
-belongs in the supporting
-note](../notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md).
-
-For a fixed factory, product development changes one family member; [factory
-development](../notes/definitions/factory-development.md) changes reusable
-machinery that will govern later members. These roles are producer-relative. A
-meta-factory may produce another factory as one of its members, making the same
-work product development relative to the first factory and factory development
-relative to the second.
-
-Such factory-valued production is prior art. The further step is
-evidence-responsive operative succession: experience from production must
-computationally determine a reusable change, and the retained result must enter
-the authority path for later work. When that learning path is [computationally
-closed](../notes/definitions/computationally-closed-software-factory-learning-loop.md),
-an actual change produces an operative [successor
-factory](../notes/definitions/successor-factory.md). This is a consequence of
-closed factory learning, not an independent requirement that a factory reproduce
-itself.
-
-Requirements, existing artifacts, user answers, corrections, bug reports,
-tests, telemetry, permissions, and acceptance responses may remain external
-evidence through declared interfaces. The path remains computationally open
-when a person supplies a factory-development decision assigned to it, such as
-the required family schema, a task-specific evaluator, a promotion choice, or
-ad hoc recovery.
-
-Closure is separate from breadth. A closed updater may remain confined to one
-family. [Domain extensibility](../notes/definitions/domain-extensible-software-factory.md)
-asks whether computation can acquire and install the family-specific machinery
-needed by sufficiently novel covered demands while fixed general learning
-machinery remains. The [unqualified universal-software-factory
-label](../notes/domain-extensibility-not-closure-determines-factory-reach.md) is
-too ambiguous: constructional universality can collapse into ordinary compiler
-expressivity, while unrestricted task universality would demand distinctions
-that the permitted evidence may not reveal.
 
 ## Holding a theory means controlling a fallible search
 
@@ -234,7 +185,7 @@ theory](../notes/disconnected-witnesses-do-not-establish-a-full-causal-path-thro
 ### Warrant and theory fit are different evaluations
 
 A well-warranted claim can still fit a working theory poorly. Conversely, a weak
-claim can appear to fit because the current implementation already assumes it.
+claim can appear useful because the current implementation already assumes it.
 [A claim's warrant therefore does not determine its fit in a working
 theory](../notes/a-claims-warrant-does-not-determine-its-fit-in-a-working-theory.md).
 
@@ -276,16 +227,16 @@ The Bitter Lesson puts pressure on the program because its present theory and
 improvement machinery emerge from a human-guided loop. Agents write much of the
 material, but operators still supply decisive high-level direction and
 selection. The issue is not who types the artifacts. It is whether computation
-can increasingly determine and operatively retain the task- or family-specific
-machinery needed as the demand class widens.
+can increasingly determine and operatively retain the task-specific machinery
+needed as the demand class widens.
 
 [Production method and representational form are different
 axes](../notes/the-bitter-lesson-selects-production-methods-not-representational.md):
 learning can produce explicit artifacts as well as weights. Fixed general
 models, learning methods, runtimes, interfaces, resource controls, and trusted
 kernels may remain. The scaling burden falls on human-supplied specialization
-that must be recreated for each new task or family, not on every handcrafted
-component merely because it is fixed.
+that must be recreated for each new task or area of work, not on every
+handcrafted component merely because it is fixed.
 
 The present loop is human-inclusive and computationally open over decisive
 high-level selection. Models search and revise project state, while symbolic
@@ -302,11 +253,11 @@ evidence. [The decisions that stay human, and what would move
 them](./the-decisions-that-stay-human-and-what-would-move-them.md) develops the
 full fixed-boundary and warrant argument.
 
-Second, widen production reach by computationally acquiring the specialization
-that novel covered demands require. Task-specific theories, schemas,
-decompositions, methods, and evaluators must not remain a new human construction
-project for every family the system claims to cover. This does not put every
-current component inside one universal revision surface. [Machinery persists by
+Second, widen the range of demands over which computation can acquire the
+specialization they require. Task-specific theories, schemas, decompositions,
+methods, and evaluators must not remain a new human construction project for
+every new region of claimed scope. This does not put every current component
+inside one universal revision surface. [Machinery persists by
 warrant, not by
 position](../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md),
 while the bootstrap [fits the Bitter Lesson only if learning outgrows its
@@ -326,7 +277,7 @@ organization. Each payoff must survive comparison at total system cost.
 
 The strategy must compete with more direct learning and search methods. It
 should be narrowed or abandoned if retained theory is causally inert, the
-evaluation loop becomes self-confirming, each novel covered family still needs
+evaluation loop becomes self-confirming, each new covered area still needs
 human-built task-specific decomposition or evaluation machinery, required
 in-scope decisions remain human, or another method wins at comparable total
 cost.

--- a/kb/articles/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md
+++ b/kb/articles/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md
@@ -13,7 +13,6 @@ source_notes:
   - kb/notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md
   - kb/notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md
   - kb/notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md
-  - kb/notes/definitions/domain-extensible-software-factory.md
 ---
 
 # The Bitter Lesson does not require everything to live in weights
@@ -102,8 +101,8 @@ methods might someday be learned. It becomes substantive when it identifies:
 
 The project's answer to the Bitter Lesson is therefore not the label but the
 prediction the label commits it to, and which it can be held to: computation
-will acquire the task- or family-specific specialization required as claimed
-reach widens instead of requiring people to construct it anew. Fixed general
+will acquire the task-specific specialization required as claimed reach widens
+instead of requiring people to construct it anew. Fixed general
 learning machinery may persist. The Bitter Lesson is a standing pressure on
 that prediction and the source of its failure conditions.
 
@@ -217,16 +216,14 @@ computationally producible or challengeable over the reach being claimed.
 Editable files are not enough. An agent may rewrite a prompt while every
 important target-specific decision remains fixed human design.
 
-The long-run criterion is [**domain
-extensibility**](../notes/definitions/domain-extensible-software-factory.md), not
-competence in several predefined domains. A system with ten hand-built
-ontologies and ten special update procedures is still a bundle of predefined
-solutions. Relative to a predeclared non-vacuous demand, evidence, acceptance,
-and coverage frame, a domain-extensible process must computationally determine
-and install the required family specialization without a person supplying it
-wholesale or piecemeal. The specialization must govern production beyond the
-product that first exposed the need, across at least one distinct admitted
-variation.
+The long-run criterion is not competence in several predefined
+domains. A system with ten hand-built ontologies and ten special update
+procedures is still a bundle of predefined solutions. As claimed scope widens,
+computation must increasingly determine and retain the task-specific theory,
+representations, methods, and checks that new demands require instead of
+receiving another bespoke human design. The retained specialization must affect
+later work beyond the episode that first exposed the need; otherwise a one-off
+repair can masquerade as a general learning method.
 
 This does not require the system to derive its own values or revise every fixed
 component. Objectives, commitments, grants of authority, general learning
@@ -274,15 +271,14 @@ than candidate volume, that recurring human judgments become reusable selection
 machinery, and that the marginal human contribution falls without hidden losses
 in quality or warrant.
 
-A later experiment can provide an initial probe toward domain extensibility.
-Before outcomes are known, declare the demand and family frame, evidence
-protocol, acceptance relation, coverage, novelty rule, and human-intervention
-boundary. Introduce a family that was not used to design the artifact ontology
-or improvement procedure. Track which schema, methods, checks, and evaluator
-components computation produces, whether the resulting specialization becomes
-operative, and whether it causally supports a distinct admitted family member.
-Broader domain-extensibility requires repeated transfer without a new bespoke
-human architecture.
+A later experiment can probe transfer beyond supplied specialization. Before
+outcomes are known, declare the demand class, evidence protocol, acceptance
+relation, coverage, novelty rule, and human-intervention boundary. Introduce
+tasks or an area not used to design the artifact ontology or improvement
+procedure. Track which theories, representations, methods, checks, and evaluator
+components computation produces, whether they become operative, and whether
+they help on independently selected later demands. Broader support requires
+repeated transfer without a new bespoke human architecture.
 
 The strategy loses in a tested regime when system use becomes self-confirming,
 retained theory makes no causal difference, additional computation does not


### PR DESCRIPTION
## Summary

- remove the premature closed-factory-learning and successor-factory section from the theory-mediated system-learning article
- replace its factory-first TL;DR with a summary of the article's actual current research question and tests
- keep the useful supplied-specialization argument while removing product-family terminology that depends on the unsettled ontology
- remove the registered `domain-extensible software factory` criterion from the Bitter Lesson article and restate the transfer requirement without committing to that definition

## Scope

This is the containment batch only. It deliberately leaves the Greenfield source ingests, software-factory definitions and theory notes, and the refoundation workshop unchanged for the ontology-import batch.

## Review notes

The branch changes only two public articles. It does not revert the broader Greenfield ingestion commit or discard its source work.