### PR TITLE
Refoundation 2/5: import the Greenfield software-factory ontology

### DIFF
--- a/kb/notes/a-software-factory-can-produce-another-factory-without-learning-its-specialization.md
+++ b/kb/notes/a-software-factory-can-produce-another-factory-without-learning-its-specialization.md
@@ -1,0 +1,90 @@
+---
+description: "Recursive software-factory construction is prior art, but the demonstrated constructors receive the family definitions, metamodels, mappings, and expertise that determine the produced factory"
+type: kb/types/note.md
+traits: [title-as-claim, has-comparison, has-external-sources]
+tags: [foundations, self-improving-systems]
+---
+
+# A software factory can produce another factory without learning its specialization
+
+Producing a software factory is not by itself evidence that a system learned how that factory should be specialized. The software-factory literature already contains recursive factory construction and tooling bootstraps. In the retained examples, computation realizes production machinery from supplied family definitions, metamodels, mappings, frameworks, or expertise. The semantically decisive specialization still originates with people.
+
+This separates two problems:
+
+```text
+factory construction
+  supplied description or specialization -> executable production machinery
+
+specialization acquisition
+  task or production evidence -> adequate family-specific production knowledge
+```
+
+A constructor can be highly expressive on the first problem while doing nothing on the second.
+
+## Greenfield's factory-building factory
+
+Greenfield and Short's [2003 software-factory account](../sources/greenfield-short-software-factories-oopsla-2003.ingest.md) explicitly describes software factories being used to produce other software factories. An IDE is used to build languages, frameworks, and tools for factory construction; those assets form a template that configures another IDE as a factory-building factory.
+
+The recursive product type is real: one configured production environment helps build another configured production environment. But product-line developers still choose the target family, define its domain models and variation, and construct the specialized template and assets. The example automates parts of factory construction; it does not infer the required family production knowledge from experience.
+
+## Tool Factory bootstraps production tooling from a supplied language family
+
+Cook and Kent's [Tool Factory](../sources/cook-kent-tool-factory-2003.ingest.md) makes the mechanism more concrete. A language designer combines supplied family fragments and patterns into a domain-specific-language definition. A generator then produces a designer and related tools on top of a shared framework. The language designer itself can be represented as another generated designer, allowing one version of the tool factory to bootstrap the next.
+
+Again, the recursive construction is substantive. What remains supplied are the language-family definition, fragments, patterns, framework, and mappings into implementation languages and technologies. Regenerating the production tooling can propagate or re-express that specialization without acquiring it.
+
+## MDSoFa computes factories from supplied metamodels and expertise
+
+Langlois and Exertier's [MDSoFa](../sources/langlois-exertier-mdsofa-software-factory-factory-2004.ingest.md) goes further by implementing a model-driven producer whose outputs can include metamodels, expertise, tools, frameworks, and another model-driven factory. The paper explicitly names the recursive case a `software factory factory`.
+
+Its computation combines supplied metamodels, mappings, aspects, generic expertise, target-platform choices, rule selection, and templates to produce specific expertise and tool environments. Human metamodel designers and architects supply the decomposition and strategic choices that make the generated factory appropriate to its target. The system demonstrates computational factory construction from encoded specialization, not evidence-driven acquisition of that specialization.
+
+## Construction and acquisition answer different questions
+
+| Question | Construction from supplied specialization | Acquisition of specialization |
+|---|---|---|
+| Primary input | Family schema, metamodel, language definition, mappings, expertise, templates, or complete factory description | Requirements, repositories, examples, failures, tests, user interaction, telemetry, and other task or production evidence |
+| Computational job | Realize, transform, package, install, regenerate, or compose production machinery | Determine what family scope, representations, workflows, tools, tests, variation knowledge, and other machinery the evidence requires |
+| Main uncertainty | Whether the description can be realized correctly and economically | Which description or production organization is adequate |
+| Prior-art status in the retained sources | Explicit and sometimes implemented | Not established as a computationally closed or general process |
+
+The distinction is not a judgment that construction is trivial. Tool generation, metamodel transformation, packaging, bootstrapping, compatibility, and installation are real technical achievements. The point is that they start after much of the target-specific production knowledge has been selected and represented.
+
+Nor must acquisition produce every detail from nothing. General models, languages, search procedures, runtimes, trusted kernels, and reusable cross-domain machinery can remain fixed. The relevant question is whether the target-specific specialization claimed as newly handled was already supplied or was determined from permitted evidence by the system.
+
+## What would turn the feedback path into learning
+
+Greenfield's [2007 account](../sources/greenfield-mass-customizing-software-factories-2007.ingest.md) already routes defects, requests, and unanticipated variation from solution developers to factory developers. Human factory developers then revise reusable assets or specialize the factory.
+
+A computational learning extension would require a stronger causal path:
+
+```text
+production under current family machinery
+  -> evidence about its limits
+  -> system-determined change to reusable family machinery
+  -> retention and later use of that change
+```
+
+That path concerns [factory development](./definitions/factory-development.md), not merely product repair. It can be driven by theory mediation, program search, trajectory reuse, learned policies, direct optimization, trial and error, or mixtures. Recursive factory output does not select among those mechanisms and does not make the transition learning by itself.
+
+## Consequences for the research program
+
+The novelty claim should not be that software factories can build software factories. That is established prior art. The open problem is whether an agentic system can use task and production evidence to acquire, revise, and retain the family-specific production knowledge that existing factory constructors receive from people.
+
+This also blocks a common shortcut. A generic interpreter or generator may be able to realize any factory when given a complete enough description. That constructional expressivity does not establish that the correct description can be found from the evidence available for a previously unanticipated demand.
+
+## Scope
+
+- The negative acquisition claim is bounded to the retained sources; it is not a claim about every system ever described under synthesis, meta-learning, or self-modification terminology.
+- Producing another producer is compatible with learning, but does not imply it.
+- Regenerating a newer tool or factory can be useful bootstrapping even when all semantically decisive changes are supplied by people.
+- A later agentic system may combine construction and acquisition in one process. The distinction remains useful because the evidence burdens differ.
+
+---
+
+Relevant Notes:
+
+- [A software factory is family-scoped lifecycle production machinery](./a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: supplies the inherited factory, family, asset, member, and development-process boundaries
+- [Software factory](./definitions/software-factory.md) — defined-in: names the configured family-specific producer constructed in the prior-art examples
+- [Factory development](./definitions/factory-development.md) — defined-in: names the acquisition or revision target when reusable family machinery changes
+- [Learning inside a fixed decomposition inherits its mistakes](./learning-inside-a-fixed-decomposition-inherits-its-mistakes.md) — extends: explains why computation inside a supplied factory structure does not test whether that structure should change

--- a/kb/notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md
+++ b/kb/notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md
@@ -1,5 +1,5 @@
 ---
-description: "Use this synthesis to recover Greenfield's versioned schema-template-factory ontology and distinguish constructing production machinery from acquiring its family specialization."
+description: "Reconstructs Greenfield's versioned software-factory ontology: declared product family, schema, packaged assets, configured environment, two development processes, and lifecycle work products"
 type: kb/types/note.md
 traits:
   - title-as-claim
@@ -10,247 +10,103 @@ traits:
 
 # A software factory is family-scoped lifecycle production machinery
 
-Here, *software factory* means the family-scoped arrangement in Greenfield's
-2003 and mature 2007 accounts. In those accounts, human developers use a
-specialized development and runtime environment to produce and sustain members
-of a declared product family. The family production knowledge is distributed
-across a schema, an installable template, processes, tools, and reusable
-assets. Product-specific lifecycle artifacts are outputs of this machinery;
-they are not the machinery itself.
+Here, *software factory* refers to the family-specific production arrangement described by Greenfield and Short in 2003 and by Greenfield's mature 2007 account. In both versions, the factory is more than a generator, workflow, model, or generic development environment. It is a development and runtime environment configured with reusable production knowledge for a declared family of software products or solutions.
 
-The vocabulary is versioned. The [available 2004 book
-preview](../sources/greenfield-short-software-factories-book-preview.ingest.md)
-confirms the book's identity, contributors, and broad integration program, but
-its publisher copy and partial contents cannot ground book-wide ontology claims.
-The detailed reconstruction is therefore bounded to fuller retained sources.
-`G03` says verbatim that “An IDE configured with a software template for a product family
-becomes a factory for producing members of the family.” ([Greenfield and Short's
-2003 account](../sources/greenfield-short-software-factories-oopsla-2003.ingest.md)).
-It supplies the original `software schema`, `software template`, developer roles,
-configured-IDE factory, and recursive construction account.
-[Greenfield's 2007 account](../sources/greenfield-mass-customizing-software-factories-2007.ingest.md)
-(`G07`) supplies the mature schema, template, lifecycle, two-process,
-specialization, composition, and feedback-supported revision account. A [later Microsoft patent
-execution model](../sources/us20090100406a1-software-factory-specification-execution-model.ingest.md)
-(`PAT`) adds precise type/instance relations for views, work products, tasks,
-and workstreams. Those relations refine the mature ontology; they are not
-definitions retroactively attributed to `G03` or `G07`.
+The vocabulary changed between the two accounts, so this note keeps the reconstruction versioned. The [2003 paper](../sources/greenfield-short-software-factories-oopsla-2003.ingest.md) supplies the original `software schema`, `software template`, configured-IDE definition, developer roles, and factory-building example. The [2007 account](../sources/greenfield-mass-customizing-software-factories-2007.ingest.md) supplies the mature software-factory schema and template, lifecycle scope, two interacting development processes, specialization, composition, and feedback-supported revision. The available [2004 book preview](../sources/greenfield-short-software-factories-book-preview.ingest.md) confirms the book and its broad integration program but is too partial to ground its detailed ontology.
 
-The stable relation across the changing vocabulary is a synthesis rather than
-a quotation:
+The stable relation is:
 
-`declared product family and production knowledge -> factory development -> schema plus packaged assets -> configured environment -> creation and sustainment of one family member through lifecycle work products`
-
-Each object in that relation has a different role.
+```text
+declared product or solution family
+  -> factory development organizes family production knowledge
+  -> schema plus packaged reusable assets
+  -> configured development and runtime environment
+  -> solution development creates and sustains family members
+  -> product-specific lifecycle work products express member state
+```
 
 ## Versioned ontology
 
-| Object | Family-production role | Product-level boundary |
-|---|---|---|
-| Product family | `G03` scopes a factory to members sharing modeled commonality and variability. `G07` describes products or solutions that vary in features and operational qualities. The declared scope, common parts, variation points, variants, and constraints delimit the admitted production space. | Family membership is not whatever a generator happens to emit. The retained sources do not supply a formal membership predicate, and ordinary member production does not infer the family boundary. |
-| `software schema` (`G03`) | A graph of viewpoints for one family, with associated domain-specific languages, constraints, and transformations. It describes the specifications needed to produce a member. | It is one constituent of the 2003 software template, not an installed factory or one product specification. |
-| `software factory schema` (`G07`) | A dynamic, family-specific architecture framework. Its viewpoints relate stakeholder concerns, relevant artifacts, activities acting on those artifacts, and assets supporting those activities. Relationships among viewpoints integrate architecture and lifecycle. | It is a richer, historically related ontology, not merely a new name for the 2003 schema. `Dynamic` does not mean learned or automatically revised. `G07` uses schema modification both when accommodating member variation and when specializing a base factory, so viewpoint change alone does not classify the operation. |
-| Software template / software factory template | In `G03`, the schema, the processes for capturing and using its information, and automation tools collectively form a `software template`. In `G07`, a `software factory template` is a structured, installable package of customizable assets. | The schema organizes production knowledge; the template packages machinery for installation and customization. The evidence supports this functional separation, not an exact later containment rule for every asset. |
-| Configured or operative factory | `G03` calls an IDE configured with the family template a software factory. `G07` calls it a specialized development and runtime environment supplying integrated special-purpose assets. *Operative factory* is the synthesis term for this installed producer. | It is not its schema, template, any single asset, a product work product, or the resulting family member. Human solution builders use it and it supplies lifecycle guidance, so it is not merely an autonomous code generator. |
-| Viewpoint, concern, and view | In `G03`, viewpoints organize family specifications. In `G07`, a viewpoint covers concerns of stakeholder roles and groups relevant artifacts, activities, and assets. `PAT` later declares viewpoint types at schema level. | A concern is what matters to a stakeholder role; a viewpoint is its organizing frame. In `PAT`, a product-specific `view` instantiates a viewpoint type. This last type/instance distinction is later precision, not timeless Greenfield vocabulary. |
-| Artifact and work product | `G07` uses `artifact` for items organized under viewpoints and for reusable partial or prototypical content. `PAT` later declares work-product types in the schema. | `PAT` represents product state as work-product instances organized through product views. A reusable prototype may be a factory asset; the product-specific work product created or changed with it is member state. `Artifact`, `work product`, and `asset` overlap but are not universal synonyms. |
-| Activity, task, and workstream | `G07` associates activities with the artifacts they act on and the assets that support them. `PAT` later defines task and workstream templates at factory level. | `PAT` instantiates those templates as product-specific tasks and workstreams. Tasks consume or produce declared work-product types. This refines rather than renames `G07`'s activity concept, and the retained account is not a complete execution state machine. |
-| Asset | `G03` distinguishes implementation assets from process assets. `G07` includes guidance, processes, content, tools, patterns, samples, templates, libraries, frameworks, models, configuration files, components, and partial lifecycle artifacts. | Assets carry or enact reusable family production knowledge, but they are not autonomous actors and need not be product state. Activities or tasks use them to create or modify member work. |
-| Family member | `G03` says product-family member, `G07` often says solution, `PAT` says product, and product-line literature says application. | These names have an analogous role here, not guaranteed identical definitions: one product-specific result built within the family production system. |
+| Object | 2003 account | Mature 2007 account | Stable boundary |
+|---|---|---|---|
+| Product or solution family | A product family is defined through common features, known variation points, variants, constraints, and domain models that delimit prospective members. | Products or solutions vary in features and operational qualities within a family addressed by the factory. | Family scope is part of factory identity; membership is not whatever a tool happens to emit. |
+| Schema | A `software schema` is a graph of family viewpoints with associated domain-specific languages, constraints, and transformations. It describes the specifications needed to produce a member. | A `software factory schema` is a dynamic, family-specific architecture framework. Its viewpoints organize stakeholder concerns, artifacts, activities, supporting assets, and relationships across architecture and lifecycle. | The schema organizes family production knowledge. The later schema is richer and should not be projected backward as a mere rename. |
+| Template | The schema, the processes for capturing and using its information, and tools that automate those processes collectively form a `software template`. | A `software factory template` is a structured, installable package of customizable tools, processes, content, partial lifecycle artifacts, and implementation assets. | The template packages reusable machinery for installation; it is not itself the configured production environment. |
+| Configured factory | An extensible IDE configured with a software template for one product family becomes a software factory. | A software factory is a specialized development and runtime environment supplying an integrated set of special-purpose assets for a family. | The factory is the configured environment that makes family production machinery available in actual work. |
+| Reusable assets | Product-line developers build implementation assets such as architecture and components, plus process assets and tools. | Assets include guidance, processes, requirements and architecture prototypes, test suites, deployment and operational material, patterns, samples, templates, libraries, frameworks, models, configuration files, components, and tools. | Reusable assets carry or enact family-level production knowledge. |
+| Family member | Product developers configure and assemble one member of the product family. | Solution developers select, adapt, configure, complete, assemble, generate, deploy, operate, maintain, and migrate individual solutions. | Product-specific lifecycle work products express the member's state; they are not automatically reusable factory machinery. |
+| Development roles | Product-line developers construct the family machinery; product developers use it to build members. | Factory developers construct and revise assets for solution developers; solution developers build and sustain solutions for customers. | Constructing reusable family machinery and developing one family member are different processes. |
 
 ## Family knowledge is distributed across the factory
 
-No authorized source puts all production knowledge in one model. It is spread
-across:
+No retained Greenfield source puts all production knowledge in one model. It is distributed across:
 
-- the family scope, commonality, variability, variants, and constraints;
-- the schema's viewpoints, concerns, relationships, languages, constraints,
-  and transformations;
-- processes, activities, task and workstream templates, and their expected
-  inputs and outputs;
-- tools, generators, frameworks, components, patterns, libraries,
-  configuration files, and other implementation assets; and
-- partial or prototypical requirements, architectures, tests, deployment
-  topologies, maintenance plans, migration pathways, and other lifecycle
-  content.
+- family scope, commonality, variability, variants, and constraints;
+- schema viewpoints, concerns, relationships, languages, constraints, and transformations;
+- processes, activities, guidance, and expected work products;
+- tools, generators, frameworks, components, patterns, libraries, configuration files, and other implementation assets; and
+- reusable or prototypical lifecycle content such as requirements, architectures, tests, deployment topologies, operational facilities, maintenance plans, and migration pathways.
 
-A [primary software-product-line account](../sources/framework-for-software-product-line-engineering.ingest.md)
-(`SPL`) calls the analogous family-level collection a reusable platform and
-includes requirements, reference architecture, components, tests, a
-variability model, and traceability. It also separates domain engineering,
-which defines the planned family and its platform, from application
-engineering, which builds one member. These terms clarify the family/member
-boundary; they are not substituted into Greenfield as if he used them.
+Model-driven development is therefore one constituent technique rather than a synonym for the factory. Greenfield's program combines software product lines, model-driven development, guidance automation, and architecture frameworks. Product lines supply managed commonality and variability; models provide metadata for automation; guidance connects activities and assets; architecture frameworks organize viewpoints and lifecycle relationships.
 
-A [primary generative-programming account](../sources/components-and-generative-programming.ingest.md)
-(`GEN`) makes `configuration knowledge` explicit as the mapping from
-problem-space requests to solution-space component configurations. Domain
-engineering supplies that mapping, the feature model, architecture,
-parameterized components, and generator. Application engineering may then use
-an algorithm or search to configure a member. Search inside that supplied
-space selects a product; it does not acquire or revise the space or mapping.
+This distributed structure matters for later agentic-system theory. A model, prompt, workflow, tool, evaluator, or schema may be one item of production machinery without being the whole producer. Conversely, a generated program can be a family member even when it was built through extensive automation.
 
-Model-driven development is one constituent technique, not a synonym for the
-whole factory. `G03` defines its synthesis as a model-driven product line:
-product-line engineering supplies the scoped family and reusable production
-assets, models carry metadata used to automate development, and component-based
-techniques realize configurable assemblies. `G07` later names four integrated
-contributors: software product lines, model-driven development, guidance
-automation, and architecture frameworks. The factory combines these under a
-family-specific lifecycle organization; a model or transformation alone is not
-the factory.
+## Factory development and solution development update different things
 
-The schema is therefore the integration structure, the template is the
-installable packaging, executable assets realize operations, and the
-configured environment makes the arrangement operative. Changing one member's
-work product and changing a reusable rule or asset for later members are
-different-level changes even when both are called adaptation. Persistence and
-reuse scope distinguish the levels; this is an inference from the two-process
-division, not a formal rule supplied by the sources.
+Greenfield's mature account explicitly uses two interacting development processes.
 
-## Factory development and member development are different paths
-
-The distinction is relative to a fixed reference factory. Product development
-changes one of that factory's members; factory development changes that
-factory's reusable production machinery. In a meta-factory, the same work may
-be product development relative to producer A and factory development relative
-to produced factory B. B is A's factory-valued product and a producer for its
-own family. Whether B later succeeds some incumbent is a separate operative
-relation.
-
-| Aspect | Factory development | Family-member development |
+| | Factory development | Solution development |
 |---|---|---|
-| Actors | `G03` product-line developers, `G07` factory developers, and the comparable `SPL` domain-engineering role. | `G03` product developers, `G07` solution developers, the `PAT` development team, and the comparable `SPL` application-engineering role. These are role mappings, not exact terminological identities. |
-| Starting inputs | Domain knowledge, intended family scope, commonality and variability, metamodels or languages, process knowledge, platform choices, and production expertise. | Requirements for one member plus an already supplied schema, template, configured environment, variability model, configuration rules, and assets. |
-| Work | Define the family and viewpoints; create process, content, implementation, and tool assets; package them in a template; configure the production environment. | Select and bind anticipated variation; choose, parameterize, adapt, configure, complete, assemble, or generate product-specific material. In `PAT`, the environment instantiates product views, work products, tasks, and workstreams, and the work products collectively express product state. |
-| Fixed and variable parts | Family scope, viewpoint structure, variability, processes, tools, and reusable assets can all vary while a factory is being developed or revised. | Those family commitments are fixed only relative to an ordinary member-development episode. The member varies within the admitted space. A reusable change for later members crosses back into factory development. |
-| Output | A schema, packaged template and assets, and a configured development/runtime environment for a family. | One family member whose evolving product state is expressed through its lifecycle work products. The member may itself be a factory when the reference producer is a meta-factory. |
-| Feedback | `G07` routes defects, feature requests, and unanticipated variation from solution developers to factory developers, who revise reusable assets. | Customers report on solutions to solution developers. A member-level discovery can motivate a factory change, but does not itself perform that change. |
+| Primary target | Reusable family-level production machinery | One family member and its lifecycle work products |
+| Typical inputs | Domain knowledge, intended family scope, commonality and variability, process knowledge, platform choices, reusable expertise | Requirements for one solution plus the already supplied schema, template, tools, guidance, and assets |
+| Typical work | Define or revise family scope and viewpoints; construct processes, content, implementation assets, and tools; package and configure the production environment | Select and bind anticipated variation; adapt, complete, assemble, generate, test, deploy, operate, maintain, or migrate product-specific work |
+| Output | A configured software factory or a revised reusable asset base | One software product or solution whose state is expressed through lifecycle work products |
+| Feedback | Solution developers report defects, requests, and unanticipated variation to factory developers | Customers and environments expose product defects, needs, and consequences |
 
-The paths remain distinct relative to the same reference factory even when one
-work episode has both roles across different factories. In particular, “fixed
-during member development” does not mean immutable across factory versions.
-Nor does feedback define a learning algorithm: the cited accounts leave people
-to interpret reports and decide how reusable machinery changes.
+The same observation may matter to both processes without collapsing them. A failed test can guide repair of the current product. It can also motivate a change to a reusable test asset or production rule. Only the second change is factory development relative to the same producing factory.
 
-## The product spans the lifecycle
-
-The factory produces more than generated implementation code. It produces and
-sustains a family member by creating and modifying the lifecycle work products
-that express product state, including executable and deployed realizations
-where applicable.
-
-| Lifecycle area | Supplied machinery and resulting work | Evidence limit |
-|---|---|---|
-| Requirements and specification | Reusable or prototypical requirements, product requirements work, specification viewpoints, languages, constraints, and transformations. `PAT` also places product specification inside its supported environment. | The sources do not show automatic discovery of the right requirements. |
-| Architecture and implementation | Logical and technical architectures, guidelines, patterns, samples, templates, libraries, frameworks, models, components, configuration files, editors, transformations, and generators support product architecture and implementation artifacts. | Generation is one possible activity inside the broader production arrangement. |
-| Testing | Reusable test suites and domain test assets support tests of a configured member and any member-specific additions. | An inventory of tests does not establish comparative test effectiveness or product quality. |
-| Deployment and operation | Deployment topologies, deployment support, runtime facilities, and operational assets extend the factory beyond compilation. | A supported phase or topology is not a complete deployment semantics, and runtime scope does not imply unattended operation. |
-| Maintenance and migration | Solution developers maintain individual solutions. Maintenance plans and migration pathways can be reusable assets; `PAT` also includes maintenance in its supported lifecycle. | The sources do not give full change-propagation, compatibility, or versioning rules. A migration pathway is not evidence of an implemented migration engine or an automatic transition between factory versions. |
+The retained sources describe people performing the interpretive and design work in this feedback path. They show that factories can be revised in response to use, but they do not define a computational learning algorithm or establish that the factory itself closes the feedback loop.
 
 ## Similar operations act at different levels
 
-| Operation | Immediate target and actor | What changes, and what does not |
-|---|---|---|
-| Product configuration | A product or solution developer configures one member with the operative factory. | Anticipated features, qualities, parameters, selected variants, and product work products vary inside supplied family and configuration rules. The operation does not by itself revise those rules, the family schema, or reusable assets. |
-| Product assembly or generation | Developers, tools, or generators materialize one selected configuration from components and other assets. | The concrete member and its lifecycle artifacts change relative to the producing factory. When that family admits factories, the product may itself be a producer; automation alone does not make it a successor. |
-| Factory specialization | Factory developers add or remove viewpoints or modify artifacts, activities, and supporting assets in the reusable or base factory. | The reusable family-level production structure, and therefore the space or method of later products, changes. A product-local configured-schema variation remains member development. This is also not automatically identical to MDSoFa's generation of `specific expertise` from generic expertise. |
-| Product composition | Portions produced using multiple factories contribute to one deliverable. | The product's make-up changes. The production definitions of the contributing factories do not thereby merge. |
-| Factory composition | Viewpoints from constituent factories are combined into a larger production system, including arrangements that support multi-factory supply chains. | The factory's integrated production structure changes. This is not assembly of outputs into one product, and constituent integration may require more than product compatibility. |
-| Feedback-supported versioned factory revision | Human factory developers revise reusable machinery in response to defects, requests, new practices or technology, and unanticipated variation. *Factory evolution* is our umbrella term for such change, not a named `G07` operation on the retained evidence. | Schema, template contents, processes, tools, or assets can change across versions. Feedback and version change alone are not learning, and not every revision is specialization or composition. |
-| Recursive factory construction | A factory-supporting environment helps developers build another factory, or a computational process produces factory assets. | Relative to a meta-factory, the produced factory is a member; relative to itself, it is a producer with reusable machinery. Factory-valued output says nothing about who supplies its specialization, whether it succeeds an incumbent, or whether learning occurred. |
+The target and reuse scope distinguish operations that otherwise use similar verbs:
 
-The sources identify these operations but do not provide a closed algebra of
-factory change. The target and reuse scope of a change, not a shared verb such
-as *configure*, *adapt*, or *compose*, determine which operation occurred.
+- **Product configuration or generation** selects, binds, adapts, assembles, or materializes one member inside supplied family machinery.
+- **Factory specialization** adds, removes, or changes reusable viewpoints and their associated artifacts, activities, and assets.
+- **Product composition** combines outputs from multiple factories into one deliverable.
+- **Factory composition** combines production structures or viewpoints from multiple factories.
+- **Feedback-supported factory revision** changes reusable machinery across versions in response to defects, new demands, practices, technology, or variation not handled by the current asset base.
 
-## Factory construction is prior art; specialization acquisition is not established
+Greenfield does not supply a closed algebra of these operations. In particular, changing a product-local configured view is not automatically factory specialization, and producing an artifact that happens to be another tool or factory does not automatically revise the producer.
 
-`G03` already makes recursive construction explicit. Its example uses an IDE
-to build languages, frameworks, and tools for building factories, packages
-them as a template, and loads that template into another IDE to create a
-factory-building factory. Its product can itself be another producer, but human
-product-line developers still choose the family definition and design the
-specialized templates and assets. This is producer-valued product recursion and
-tool-assisted bootstrapping, not evidence-responsive acquisition of production
-knowledge.
+## The factory spans the lifecycle
 
-Cook and Kent give the book program's tool-level mechanism. Their language
-designer is itself an instance of the generated designer architecture, and
-they state verbatim: “This allows the tool factory to bootstrap itself from
-one version to the next” ([their Tool Factory proposal](../sources/cook-kent-tool-factory-2003.ingest.md)).
-The construction starts from a supplied language-family definition, fragments,
-patterns, framework, and mappings into implementation technology. It can
-therefore regenerate or bootstrap production tooling without acquiring the
-family specialization that the tooling embodies.
+The product is not only generated implementation code. The factory may supply machinery for requirements, specification, architecture, implementation, testing, deployment, operation, maintenance, and migration. Its products are correspondingly represented by lifecycle work products, including executable and deployed realizations where relevant.
 
-MDSoFa makes factory construction more computational. Langlois and Exertier
-state verbatim that “a model driven software factory can produce a model-driven factory” in [their MDSoFa account](../sources/langlois-exertier-mdsofa-software-factory-factory-2004.ingest.md).
-Their implemented process combines supplied metamodels and generic expertise,
-selects QVT rules through pattern matching, and applies templates to produce
-specific expertise and target assets. Human metamodel designers supply
-metamodels, mappings, and aspects; software architects participate in
-architectural choices; people also supply expertise, platform, packaging, and
-strategy choices. It is therefore useful to understand the computation as
-compiling supplied specialization. *Compilation* is a comparison label here,
-not MDSoFa's claim that the system learns.
+This lifecycle scope is one reason a generic code generator or coding agent is not automatically a Greenfield-style factory. The term denotes an integrated family production arrangement, not merely a capability to emit source code.
 
-Together the sources establish four progressively automated arrangements:
+## What the imported ontology does not establish
 
-1. human-designed machinery can help humans construct another factory
-   (`G03`);
-2. a generated tool chain can bootstrap its own designer class from supplied
-   language definitions and implementation mappings (Cook and Kent);
-3. a computational process can construct substantial factory assets from
-   supplied metamodels and expertise (MDSoFa); and
-4. an algorithm or search can configure and materialize a product inside a
-   supplied family model (`GEN`).
+The Greenfield ontology does not by itself imply:
 
-`G07` and `SPL` also establish feedback between product work and family
-engineering. In their accounts, people interpret that feedback and revise the
-reusable machinery. None of the retained sources establishes the complete
-transition:
+- that the factory learns from production experience;
+- that its family scope or assets are acquired computationally;
+- that the configured environment acts without human developers;
+- that every useful production decision is inside one computational boundary;
+- that producing another factory is self-improvement; or
+- that one factory can handle previously unanticipated product families.
 
-`experience from produced members -> computationally determined reusable change -> evidence-governed operative retention -> later production under F_{t+1}`
+Greenfield, Cook and Kent, and MDSoFa do provide real prior art for factories or tool factories producing other production machinery. The separate note [A software factory can produce another factory without learning its specialization](./a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) identifies the remaining distinction: constructing a producer from supplied family knowledge is not the same as acquiring or revising that knowledge from experience.
 
-Explicit candidate generation, reject-capable evaluation, selection, and
-promotion are one implementation of that transition. A direct evidence-to-update
-path need not expose competing candidates.
+## Evidence limits
 
-In particular, they do not establish computational acquisition or
-evidence-responsive revision of a previously human-supplied family scope,
-viewpoint decomposition, variability model, configuration knowledge, process,
-or asset strategy. Generation, search, recursion, feedback, a dynamic schema,
-specialization, and versioning can all occur while those commitments remain
-human supplied. The prior-art boundary is therefore the location of acquisition
-and revision, not whether computation produces an ordinary member or a
-factory-valued member.
+These sources primarily present an architectural and methodological program. The 2003 paper and 2007 essay support the ontology and intended process division more strongly than claims of productivity, quality, predictability, or economic transformation. Their Microsoft tooling context should not be mistaken for a timeless implementation prescription. What transfers most reliably is the family/machinery/member distinction and the separation of factory development from solution development.
 
-## Scope
+---
 
-- The unified ontology is a version-aware synthesis. The retained material
-  contains no single canonical ontology spanning `G03`, `G07`, and `PAT`.
-- The sources do not provide a formal family-membership predicate, a complete
-  executable metamodel with cardinalities, a complete task state machine, or a
-  closed algebra of specialization, composition, and versioned revision.
-- Classifying a change by persistence and reuse scope is an inference from the
-  two development paths. The exact boundary between adapting an asset copy for
-  one member and changing a reusable factory asset is not formalized.
-- Lifecycle inventories establish scope, reusable content, and partial
-  automation. They do not establish end-to-end autonomy or measured gains in
-  productivity, quality, predictability, or reuse.
-- The feedback accounts are organizational and human-directed. They do not
-  specify computational determination and operative retention of reusable
-  change. Candidate generation, evaluation, and selection are also unspecified
-  where that architecture would be used.
-- MDSoFa establishes implemented construction from supplied knowledge, not
-  acquisition or revision of that knowledge. Its artifact counts and platform
-  coverage do not establish comparative performance or unrestricted
-  applicability.
-- Cook and Kent establish a proposed generated-designer architecture and
-  conditional self-bootstrap, not a tested complete tool chain or acquisition
-  of its language-family definition and implementation mappings.
-- The negative prior-art finding is bounded to the retained sources. This note
-  supplies a foundation and mismatch record; it does not define a closed
-  learning loop, successor-factory relation, domain-extensibility, a universal
-  factory, or autonomous learning.
+Relevant Notes:
+
+- [Software factory](./definitions/software-factory.md) — defined-in: supplies the compact term boundary derived from this reconstruction
+- [Factory development](./definitions/factory-development.md) — defined-in: isolates the process that constructs or revises reusable family machinery
+- [A software factory can produce another factory without learning its specialization](./a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) — extends: uses recursive-construction prior art to identify the acquisition boundary
+- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — compares: likewise treats behavior as determined by a configured arrangement of models, artifacts, tools, and runtime machinery

--- a/kb/notes/definitions/factory-development.md
+++ b/kb/notes/definitions/factory-development.md
@@ -1,51 +1,40 @@
 ---
-description: "Definition — factory development constructs or changes reusable family-level production machinery, rather than one product's lifecycle state"
+description: "Definition — factory development constructs or revises reusable family-level production machinery rather than one product's lifecycle state"
 type: kb/types/definition.md
 tags: [foundations, self-improving-systems]
 ---
 
 # Factory development
 
-**Factory development** is the process that constructs or changes the reusable, family-level machinery that determines how software products will subsequently be produced. Its targets may include product-family scope, schemas, viewpoints, variability and configuration knowledge, templates, assets, tools, methods, representations, evaluators, workflows, runtime support, and the authority paths that make them operative.
+**Factory development** is the process that constructs or revises the reusable, family-level production machinery of a [software factory](./software-factory.md). Its targets can include the declared product-family scope, commonality and variability, the factory schema and viewpoints, processes or guidance, packaged assets, tools, frameworks, generators, and development or runtime support.
 
-For a fixed reference factory, the defining boundary is the target and reuse scope of the change. **Product development** changes one family member or its lifecycle work products under supplied production machinery. Factory development changes that machinery for later work. A discovery made while building one product crosses into factory development only when it changes reusable machinery that can govern subsequent production.
+Greenfield's mature account distinguishes factory development from **solution development**. Factory developers build and revise production assets for solution developers; solution developers use those assets to create and sustain particular family members. The earlier 2003 account makes the analogous distinction between product-line developers and product developers.
 
-The distinction is producer-relative. When meta-factory \(A\) constructs factory \(B\), the same work is product development relative to \(A\) and factory development relative to \(B\). \(B\) is a factory-valued member of \(A\)'s family and reusable production machinery for its own family. It becomes a [successor factory](./successor-factory.md) only through a separately declared operative relation to an incumbent.
-
-Greenfield supplies schemas, viewpoints, templates, assets, processes, specialization, composition, and developer roles. Evaluators, representations, authority paths, operative retention, and the producer-relative rule are explicit extensions used by this research program to state what a computational learning transition changes.
+The boundary is the target and reuse scope of the work. Changing one product's requirements, design, code, tests, deployment state, or other lifecycle work products is solution development relative to the producing factory. A discovery made during that work becomes factory development only when it changes reusable family-level machinery intended to govern later family members or later work on the family.
 
 ## Scope
 
-Factory development includes initial construction, family-template installation or environment configuration that establishes an operative [software factory](./software-factory.md), and later changes to it. Greenfield names factory specialization and factory composition as family-level operations within this broader process:
+Factory development includes initial definition of the family and its production knowledge, construction and packaging of the schema and reusable assets, and later revision of that machinery. Greenfield's 2007 account names two important family-level operations:
 
-- **specialization** adds, removes, or changes the reusable or base factory's viewpoints and their artifacts, activities, and assets;
-- **composition** integrates production structures from multiple factories; and
-- **feedback-supported, versioned factory revision** changes reusable machinery in response to defects, new demands, practices, or technology. *Factory evolution* is this synthesis's umbrella term for such changes, not a named Greenfield operation on the retained evidence.
+- **factory specialization** adds, removes, or changes viewpoints and their associated artifacts, activities, and assets; and
+- **factory composition** combines production structures from multiple factories.
 
-Greenfield also uses schema modification to accommodate anticipated variation in one product. Viewpoint change alone therefore does not classify the work: a product-local configured-schema variation remains product development, while a change to reusable base-factory structure is specialization.
+Feedback from solution development can motivate factory revision. A defect report, feature request, or unanticipated variation is evidence for factory development, not the revision itself. In Greenfield's account, human factory developers interpret that evidence and decide how the reusable machinery changes.
 
-The definition does not fix the actor or mechanism. Human factory developers, computational generators supplied with metamodels, or a factory's own learning pathway can all perform factory-development work. Those cases differ in actor allocation and in where the family-specific knowledge originates.
-
-A factory-development result may first be a candidate. The transition becomes operative only when the result is installed into a production path and affects later work over the declared horizon. [Operative change](./operative-change.md) supplies that stronger condition.
+This definition does not fix the future actor allocation. A later theory may assign some factory-development work to computational actors. That is an extension of the inherited ontology and must be stated separately rather than read back into Greenfield's definition.
 
 ## Exclusions
 
-- Selecting or binding an anticipated product variant is product configuration, not factory development relative to the producing factory.
-- Generating or assembling a family member changes a product relative to the producing factory even when the operation is fully automatic. A factory-valued member may simultaneously be the result of factory development relative to the produced factory.
-- Editing a copied asset only for one product is product development unless the change enters the reusable factory machinery.
-- Feedback, telemetry, a feature request, or a proposed schema is an input or candidate, not completed factory development by itself.
-
-## Misuse Cases
-
-- Calling every edit made by a factory developer factory development even when the edit affects only one product.
-- Calling computational product generation factory construction because both produce software artifacts.
-- Treating a stored factory candidate as an operative revision without identifying its later production consumer and authority path.
+- Selecting or binding an anticipated product variant within the supplied family machinery is solution configuration, not factory development.
+- Generating or assembling a family member is product work even when it is fully automated.
+- Editing a copied asset only for one product is not factory development unless the change enters the reusable family machinery.
+- A report, observation, candidate schema, or proposed tool is an input to factory development until it is incorporated into the reusable production arrangement.
+- Factory development does not by itself imply learning, improvement, reflection, self-production, computational closure, or autonomy.
 
 ---
 
 Relevant Notes:
 
-- [A software factory is family-scoped lifecycle production machinery](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: supplies the historical factory/member process split, Greenfield's specialization and composition operations, and the evidence for feedback-supported versioned revision
-- [Software factory](./software-factory.md) — defined-in: names the family-scoped production machinery that factory development constructs or changes
-- [Behavior-determining organization](./behavior-determining-organization.md) — extends: supplies the general system-level class into which a factory's reusable production machinery falls
-- [Operative change](./operative-change.md) — extends: distinguishes an installed, behavior-reaching factory transition from a proposal or inert artifact
+- [Software factory](./software-factory.md) — defined-in: names the family-specific development and runtime environment whose reusable machinery is constructed or revised
+- [A software factory is family-scoped lifecycle production machinery](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: supplies the historical two-process distinction and the specialization and composition operations
+- [A software factory can produce another factory without learning its specialization](../a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) — contrasts: shows that automated factory construction can still consume human-supplied family specialization

--- a/kb/notes/definitions/software-factory.md
+++ b/kb/notes/definitions/software-factory.md
@@ -1,38 +1,37 @@
 ---
-description: "Definition — a software factory is configured, family-specific production machinery for creating and sustaining software and its lifecycle work products"
+description: "Definition — in Greenfield's approach, a software factory is a family-specific development and runtime environment configured with reusable production knowledge"
 type: kb/types/definition.md
 tags: [foundations, self-improving-systems]
 ---
 
 # Software factory
 
-A **software factory** is configured production machinery specialized for a declared software product family. It integrates a family schema, packaged reusable assets, methods or workflows, tools, and development or runtime support so that human and computational actors can produce and sustain family members through their lifecycle work products.
+In Greenfield and Short's approach, a **software factory** is a specialized development and runtime environment configured for a declared family of software products or solutions. It integrates family-specific production knowledge through a schema, reusable assets packaged in a template, methods or guidance, tools, and development or runtime support used to create and sustain family members across the relevant lifecycle.
 
-This is a Greenfield-style explication. The [versioned source reconstruction](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) is the authority for the inherited schema, template, viewpoint, artifact, activity, asset, and developer-role vocabulary. This definition supplies a cheaper term boundary for later theory; it does not project one timeless ontology across every Greenfield source.
+This is a version-bounded explication of the [2003 account](../../sources/greenfield-short-software-factories-oopsla-2003.ingest.md) and Greenfield's [mature 2007 account](../../sources/greenfield-mass-customizing-software-factories-2007.ingest.md). Their vocabularies are historically related but not identical. The [versioned ontology reconstruction](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) owns the detailed schema, template, viewpoint, artifact, activity, asset, and developer-role distinctions.
 
-## Scope
+## Core boundary
 
-The product family is part of the factory's identity. Its declared scope, commonality, variability, variants, and constraints delimit the production space for which the reusable machinery is intended. A factory may guide or automate requirements, specification, architecture, implementation, testing, deployment, operation, maintenance, and migration. It produces and sustains a family member by creating and changing lifecycle work products that express the member's state, including executable and deployed realizations where applicable.
+The declared product or solution family is part of the factory's identity. Its commonality, variability, variants, constraints, and lifecycle concerns delimit the space for which the reusable production machinery is intended.
 
-The schema organizes family production knowledge. A software factory template packages customizable assets for installation. An **operative factory** is the installed or configured producer whose machinery can govern actual work. None of the schema, template, one asset, or one work product is the whole factory by itself.
+The schema organizes family production knowledge. A software factory template packages customizable assets for installation. The configured development and runtime environment is the factory that solution developers use. A schema, template, tool, workflow, or reusable asset may be part of a factory without being the whole factory.
 
-Actor allocation must be declared separately. A conventional factory can supply an environment to human solution developers, automate selected activities, or combine both. Calling it a software factory does not imply autonomy, learning, or unattended end-to-end generation.
+Product-specific requirements, designs, models, code, tests, deployment descriptions, and other lifecycle work products express the state of one family member. They are outputs or working state of solution development, not reusable factory machinery merely because the factory helped create them.
+
+Actor allocation is separate. Greenfield's accounts primarily describe human factory developers and solution developers supported by automation. Calling an arrangement a software factory does not imply learning, autonomy, computational closure, unattended generation, or self-improvement.
 
 ## Exclusions
 
-- A generic IDE, coding agent, build pipeline, or workflow is not a software factory in this sense merely because someone calls it a factory. The term requires family-specific reusable production knowledge and a declared reuse scope.
-- A generator that emits one program is not the whole factory when schema, configuration knowledge, tests, workflows, assets, or human production activities remain outside it.
-- A family member and its product-specific work products are not reusable machinery of the factory that produces them. A member may nevertheless be another software factory when the producing factory's family admits factory-valued products.
-
-## Misuse Cases
-
-- Calling a factory schema or installable template the operative software factory without identifying the configured environment and authority path that enacts it.
-- Treating every product the machinery happens to emit as a family member even when no declared family boundary admits it.
-- Inferring factory learning from improved product output without a retained change to the production machinery.
+- A generic IDE, coding agent, agent harness, build pipeline, or workflow is not a software factory in this sense merely because it helps produce software. The family-specific reusable production knowledge and declared reuse scope are essential.
+- A generator that emits one program is not the whole factory when the family schema, processes, tools, tests, configuration knowledge, or other reusable assets remain elsewhere.
+- A software factory schema or installable template is not by itself the configured development and runtime environment that Greenfield calls a factory.
+- A family member is not the factory that produced it. A member may itself be another factory only when the producing factory's declared family admits factory-valued products.
+- Producing, configuring, or revising one product does not by itself show that the factory has changed or learned.
 
 ---
 
 Relevant Notes:
 
-- [A software factory is family-scoped lifecycle production machinery](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: reconstructs the versioned historical ontology and the boundary between family machinery and member state
-- [Behavioral authority](./behavioral-authority.md) — extends: identifies the consumer, channel, and force through which installed factory machinery governs later production
+- [A software factory is family-scoped lifecycle production machinery](../a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: reconstructs the versioned historical ontology and the family-machinery/member boundary
+- [Factory development](./factory-development.md) — defined-in: names the separate process that constructs or revises reusable factory machinery
+- [A software factory can produce another factory without learning its specialization](../a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) — contrasts: separates recursive construction from acquiring the production knowledge supplied to the constructor


### PR DESCRIPTION
## Intent

Import Greenfield's software-factory ontology before using the term to carry claims about agentic learning.

## Changes

- define `software factory` conservatively as a family-specific configured development and runtime environment;
- define `factory development` separately from solution development;
- reduce the large synthesis to the versioned family/schema/template/configured-environment/two-process ontology;
- extract the prior-art boundary: a factory can produce another factory without learning the supplied specialization.

## Deliberate exclusions

This PR does not use successor-factory, computational-closure, domain-extensibility, or self-improvement terminology to define the imported ontology. Those remain possible later extensions rather than Greenfield's definition.

## Stack

The containment step has already merged as PR 147. This is the first active review batch. Draft PRs 152, 153, and 154 are dependency-scoped follow-ons. Merge this PR first, then retarget the selected follow-on to `main` before merging it.