### PR TITLE
Refoundation 3/5: rebase the workshop on agentic factory development

### DIFF
--- a/kb/work/agentic-system-learning-refoundation/README.md
+++ b/kb/work/agentic-system-learning-refoundation/README.md
@@ -4,265 +4,152 @@
 
 ## Intent
 
-Re-found the theory-mediated system-learning research program on a more general
-architectural argument. Preserve the existing theory-mediated claims,
-experiments, and evidence, but make them downstream of the architecture they
-are proposed to improve.
+Re-found the theory-mediated system-learning research program on an architectural argument that does not assume theory mediation. Preserve the existing theory-specific claims, experiments, and evidence, but place them downstream of a more general account of agentic software production and continual learning.
 
-This is not a rewrite around *software factory* or any other new vocabulary.
-The argument must remain intelligible if the provisional labels are replaced by
-plain descriptions of the machinery and its causal role.
+The refoundation must remain valid if theory mediation loses to another learning mechanism. It must also remain intelligible without using *software factory* as a metaphor. Historical terminology may compress an already established relation; it must not create the relation by definition.
 
-The intended conceptual spine is:
+## Starting point: the agentic computational substrate
+
+The computational starting point is already developed in the [computational-model cluster](../../notes/computational-model-README.md). Agentic work is performed through bounded LLM calls embedded in persistent software machinery that can retain state, assemble context, schedule calls, expose tools, execute exact transitions, aggregate results, and check outcomes.
+
+The [bounded-context orchestration model](../../notes/bounded-context-orchestration-model.md) gives one explicit form of that architecture, while [scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) explains why exact progression and bookkeeping often belong in software rather than accumulated natural-language context.
+
+This starting point does not imply that the software substrate learns, writes itself, or changes at all. A fixed, sufficiently general substrate remains possible in principle.
+
+## Import the software-factory boundary before extending it
+
+Greenfield's software-factory ontology supplies a useful established distinction, but it is narrower than a generic agentic system.
+
+A Greenfield-style [software factory](../../notes/definitions/software-factory.md) is a development and runtime environment configured for a declared family of software products or solutions. Its family-specific production knowledge is distributed across a schema, packaged assets, processes or guidance, tools, frameworks, and lifecycle support. [Factory development](../../notes/definitions/factory-development.md) constructs or revises that reusable machinery; solution development uses it to create and sustain a family member.
+
+The mapping used by this workshop is therefore:
 
 ```text
-agentic system
-  + practical generality over a broad task family
-  -> extensible software factory
-  + continual learning
-  -> learning software factory
-  + hard machinery-construction problems
-  -> recursive and, where the criteria are met, reflective factory structure
-  -> alternative learning mechanisms
-  -> theory mediation as a particularly versatile candidate
+general agentic substrate
+  + declared software product family
+  + reusable family-specific production knowledge
+  -> configured agentic software factory
 ```
 
-Each `+` introduces an additional premise. None of the arrows is licensed by
-terminology alone. The [conceptual spine](./conceptual-spine.md) states the
-premises, conclusions, and failure tests in detail.
+A generated script or task-local orchestrator is not yet a Greenfield-style factory. It may be software used during production. It becomes factory machinery only when it carries reusable production knowledge for a declared family or admitted variation space.
+
+This also means that a task family and a product family must not be silently equated. A benchmark may group tasks because they stress the same solver capability, while a product family groups software products or solutions through declared commonality and variability.
 
 ## Research question
 
-For a sufficiently broad task family, can an agentic system improve how it
-constructs and retains the software machinery used to solve later tasks? If so,
-does natural-language theory provide a particularly versatile way to organize
-evidence and translate it into heterogeneous changes to that machinery?
+For a sufficiently broad class of software demands, can an agentic system use production experience to construct and retain the family-specific machinery needed for later production? Among the mechanisms that could perform that work, does natural-language theory provide unusually versatile coordination across task understanding, solver limitations, failure diagnosis, proposed interventions, and heterogeneous software changes?
 
-The first question establishes the learning architecture. The second is the
-research proposal. A negative answer to the second must not undo the first.
+The first question concerns agentic factory development and continual learning. The second is the theory-mediation proposal. A negative answer to the second must not undo the first.
+
+## Conceptual spine
+
+```text
+agentic computational substrate
+  + family-specific production knowledge
+  -> configured software factory
+
+configured software factory
+  + demands that exceed currently installed family machinery
+  + agentic construction or revision of reusable production machinery
+  -> agentic factory development
+
+agentic factory development
+  + production experience causally determines a retained factory change
+  + later production depends on that change
+  -> factory-level continual learning
+
+factory-level continual learning
+  -> compare learning mechanisms on the same causal job
+  -> theory mediation as one particularly versatile candidate
+```
+
+Each `+` introduces an additional premise. The [conceptual spine](./conceptual-spine.md) records what follows, what does not follow, and which counterexamples defeat each step.
+
+## What is downstream rather than foundational
+
+Several important ideas remain in the program, but they are not required to derive factory-level continual learning:
+
+- **Higher-order or recursive factory development** begins when production machinery is used to construct or revise machinery for constructing later production machinery.
+- **Reflection** additionally requires a causally connected representation of selected aspects of the same system to participate in operation or revision.
+- **Computational closure** asks whether all decisions assigned to a declared learning path are computationally supplied, conditional on permitted external evidence and interaction.
+- **Self-improvement** adds an objective and evidence that the system's own change improves it relative to that objective.
+- **Compounding** requires later evidence that an earlier change improved the capacity to produce further improvements.
+- **Breadth or domain extensibility** asks which demands the process can turn into adequate family specialization; it is independent of closure.
+
+Factory-valued output, recursion, reflection, learning, improvement, closure, and compounding must remain separately classifiable.
 
 ## Direction fixed by the operator
 
-### Start from the agentic system
+### Practical generality, not a necessity theorem
 
-Use a modest minimal architecture: bounded LLM calls operate with persistent
-software machinery outside the calls. The machinery may schedule calls, retain
-state, assemble context, expose tools, execute transitions, and check results.
-The [bounded-context orchestration
-model](../../notes/bounded-context-orchestration-model.md) and
-[scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md)
-support this separation without proving that one scheduler design is mandatory.
+Do not claim that every agentic system must construct new production machinery. A fixed universal interpreter or substrate could in principle express every required workflow or program.
 
-The starting point does not require the software substrate to learn or modify
-itself. A fixed and universal substrate remains possible in principle.
+The practical conjecture is weaker: across sufficiently broad software demands, useful family-specific schemas, representations, decompositions, evaluators, tools, and workflows will often not be worth or possible to enumerate in advance. A general agentic system should therefore be able to participate in factory development when its installed machinery is inadequate.
 
-### Derive the software-factory role from practical generality
+### Continual learning is an additional premise
 
-For a sufficiently broad task family, it is unrealistic to predefine every
-useful schema, workflow, decomposition, validator, algorithm, representation,
-tool, and coordination structure. When the agent constructs such software
-machinery for its own work, the agentic system is functioning as a software
-factory in the sense relevant to this program. The machinery may initially be
-task-local; cross-task retention enters only with the continual-learning step.
+Software production and factory development do not imply learning. Factory-level continual learning requires a causal cross-episode relation:
 
-This is a practical generality claim, not a logical necessity claim. It does
-not say that every agentic system is a software factory, that no fixed universal
-substrate could exist, or that Greenfield's family-specific software-factory
-ontology must define the research program. The relation between the plain
-architectural role and that narrower historical vocabulary remains a question
-for the supporting notes.
+```text
+production experience
+  -> system-determined retained change to reusable factory machinery
+  -> changed later production
+```
 
-### Add continual learning independently
+The change need not be beneficial. Improvement, warrant, validation, autonomy, and closure add stronger requirements. The existing [continual-learning governance note](../../notes/continual-learning-requires-governing-behaviour-changing-writes.md) remains useful for governed deployment, but it must not be used to build all stronger conditions into the minimal learning relation.
 
-Use the minimal cross-task condition: experience on earlier tasks changes how
-later tasks are solved. Persistent changes may live in model weights, retrieved
-memories, natural-language artifacts, symbolic software, or mixtures. The
-software substrate is therefore part of the possible learning surface, not
-merely fixed support around model learning.
+### Compare mechanisms before proposing theory mediation
 
-Stronger claims remain separate. An improvement attribution needs an objective
-and evidence that the change helped. Self-improvement, computational closure,
-warrant, and autonomy each add further causal or evaluative requirements. Do
-not build those stronger requirements into the minimal continual-learning
-premise.
+The relevant comparison is not natural language versus code or weights. It is among mechanisms that turn experience into retained changes affecting later production. Live candidates include trial-and-error retention, trajectory reuse, program search, learned construction or selection policies, direct optimization, theory mediation, and mixtures.
 
-### Derive the learning and reflective factory
-
-When the agent constructs software machinery, retains a successful change, and
-later work depends on it, the production machinery has learned in the minimal
-cross-task sense. Decompositions, context-management strategies,
-representations, evaluators, search procedures, tools, and coordination
-structures become examples of learnable production machinery. They are not
-foundational assumptions.
-
-Introduce recursion only when constructing useful machinery is itself a task
-that needs constructed machinery. Introduce reflection only when a causally
-connected representation of the factory's own relevant organization
-participates in changing later operation. A factory that emits factory-valued
-artifacts is not reflective merely because the word *factory* recurs.
-
-### Compare learning mechanisms before proposing theory mediation
-
-At the learning-factory stage, compare trial and error, trajectory reuse,
-program search, learned policies, optimization, theory mediation, and mixtures.
-The list is provisional rather than an exhaustive taxonomy.
-
-The positive research claim is narrower: natural-language theory may be
-unusually versatile because one LLM-interpretable medium can represent task
-structure, solver limitations, failure explanations, proposed interventions,
-and evidence, then guide heterogeneous changes to software machinery. This is a
-comparative hypothesis to test, not a premise used to derive the architecture.
+The positive conjecture is that natural-language theory may be unusually versatile because one LLM-interpretable medium can express claims about tasks, solver capacities, failures, interventions, evidence, and scope, then guide changes across schemas, workflows, tools, evaluators, representations, prompts, and code. This is a comparative hypothesis, not a definition of learning.
 
 ## Explicit non-goals
 
-- Do not claim that theory mediation is necessary, universally superior, or
-  sufficient for general learning.
-- Do not claim that every agentic system must construct software machinery.
-- Do not infer practical breadth, improvement, warrant, autonomy, or closure
-  from the presence of a loop or from software authorship alone.
-- Do not require universal self-modification. Fixed general machinery,
-  interfaces, objectives, resource controls, or trusted kernels may remain.
-- Do not equate recursion, factory-valued production, reflection, learning,
-  self-improvement, and compounding.
-- Do not let a historical software-factory definition carry the broad-task
-  generality argument by stipulation.
-- Do not discard existing theory-mediated material merely because its
-  argumentative position changes.
-
-## Relationship to the existing workshop
-
-The [theory-mediated self-improvement series
-workshop](../theory-mediated-self-improvement-series/README.md) remains active.
-This workshop does not close, delete, rename, or silently supersede it.
-
-The old workshop continues to own its source controls, accepted and rejected
-drafts, ledgers, completed investigations, and current account of the
-theory-mediated program. This workshop owns the new architectural derivation
-and the decisions about how existing material should be repositioned. The
-[transition map](./transition-map.md) records those decisions without moving
-anything yet.
-
-Later transfer uses four dispositions:
-
-- **carry downstream unchanged** — the claim remains sound but no longer opens
-  the argument;
-- **revise dependency or scope** — the claim survives after its premise or
-  strength is corrected;
-- **split** — a general architectural claim and a theory-specific claim need
-  separate homes; or
-- **retire after replacement** — the old formulation disappears only after its
-  durable contribution has a validated successor.
-
-Until the foundational notes settle the arrows, do not restructure the main
-article. At the time this workshop was commissioned, the article and several
-software-factory notes had unrelated in-flight edits in the shared worktree.
-Inspect current diffs and establish ownership before editing any of them.
+- Do not claim that theory mediation is necessary, sufficient, or universally superior.
+- Do not call every coding agent, workflow, generated program, or task-local orchestrator a software factory.
+- Do not infer a product family from an evaluator's task grouping.
+- Do not infer factory learning from product repair, retained bytes, or improved output on the same task.
+- Do not infer learning from recursive construction when the target specialization was supplied.
+- Do not require universal self-modification; fixed general machinery, objectives, interfaces, resource controls, and trusted kernels may remain.
+- Do not make computational closure, reflection, self-improvement, or compounding part of the minimal continual-learning premise.
+- Do not discard theory-mediated material merely because its argumentative position changes.
 
 ## Implementation sequence
 
-1. **Write or revise the supporting theory notes.** Give each arrow in the
-   spine an independent argument. Prefer a small number of notes organized by
-   argumentative job rather than one note per new noun.
-2. **Adversarially check the derivation.** Remove the theory-mediation premise
-   and confirm that the learning-factory architecture still follows. Remove the
-   software-factory label and confirm that the practical argument still makes
-   sense. Check fixed-substrate, non-reflective learning, one-off generated
-   code, and factory-valued-but-inert counterexamples.
-3. **Survey alternative learning mechanisms.** Compare what state each changes,
-   how experience controls the change, how the result becomes operative, and
-   what it costs. Do not arrange the mechanisms as a ladder with theory at the
-   top.
-4. **Restructure the research-program article.** Make the article follow the
-   architectural spine. Preserve the strongest existing theory-mediated
-   material as the downstream proposal, experiment, and evidence sections.
-5. **Disposition the old workshop.** Move or promote only after every retained
-   artifact has a destination and the old source-handling constraints have been
-   honored. Close the old workshop in a later, explicit step.
+1. **Contain premature article integration.** Remove article-level claims that depend on successor-factory, closure, or domain-extensibility terminology before the ontology is settled.
+2. **Import the Greenfield ontology.** Keep compact definitions for software factory and factory development, a versioned reconstruction, and a separate construction-versus-acquisition prior-art note.
+3. **Rebase this workshop.** Replace the loose task-local factory usage with the substrate/configured-factory/factory-development distinction and move recursion and closure downstream.
+4. **Write the learning bridge.** Add durable notes for the agentic-substrate mapping, task-family/product-family distinction, practical pressure for agentic factory development, minimal factory-level continual learning, and neutral mechanism comparison.
+5. **Restructure the research-program article.** Make the architectural dependency order visible, then preserve the strongest existing theory-mediated argument, experiment, and evidence as the downstream proposal.
 
-The sequence fixes dependencies, not exact filenames, article headings, or the
-number of notes. Live evidence may change the implementation within these
-bounds.
+The [transition map](./transition-map.md) records the current disposition of existing material.
+
+## Relationship to the existing workshop
+
+The [theory-mediated self-improvement series](../theory-mediated-self-improvement-series/README.md) remains active until a separate migration and closure decision. It continues to own its accepted and rejected drafts, ledgers, source controls, evidence records, and theory-specific investigations.
+
+This workshop owns the new dependency order and the mapping between agentic computation, software-factory ontology, factory-level continual learning, alternative mechanisms, and theory mediation. Historical process records must not be rewritten as though the new framing had governed their production.
 
 ## Evaluation
 
-The re-foundation succeeds only if a skeptical reader can recover the following
-argument without accepting the theory-mediation hypothesis:
+The refoundation succeeds only if a skeptical reader can recover these claims without accepting theory mediation:
 
-1. bounded model calls rely on consequential persistent software machinery;
-2. broad practical generality creates pressure to construct task-appropriate
-   machinery rather than predefine all of it;
-3. cross-task experience can persist by changing that machinery;
-4. changes to machinery-construction machinery create the higher-order
-   factory structure; and
-5. several learning mechanisms could drive those changes.
+1. bounded LLM calls participate in a larger behavior-producing software system;
+2. adding family-specific reusable production knowledge configures that substrate as a software factory;
+3. broad demands can create a practical need for the agent to construct or revise that machinery;
+4. production experience can causally change reusable machinery used in later production; and
+5. several learning mechanisms could drive such changes.
 
-The theory-mediation proposal then earns its place by making a positive,
-testable comparative claim. Useful evidence includes matched tasks where a
-theory-mediated condition and credible alternatives receive comparable
-information and budgets; interventions on retained theory; heterogeneous
-software changes traced to the mechanism; delayed or cross-task consequences;
-and failures that expose where natural-language theory adds cost, distortion,
-or no advantage.
-
-Terminology passes only when it compresses an already established relation.
-If replacing *software factory*, *learning factory*, or *reflective factory*
-with its plain causal description changes the argument, the derivation is not
-ready.
-
-## Current working material
-
-- [Conceptual spine](./conceptual-spine.md) — dependency ledger and
-  counterexamples for the new argument.
-- [Transition map](./transition-map.md) — provisional disposition of current
-  notes, articles, and old-workshop records; no files have moved.
-- [Provisional merged changes — 2026-08-31](./provisional-merged-changes-2026-08-31.md)
-  — changes allowed to remain in `main` but held for later review against this
-  workshop's dependency and migration gates.
-- [The deployed system, not the model alone, is the unit of
-  learning](../../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md)
-  — current support for putting software machinery inside the learning
-  boundary.
-- [Orchestration strategies and run-state have opposite persistence
-  economics](../../notes/orchestration-strategies-and-run-state-have-opposite-persistence.md)
-  — concrete case where a constructed control strategy can be retained for
-  later tasks.
-- [Learning inside a fixed decomposition inherits its
-  mistakes](../../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md)
-  — pressure to make some task-specific production choices constructible.
-- [Reflective system](../../notes/definitions/reflective-system.md) — the
-  criterion that prevents recursion or self-production from being mislabeled as
-  reflection.
-- [A research program for theory-mediated system
-  learning](../../articles/a-research-program-for-theory-mediated-system-learning.md)
-  — eventual article target, deliberately held behind the supporting-note gate.
-
-## Hand-back conditions
-
-Return to the operator before changing the researcher-facing purpose, making a
-necessity or universal-superiority claim for theory mediation, choosing a
-historical terminology that materially narrows the intended architecture,
-discarding a load-bearing old-workshop result without a successor, or creating
-an external research commitment.
+Theory mediation then earns its place through comparative evidence. Useful tests hold information and total cost as comparable as possible and ask whether retained theory improves transfer, diagnosis, recovery, selective revision, or heterogeneous machinery change relative to credible alternatives.
 
 ## What closes this workshop
 
 The workshop closes when:
 
-1. durable supporting notes carry every arrow in the conceptual spine without
-   circular dependence on theory mediation or on a software-factory label;
-2. the relation among minimal continual learning, improvement,
-   self-improvement, reflection, recursion, closure, and compounding is explicit
-   enough to classify the main counterexamples;
-3. alternative learning mechanisms are represented fairly and the positive
-   theory-mediation hypothesis is testable against credible rivals;
-4. the research-program article has been restructured around the derived spine,
-   with existing theory-mediated material preserved downstream where it remains
-   warranted;
-5. every old-workshop artifact has a recorded disposition, its durable outputs
-   validate in their receiving collections, and the old workshop can be closed
-   separately without loss; and
-6. the resulting research surface states the fixed-substrate possibility and
-   the theory-mediation non-goals plainly.
-
-Article completion without the supporting derivation does not close the
-workshop.
+- durable notes carry every step of the revised spine without circular dependence on theory mediation;
+- task families and product families are kept distinct;
+- factory-valued construction, specialization acquisition, learning, reflection, closure, self-improvement, and compounding can be classified independently;
+- alternative mechanisms are represented fairly;
+- the research-program article has been restructured around the derived architecture; and
+- every old-workshop artifact has a recorded disposition before the old workshop is closed separately.

--- a/kb/work/agentic-system-learning-refoundation/conceptual-spine.md
+++ b/kb/work/agentic-system-learning-refoundation/conceptual-spine.md
@@ -1,269 +1,152 @@
 # Conceptual spine
 
-This is the dependency ledger for the re-foundation. It separates what each
-stage assumes, what it concludes, and what would defeat the inference. The
-labels are provisional; the causal descriptions are load-bearing.
+This ledger states what each stage assumes, what it concludes, and what remains unestablished. The causal relations are load-bearing; the labels merely compress them.
 
 ## Dependency map
 
 | Stage | Additional premise | Derived claim | Not yet established |
 |---|---|---|---|
-| 1. Agentic system | Work is performed through bounded LLM calls plus persistent software machinery that stores state and mediates effects across calls. | The model call is not the whole behavior-producing system; consequential functions can live in software. | The software need not be generated, mutable, learning, or universal. |
-| 2. Extensible production machinery | The task family is broad enough that predefining every useful schema, workflow, decomposition, validator, algorithm, representation, tool, and coordination structure is practically unrealistic; the agent can construct some of this machinery. | The system can function as an extensible software factory for its own work. | This is not true of every agentic system and does not rule out a fixed universal substrate in principle. |
-| 3. Continual learning | Experience on earlier tasks persistently changes how later tasks are solved. | The learning surface may include software machinery as well as weights and memories. | The change need not be an improvement, reflective, autonomous, or computationally closed. |
-| 4. Learning software factory | Earlier experience changes retained production machinery and later work depends on that change. | The factory itself learns in the cross-task sense; decompositions, evaluators, context strategies, representations, tools, search procedures, and coordination structures become learnable machinery. | One retained change does not establish compounding, broad reach, or repeated self-improvement. |
-| 5. Recursive or reflective factory | Constructing the machinery needed for a task is itself a difficult task; retained machinery can affect how later machinery is constructed. A causally connected self-representation is additionally present when reflection is claimed. | A factory-building-factory relation emerges, and some paths may be reflective with respect to represented machinery. | Factory-valued output alone is not recursion in operation; recursion alone is not reflection; reflection alone is not improvement. |
-| 6. Learning-mechanism comparison | More than one mechanism can turn experience into operative changes. | Trial and error, trajectory reuse, program search, learned policies, optimization, theory mediation, and mixtures are live candidates. | No ordering, exhaustiveness, or winner follows from the list. |
-| 7. Theory-mediation proposal | Natural-language theory can jointly represent task structure, solver limits, failure explanations, interventions, and evidence, and an LLM can interpret it into heterogeneous software changes. | Theory mediation may be a particularly versatile learning mechanism for the factory. | Necessity, sufficiency, universal superiority, and general learning remain unestablished. |
+| 1. Agentic computational substrate | Work is performed through bounded LLM calls embedded in persistent software machinery that stores state and mediates effects across calls. | The model call is not the whole behavior-producing system; consequential functions can live in software. | The software need not be generated, mutable, learning, family-specific, or universal. |
+| 2. Configured software factory | The substrate is configured with reusable production knowledge for a declared software product or solution family. | The resulting development and runtime environment is a Greenfield-style software factory for that family. | A generic harness, task family, or task-local program does not yet satisfy this boundary. |
+| 3. Agentic factory development | Current family machinery is inadequate for a covered demand, and the agent constructs or revises reusable family-level production machinery. | The agent participates in factory development rather than only solution development. | This is a practical capability claim, not a theorem that all useful machinery must be learned. |
+| 4. Factory-level continual learning | Production experience causally determines a retained factory-development change and later production depends on it. | The factory learns in the minimal cross-episode sense. | The change need not improve outcomes, be warranted, reflective, autonomous, broad, or computationally closed. |
+| 5. Learning-mechanism comparison | More than one mechanism can perform the experience-to-retained-factory-change transition. | Trial and error, trajectory reuse, program search, learned policies, direct optimization, theory mediation, and mixtures are live alternatives. | The list is not exhaustive and supplies no ranking. |
+| 6. Theory-mediation proposal | Natural-language theory can jointly represent task structure, solver limits, failures, interventions, evidence, and scope, and an LLM can interpret it into heterogeneous factory changes. | Theory mediation may be an unusually versatile mechanism for factory-level continual learning. | Necessity, sufficiency, universal superiority, and general learning remain unestablished. |
 
-## Stage 1: bounded calls plus persistent software
+## Stage 1: bounded calls participate in a larger software system
 
-The minimum claim is architectural, not ontological. A deployed agentic system
-uses one or more bounded model calls while software outside those calls carries
-some consequential state or effect path. The machinery can include prompt and
-context assembly, scheduling, memory access, tool dispatch, permissions,
-execution, validation, recovery, and retention.
+The computational foundation already exists in the [computational-model cluster](../../notes/computational-model-README.md). The [bounded-context orchestration model](../../notes/bounded-context-orchestration-model.md) gives one explicit architecture in which symbolic state and transitions surround bounded model calls. The [scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) explains why exact progression, bookkeeping, and cheaply checkable invariants often belong in software rather than accumulated natural-language context.
 
-The [bounded-context orchestration
-model](../../notes/bounded-context-orchestration-model.md) is one useful form
-when transition state is explicit and inter-call execution is symbolic. The
-more general starting claim should not inherit all of that form's closed-world,
-barrier, or scheduler conditions. The
-[scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md)
-supports why exact state transitions often belong in software rather than
-accumulated model context. It still leaves the placement boundary empirical and
-revisable.
-
-Required supporting-note job: state the minimal system boundary and explain why
-software machinery is behavior-producing rather than inert infrastructure.
+The minimum premise is broader than either note's full formal conditions. A deployed agentic system uses one or more bounded calls while software outside those calls carries some consequential state or effect path: context assembly, memory access, scheduling, tool dispatch, permissions, execution, validation, recovery, aggregation, or retention.
 
 Counterexamples and limits:
 
-- A single stateless model call still has serving software, but it may not have
-  the persistent cross-call machinery relevant to this program.
-- An LLM-mediated scheduler keeps some progression in conversation; this weakens
-  the clean separation without erasing the surrounding software substrate.
-- A perfect fixed substrate would satisfy the starting architecture. The later
-  extensibility claim needs an independent practical premise.
+- A single stateless model call may lack the persistent cross-call machinery relevant to this program.
+- An LLM-mediated scheduler weakens a clean model/software split but does not erase the surrounding serving and effect machinery.
+- A fixed, perfectly general substrate satisfies this stage. Later construction and learning claims need additional premises.
 
-## Stage 2: practical generality creates a factory role
+## Stage 2: family-specific production knowledge configures a factory
 
-The new premise concerns breadth. Across a sufficiently broad family of tasks,
-the useful production machinery is not known exhaustively in advance. Different
-tasks may reward different decompositions, data representations, checks,
-searches, algorithms, tools, context policies, or coordination structures. If
-the agent constructs some of these and uses them to perform its work, the
-system has taken on a software-factory role.
+The historical term now has an imported boundary. A [software factory](../../notes/definitions/software-factory.md) is a development and runtime environment configured for a declared family of software products or solutions. The reusable production knowledge may be distributed across a schema, packaged assets, processes or guidance, tools, frameworks, generators, tests, and lifecycle support.
 
-The claim is deliberately weaker than an impossibility theorem. A fixed
-universal substrate could in principle interpret or generate every needed
-program. The practical conjecture is that supplying all task-appropriate
-machinery extensionally in advance is unrealistic, while constructing it from
-task evidence is useful for broad enough demand families.
-
-Required supporting-note job: state the breadth condition and distinguish a
-target work product from software that organizes or performs the production
-process. Such machinery may be task-local at this stage. Later cross-task use
-belongs to the learning-factory inference rather than to the factory premise.
-
-Terminology question: the in-flight Greenfield-style definition of [software
-factory](../../notes/definitions/software-factory.md) requires a declared
-product family and lifecycle machinery. That may supply useful distinctions,
-but the general derivation must be established first. It should not turn a
-broad agentic architecture claim into a software-product-line claim merely to
-inherit the word *factory*.
-
-Counterexamples and limits:
-
-- A fixed tool loop over a narrow task family is an agentic system without the
-  extensible factory role.
-- Generating a one-off answer or target program is product work, not evidence
-  that production machinery was constructed. A task-local generated
-  orchestrator may be production machinery without yet being retained learning.
-- Selecting one item from a fully predefined catalog shows configuration reach,
-  not construction of unanticipated machinery.
-- Model-written code that is discarded after one task may demonstrate factory
-  activity within the task, but not a learning factory across tasks.
-
-## Stage 3: continual learning widens the persistent change surface
-
-Use the minimal temporal relation:
+The mapping is:
 
 ```text
-experience on task t
-  -> persistent change in the system
-  -> a different solution process on a later task
+general agentic substrate
+  + declared product or solution family
+  + reusable family-specific production knowledge
+  -> configured agentic software factory
 ```
 
-The persistent change may be parametric, natural-language, symbolic, or mixed.
-This is why the [deployed system rather than the model
-alone](../../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md)
-is the relevant boundary: prompts, retrieval, context policies, schedulers,
-tools, validators, and runtime rules can all change later behavior.
+The substrate can host or instantiate multiple factories. It should not automatically be called one universal factory. The Greenfield ontology classifies the configured family-specific producer, not every general mechanism on which it depends.
 
-The existing [continual-learning governance
-note](../../notes/continual-learning-requires-governing-behaviour-changing-writes.md)
-adds selection, validation, authorization, and coordination. Those are
-important for warranted deployment, but the foundation first needs the weaker
-cross-task dependence. The supporting work should say exactly when it moves
-from minimal continual learning to improvement-directed or self-improving
-change.
+A **task family** groups tasks under some evaluation or solver-relevant relation. A **product family** groups software products or solutions through declared commonality and variability. The same collection may satisfy both descriptions, but neither follows from the other.
 
 Counterexamples and limits:
 
-- Saving a trace that later work never consumes is persistence without
-  learning effect.
-- Loading a memory that is ignored does not establish causal dependence.
-- A human maintenance edit can change later work without showing that the agent
-  learned the change.
-- A later process that changes only because the task differs does not establish
-  retained learning from earlier experience.
+- A generic coding agent or IDE is not a Greenfield-style factory merely because it produces software.
+- A one-off generated script or orchestrator may help perform a task without carrying reusable family production knowledge.
+- A schema, template, workflow, generator, or tool can be factory machinery without being the whole configured factory.
+- A family member is product state relative to its producer, even when it happens to be another tool or factory.
 
-## Stage 4: retained construction makes the factory learn
+## Stage 3: broad demands create pressure for agentic factory development
 
-Combine stages 2 and 3 only after both stand independently. The relevant event
-is not merely that the agent writes code, nor merely that state persists. The
-agent constructs or changes production machinery from experience; the result is
-retained; and later work uses the changed machinery.
+[Factory development](../../notes/definitions/factory-development.md) changes reusable family-level production machinery. Solution development changes one family member under supplied machinery. An agent participates in factory development when it constructs or revises family scope, schemas, variation knowledge, processes, tools, evaluators, representations, workflows, or other reusable machinery for later family production.
 
-The concrete candidates include:
+The premise is practical rather than logical. A fixed universal interpreter might express every required program. A complete catalog might contain every useful schema and workflow. The claim is that for sufficiently broad software demands, exhaustively pre-supplying task-appropriate specialization is unlikely to be economical or adequate. Novel requirements, repositories, environments, and failure modes will often expose missing or mistaken production knowledge.
 
-- task decomposition and aggregation strategies;
-- context selection, compression, and retrieval policies;
-- representations and schemas;
-- evaluators, tests, and validation procedures;
-- search, planning, and recovery procedures;
-- tool implementations and interfaces; and
-- delegation and coordination structures.
-
-The [orchestration persistence
-note](../../notes/orchestration-strategies-and-run-state-have-opposite-persistence.md)
-provides one narrow example: task-specific run state can remain ephemeral while
-reusable selection strategies are promoted into tested library code. The
-example should support the general possibility without becoming the definition.
-
-Required supporting-note job: derive the learning-factory intersection and
-separate four thresholds: constructed machinery, retained machinery, causal
-later use, and evidence of improvement.
+This stage still does not require learning. An agent can construct a new factory from a complete human-supplied description. The [factory-construction prior-art boundary](../../notes/a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) shows why construction and specialization acquisition must stay separate.
 
 Counterexamples and limits:
 
-- A retained but unused tool is not operative learning.
-- A reused tool written independently of experience is reusable machinery, not
-  continual learning from the earlier task.
-- Better output on the task that caused the change does not show cross-task
-  learning.
-- One successful transfer does not establish an indefinitely self-improving or
-  compounding system.
+- Selecting an anticipated variant from a complete catalog is configuration, not acquisition of new production knowledge.
+- Repairing one product does not become factory development unless the result changes reusable machinery.
+- Constructing machinery from a supplied metamodel or schema demonstrates realization capability, not inference of that structure from production evidence.
+- Fixed general machinery can remain. The burden falls on specialization claimed to be newly handled.
 
-## Stage 5: higher-order construction yields recursion; reflection needs more
+## Stage 4: production experience can make the factory learn
 
-Some object-level tasks are difficult because they need decomposition,
-representation, evaluation, or tool construction. Choosing or constructing the
-right decomposition, representation, evaluator, or tool can itself be a
-difficult task. The factory may therefore use production machinery to build
-machinery that changes how later production machinery will be built.
+Combine agentic factory development with a causal cross-episode learning relation:
 
-That is the factory-building-factory structure. It becomes operationally
-recursive when the produced machinery participates in another machinery-
-construction transition. It becomes reflective only on a path satisfying the
-[reflective-system definition](../../notes/definitions/reflective-system.md): a
-causally connected representation of selected aspects of the same system is
-used in operation and can affect later behavior.
+```text
+production under current factory machinery
+  -> experience or evidence about its behavior
+  -> system-determined retained change to reusable factory machinery
+  -> later production depends on the change
+```
 
-The [fixed-decomposition
-argument](../../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md)
-explains why some higher-order choices must remain challengeable when they carry
-task-specific mistakes. It does not imply that every fixed component is a
-defect. General learning machinery, objectives, interfaces, resource controls,
-or trusted kernels may remain fixed over the claimed reach.
+All four links matter. Experience that triggers only product repair does not change the factory. A generated candidate that is discarded does not persist. A stored artifact that no later production consumes has no demonstrated learning effect. A later change caused only by a different task rather than retained experience is not continual learning from the earlier episode.
 
-Required supporting-note job: derive the higher-order structure from nested
-task difficulty and state when recurrence, reflection, self-improvement, and
-compounding do or do not follow.
+This is deliberately weaker than the existing [continual-learning governance](../../notes/continual-learning-requires-governing-behaviour-changing-writes.md) account. Governed deployment may require candidate selection, validation, authorization, rollback, and coordination across representational forms. Those are important stronger conditions, but not every direct evidence-responsive update exposes a proposal-selection architecture.
+
+The [deployed system, not the model alone](../../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md), is the relevant learning boundary. The retained change may live in weights, natural-language artifacts, symbolic software, retrieved memories, or mixtures. Factory-level learning is the subset that changes reusable production machinery.
 
 Counterexamples and limits:
 
-- A conventional generator can emit another generator from a supplied complete
-  specification without learning or reflecting.
-- A reflective system can inspect its scheduler without changing it.
-- An adaptive system can change its controller without a self-representation
-  and therefore learn without reflection.
-- A successor can remove the path that produced it; one transition does not
-  establish repeatability.
+- A human maintenance edit can improve later production without showing that the agentic system learned the change.
+- Better performance on the same product that caused the revision does not by itself show cross-episode reuse.
+- A retained change can be harmful; learning is not yet improvement.
+- One occurrence does not establish repeatability, compounding, broad reach, or autonomy.
 
-## Stage 6: compare mechanisms on the same causal job
+## Stage 5: compare mechanisms on the same causal job
 
-The comparison object is a transition from experience to a persistent change
-that affects later production. Candidate mechanisms include:
+The shared comparison object is the transition from production experience to a retained factory change that affects later production. Candidate mechanisms include:
 
 - trial-and-error retention of successful machinery;
-- reuse or transformation of trajectories and episodes;
+- retrieval, reuse, transformation, or compression of trajectories and episodes;
 - enumerative, stochastic, evolutionary, or LLM-guided program search;
-- learned policies for selecting or constructing machinery;
+- learned policies for selecting, composing, or constructing machinery;
 - gradient-based or other direct optimization;
 - natural-language theory construction and revision; and
-- mixtures operating at different times or on different machinery.
+- mixtures operating on different artifacts, timescales, or parts of the factory.
 
-Compare them by what evidence they consume, what change space they can reach,
-how they assign credit, how a result becomes operative, how they handle
-negative transfer and revision, and their total computational and human cost.
-Do not equate a readable mechanism with a better one or a parametric mechanism
-with a more general one.
+Compare mechanisms by the evidence they consume, the change spaces they reach, how they allocate search and credit, how changes become operative, how they detect negative transfer, their revision costs, and their total computational and human cost.
 
-Required supporting-note job: produce a neutral comparison frame or show that
-existing notes already supply one. A catalog that merely names techniques does
-not carry the argument.
+Readable state is not automatically better state. Parametric learning is not automatically more general. Exact symbolic machinery is not automatically correct. A fair comparison must hold task information, model access, interaction, and budget as comparable as the mechanism permits.
 
-## Stage 7: theory mediation is the proposal
+## Stage 6: theory mediation is the research proposal
 
-Natural-language theory is a candidate coordination medium for the learning
-factory because it can place several kinds of state in one interpretable
-representation:
+Natural-language theory is a candidate coordination medium because it can express several kinds of state in one LLM-interpretable representation:
 
-- a model of task or domain structure;
-- a model of the solver's relevant capacities and limitations;
-- explanations of observed successes and failures;
-- proposed changes and their intended mechanisms;
-- scope conditions and predictions; and
+- models of task or domain structure;
+- models of relevant solver capacities and limitations;
+- explanations of successes and failures;
+- proposed interventions and their intended mechanisms;
+- scope conditions, predictions, and expected failure modes; and
 - evidence that should revise or reject the account.
 
-An LLM can interpret this state into different software changes rather than
-requiring one fixed update operator per artifact kind. Existing work on
-[program theory and delayed
-feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md),
-[theory-mediated causal
-paths](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md),
-and [sample efficiency under structured
-shifts](../../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md)
-supplies the downstream hypothesis and evidence requirements.
+An LLM can interpret such theory into heterogeneous changes rather than requiring one fixed update operator per artifact kind. Existing notes on [program theory under delayed feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md), [theory-mediated causal paths](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), and [sample efficiency under structured shifts](../../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md) supply the downstream hypothesis and evidence requirements.
 
-The comparative prediction must be sharper than “theory is flexible.” Plausible
-tests ask whether theory mediation, at comparable information and total cost:
+The comparative prediction must be stronger than “theory is flexible.” At comparable information and total cost, theory mediation should sometimes:
 
-- transfers one explanation into several different machinery changes;
-- predicts where a mechanism will fail or stop applying;
-- improves diagnosis and recovery after delayed feedback;
-- supports selective revision without replaying all prior experience; or
-- performs no better, or worse, than trajectories, rules, program search,
-  learned policies, direct optimization, or mixtures.
+- transfer one explanation into several different factory changes;
+- expose where a decomposition, representation, or evaluator will stop applying;
+- improve diagnosis and recovery when decisive feedback arrives later;
+- support selective revision without replaying all prior experience; or
+- lose clearly when trajectories, direct search, learned policies, optimization, or mixtures solve the same transition more effectively.
 
-Required supporting-note job: state versatility as a defeasible comparative
-claim. The article may then make theory mediation its research bet without
-making it the foundation of the architecture.
+## Optional extensions
 
-## Integration tests for the final article
+These properties classify stronger systems or experiments. They do not sit on the mandatory path to theory mediation.
 
-1. Delete the theory-mediation section. The reader should still understand why
-   an agentic system can become a learning software factory.
-2. Replace every factory term with its plain causal description. The argument
-   should lose brevity, not validity.
-3. Hold the software substrate fixed. The starting architecture must remain
-   coherent, while the practical-generalization claim becomes an empirical
-   question rather than a contradiction.
-4. Let the factory learn without a self-representation. Continual learning must
-   remain possible, while reflection is correctly withheld.
-5. Let the system construct one-off code and discard it. Factory activity may
-   occur, but cross-task factory learning must be withheld.
-6. Let theory mediation lose to a direct optimizer. The comparative proposal
-   must lose or narrow without collapsing the architectural spine.
+| Extension | Additional condition | What it establishes |
+|---|---|---|
+| Higher-order factory development | Factory machinery constructs or revises machinery used for later factory development. | A factory-building-factory relation in operation. |
+| Operational recursion | The result of one machinery-construction transition participates in another transition of the same relevant class. | Recurrence of the construction path, not necessarily learning or improvement. |
+| Reflection | A causally connected representation of selected aspects of the same system participates in operation or revision. | Aspect-relative reflective organization. |
+| Computational closure | Every decision assigned to a declared learning path is computationally supplied, conditional on permitted external evidence and interaction. | Actor allocation for that path, not quality or breadth. |
+| Self-improvement | Evidence supports that the system's own retained change improved a declared objective. | Improvement attribution, not compounding. |
+| Compounding | A prior change improves the capacity to produce or select later improvements. | Improvement of the improvement process. |
+| Domain breadth | The process acquires adequate specialization across a declared class of demands. | Reach, independent of closure. |
+
+A factory can learn without reflection. A reflective factory can fail to learn. A closed path can perform badly. A broad process can remain human-open. A successor implementation can remove the path that produced it.
+
+## Integration tests
+
+1. Delete the theory-mediation stage. The reader should still understand configured software factories, agentic factory development, and factory-level continual learning.
+2. Replace every factory term with its causal description. The argument should lose brevity, not validity.
+3. Hold the substrate fixed. The architecture remains coherent; only the practical construction premise becomes false for the tested regime.
+4. Generate one-off code and discard it. Production software exists, but factory machinery and continual learning are withheld.
+5. Generate a factory from a complete supplied schema. Factory construction is established; specialization acquisition and learning are withheld.
+6. Retain a harmful factory change. Learning may have occurred, while improvement is withheld.
+7. Let a direct optimizer beat theory mediation. The theory proposal narrows or loses without collapsing the earlier stages.

--- a/kb/work/agentic-system-learning-refoundation/transition-map.md
+++ b/kb/work/agentic-system-learning-refoundation/transition-map.md
@@ -1,142 +1,104 @@
 # Transition map
 
-This map records how current material may serve the new conceptual spine. It is
-not a move manifest and does not authorize edits to the listed artifacts. The
-[old workshop](../theory-mediated-self-improvement-series/README.md) remains
-active until a later explicit closure pass.
+This map records how current material serves the revised conceptual spine. It is a disposition ledger, not a claim that every action has already been completed. The [theory-mediated self-improvement workshop](../theory-mediated-self-improvement-series/README.md) remains active until a separate migration and closure pass.
 
-The map reflects the worktree observed on 2026-08-31. Several software-factory
-notes and article changes were in flight and uncommitted. Re-read their current
-content and establish edit ownership before acting on a disposition below.
+## Disposition vocabulary
 
-## Disposition rules
+- **Carry** — retain the claim and use it at the same level.
+- **Reposition** — retain the claim but move it later in the dependency order.
+- **Revise** — preserve the job while correcting scope or terminology.
+- **Split** — extract independently useful claims into separate homes.
+- **Park** — keep as specialized methodology or working material, outside the foundation.
+- **Retire after replacement** — remove the current formulation only after its durable content has a validated successor.
 
-- **Foundation candidate** — may carry an early arrow after its scope and
-  independence are checked.
-- **Downstream theory material** — preserve, but place after the learning-
-  factory architecture and alternative-mechanism comparison.
-- **Specialized extension** — useful for a narrower claim, not required by the
-  general spine.
-- **Evidence or process record** — retain until its live conclusion has a
-  durable home; do not seed article prose directly unless its source rules allow
-  that use.
-- **Reframe later** — likely article or synthesis work, deliberately blocked on
-  the supporting notes.
+## Foundation and bridge material
 
-## New-spine support
-
-| Spine job | Current material | Provisional disposition | Gap before use |
+| Job in the revised spine | Current material | Disposition | Required action |
 |---|---|---|---|
-| Minimal agentic architecture | [Bounded-context orchestration model](../../notes/bounded-context-orchestration-model.md); [scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md); [agent-runtime decomposition](../../notes/agent-runtime-analysis-should-separate-scheduling-context-state.md) | Foundation candidates | Extract a minimal bounded-calls-plus-persistent-software claim without inheriting the orchestration model's closed-world and barrier conditions. |
-| Software as part of the behavior-producing and learning boundary | [The deployed system, not the model alone, is the unit of learning](../../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md); [retained system-definition artifacts](../../notes/retained-artifacts-enable-persistent-deployment-time-adaptation.md) | Foundation candidates | Separate the minimal cross-task learning premise from stronger evidence-responsive improvement and deployment-governance requirements. |
-| Practical need to construct task machinery | [Learning inside a fixed decomposition inherits its mistakes](../../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md); [orchestration persistence economics](../../notes/orchestration-strategies-and-run-state-have-opposite-persistence.md) | Foundation candidates | Add the positive broad-task-family argument. Fixed decompositions can be mistaken, but that alone does not show agents must construct machinery. |
-| General software-factory role | In-flight [software-factory reconstruction](../../notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md) and [software-factory definition](../../notes/definitions/software-factory.md) | Specialized extension pending terminology decision | Determine whether Greenfield's product-family and lifecycle boundary fits the general agentic role. Do not make the architectural premise true by adopting the narrower definition. |
-| Breadth and extensibility | In-flight [domain-extensible software factory](../../notes/definitions/domain-extensible-software-factory.md) and [factory reach](../../notes/domain-extensibility-not-closure-determines-factory-reach.md) | Specialized extension | Their declared tuples and family-specialization tests may support later evaluation. The foundation first needs the modest practical claim that not all useful machinery will realistically be predefined. |
-| Minimal continual learning | [Learning is not only about generality](../../notes/learning-is-not-only-about-generality.md); [continual-learning governance](../../notes/continual-learning-requires-governing-behaviour-changing-writes.md); [self-improving-system definition](../../notes/definitions/self-improving-system.md) | Split | Retain their stronger distinctions, but add or revise support for the weaker “earlier experience changes later solving” premise. Do not import self-improvement membership into continual learning by definition. |
-| Learning factory | In-flight [closed factory-learning transition](../../notes/a-closed-factory-learning-transition-produces-a-successor-factory.md), [operative succession](../../notes/operative-succession-turns-meta-factory-construction-into-learning.md), and [computationally closed factory-learning loop](../../notes/definitions/computationally-closed-software-factory-learning-loop.md) | Specialized extension | First derive the simpler intersection of retained constructed machinery and cross-task dependence. Closure, evidence-responsive improvement, and successor terminology should remain optional stronger claims. |
-| Recursion and reflection | [Reflective system](../../notes/definitions/reflective-system.md); [fixed decomposition](../../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md); [repeatable redesign path](../../notes/a-repeatable-operative-path-keeps-a-redesign-class-open-to-revision.md); [machinery persists by warrant](../../notes/machinery-persists-by-warrant-not-position-in-a-reflective-loop.md) | Foundation candidates for the higher-order stage | Add the nested-difficulty derivation. Keep factory-valued production, operational recursion, reflection, repeatability, and compounding separate. |
-| Alternative learning mechanisms | [Proposal-selection loop](../../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md); [Bitter Lesson production-method distinction](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md); existing related-system evidence | Split or new synthesis | Build a neutral comparison on the shared experience-to-operative-change job. Current material is distributed and often organized around theory mediation or proposal selection. |
-| Theory mediation as candidate | [Program theory under delayed feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md); [theory-mediated causal path](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md); [theory-mediated system-learning synthesis](../../notes/theory-mediated-system-learning-combines-runtime-self-modeling-with-theory-refinement.md); [sample-efficiency conjecture](../../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md) | Downstream theory material | State the versatility hypothesis against alternatives and connect it to heterogeneous factory changes. Remove any dependence in the opposite direction. |
+| Agentic computational substrate | [Computational-model cluster](../../notes/computational-model-README.md), [bounded-context orchestration model](../../notes/bounded-context-orchestration-model.md), [scheduler–LLM separation](../../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md), [select/call normal form](../../notes/any-symbolic-program-with-llm-calls-is-a-select-call-program.md) | Carry | Import the cluster rather than write another note asserting bounded calls plus software. Use only the minimal premises needed by the article. |
+| Software as part of the learning boundary | [The deployed system, not the model alone, is the unit of learning](../../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md), [retained system-definition artifacts](../../notes/retained-artifacts-enable-persistent-deployment-time-adaptation.md) | Carry and reposition | Use after the computational substrate and before the continual-learning bridge. Keep stronger deployment claims separate from the minimal relation. |
+| Imported software-factory ontology | [Software factory](../../notes/definitions/software-factory.md), [factory development](../../notes/definitions/factory-development.md), [versioned Greenfield reconstruction](../../notes/a-software-factory-is-family-scoped-lifecycle-production-machinery.md) | Revise | Keep two compact definitions plus one versioned synthesis. Remove closure, successor, and domain-reach extensions from the imported meanings. |
+| Recursive-construction prior art | Greenfield 2003, Tool Factory, MDSoFa, and the current long synthesis | Split | Extract the claim that a factory can produce another factory without learning the supplied specialization. Keep construction and acquisition separate. |
+| Agentic substrate to configured factory mapping | No durable atomic note | New bridge | State that a general agentic substrate becomes a Greenfield-style factory only when configured with declared family-specific reusable production knowledge. |
+| Task family versus product family | No durable atomic note | New bridge | Define the different classification jobs and block benchmark task groupings from silently becoming software-product families. |
+| Practical pressure for agentic factory development | [Learning inside a fixed decomposition inherits its mistakes](../../notes/learning-inside-a-fixed-decomposition-inherits-its-mistakes.md), [orchestration persistence economics](../../notes/orchestration-strategies-and-run-state-have-opposite-persistence.md) | Carry as support; add new claim | State the positive practical premise: broad demands often require construction or revision of reusable production machinery. Preserve the fixed-universal-substrate possibility. |
+| Minimal factory-level continual learning | [Learning is not only about generality](../../notes/learning-is-not-only-about-generality.md), [continual-learning governance](../../notes/continual-learning-requires-governing-behaviour-changing-writes.md) | Split | Add a weaker causal note: production experience determines a retained reusable-factory change used later. Keep governance, validation, and authorization as stronger deployment requirements. |
+| Neutral mechanism comparison | [Proposal-selection loop](../../notes/a-proposal-selection-loop-requires-search-evaluation-and-retention.md), [Bitter Lesson production-method distinction](../../notes/the-bitter-lesson-selects-production-methods-not-representational.md), related-system ingests | New synthesis | Compare mechanisms on the same experience-to-retained-factory-change job. Do not make proposal selection universal or arrange a ladder with theory at the top. |
+| Theory mediation as a candidate | [Program theory under delayed feedback](../../notes/program-theory-sustains-search-under-delayed-feedback.md), [theory-mediated causal path](../../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md), [sample-efficiency conjecture](../../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md) | Reposition | Preserve as the downstream research proposal and sharpen the comparative versatility hypothesis. |
 
-## Existing research-program article
+## Premature software-factory extensions
 
-The current [research-program
-article](../../articles/a-research-program-for-theory-mediated-system-learning.md)
-contains valuable downstream material:
+The 2026-08-31 batch contains useful distinctions but registered them too early as foundational definitions or article premises.
 
-- Naur's bearer question and longitudinal coherent modification;
-- the theory-mediation causal path and evidence ladder;
-- theory intervention and delayed-feedback experiment design;
-- the separation of claim warrant from fit in a working theory;
-- Commonplace and programming agents as testbeds; and
-- the admission that current evidence is human-inclusive and not comparative.
-
-Carry these downstream rather than discard them.
-
-The article currently opens from theory mediation, and its in-flight edit adds a
-Greenfield-style “closed learning produces successor factories” section before
-the coherent-search argument. Both arrangements remain blocked for this
-workshop. The eventual restructure should instead:
-
-1. establish the minimal agentic architecture;
-2. derive the practical factory role;
-3. add continual learning and retained machinery;
-4. derive the higher-order factory structure only where needed;
-5. compare alternative learning mechanisms; and
-6. introduce the existing theory-mediated program as the positive proposal.
-
-The article need not carry the full derivation of every arrow once durable notes
-do. It should make the dependency order visible and link the supporting claims.
-
-## Old-workshop core artifacts
-
-| Artifact | Contribution worth preserving | Later action |
+| Artifact | Durable content | Disposition |
 |---|---|---|
-| [README](../theory-mediated-self-improvement-series/README.md) | Researcher-facing intent, evidence standards, actor-allocation disclosure, source controls, and hand-back conditions | Preserve as the old commission until migration. Reframe its theory-first central question in the successor article rather than editing the historical commission now. |
-| [Shared model](../theory-mediated-self-improvement-series/shared-model.md) | Mixed-form system account, theory-mediation levels, truth-versus-fit distinction, current human/computational allocation, experiments, and episode-record schema | Carry the theory-specific material downstream. Split general architecture from theory-specific mechanism where the shared model currently combines them. |
-| [Target problems](../theory-mediated-self-improvement-series/target-problems.md) | Coherent modification, warranted transfer, operative-theory attribution, evaluation, and bootstrap failure modes | Reorder. The current P1/P3 center becomes the downstream proposal; architectural generality and learning-factory questions become prior jobs. Keep closure and warrant as separate evaluation coordinates. |
-| [Article roles](../theory-mediated-self-improvement-series/article-roles.md) | Useful modular editing boundary and companion-article discipline | Rebuild after the supporting notes settle the new article dependency order. Do not preserve the old module order merely for synchronization. |
-| [Program-article review residuum](../theory-mediated-self-improvement-series/program-article-review-residuum-2026-08-30.md) | Minimum-theory threshold, nested hypotheses, stronger controls, decomposition mapping, fit taxonomy, scaling denominators, and instrumentation gaps | Carry downstream as an unresolved research queue. The new foundation reduces pressure to settle the minimum-theory threshold before the architecture can be stated. |
-| [Task-scoped computational closure](../theory-mediated-self-improvement-series/task-scoped-computational-closure.md) and [closure–capability map](../theory-mediated-self-improvement-series/closure-capability-map.md) | Careful separation of structural closure, capability, warrant, usefulness, and power | Specialized extension and evaluation material. Do not use closure to define the learning factory. |
-| [Gradual compatibility](../theory-mediated-self-improvement-series/gradual-compatibility.md) | Narrow Bitter Lesson response and bootstrap conditions | Reconcile with the fixed-general-substrate possibility and keep as a scaling companion rather than the architectural foundation. |
+| [Software-production task and process](../../notes/definitions/software-production-task-and-process.md) | Longitudinal task identity, evidence protocol, acceptance, horizon, resources, and coverage | Park as evaluation methodology. It is not part of the imported Greenfield ontology. |
+| [Computationally closed software-factory learning loop](../../notes/definitions/computationally-closed-software-factory-learning-loop.md) | Path-relative actor allocation and the evidence/intervention boundary | Park as a specialized closure definition. Closure is not required for factory-level continual learning. |
+| [Domain-extensible software factory](../../notes/definitions/domain-extensible-software-factory.md) | The research question of acquiring family specialization for demands outside installed families; useful experimental indices | Demote from foundational definition to hypothesis or experiment scaffold after the minimal learning bridge exists. |
+| [Successor factory](../../notes/definitions/successor-factory.md) | The distinction between generated candidates and changes that actually govern later production | Retire after replacement. Existing operative-change and causal-use vocabulary can carry the useful boundary without a new factory noun. |
+| [A closed factory-learning transition produces a successor factory](../../notes/a-closed-factory-learning-transition-produces-a-successor-factory.md) | Operative retention is required before a changed factory affects later work | Retire after replacement. Most of the claim is generated by the successor definition itself. |
+| [Evidence-responsive operative succession turns meta-factory construction into learning](../../notes/operative-succession-turns-meta-factory-construction-into-learning.md) | Greenfield/Tool Factory/MDSoFa prior art and the construction-versus-learning distinction | Split. Move the prior-art result into the compact construction-versus-acquisition note; leave closure and succession downstream. |
+| [Domain extensibility, not closure, determines factory reach](../../notes/domain-extensibility-not-closure-determines-factory-reach.md) | Closure and breadth are independent; construction from a supplied description is not acquisition of that description | Split, then retire the current omnibus note. Preserve the two distinctions separately; park the universal-factory formalization until the literature scan is settled. |
 
-## Old-workshop evidence and source controls
+Until replacements merge, these files remain available as working material. New article prose should not depend on their registered terminology.
 
-The following are process or evidence records, not obsolete drafts:
+## Source ingests
 
-- [incumbent ledger](../theory-mediated-self-improvement-series/incumbent-ledger.md);
-- [match register](../theory-mediated-self-improvement-series/match-register.md);
-- [adequacy-gate run](../theory-mediated-self-improvement-series/adequacy-gate-run.md);
-- [absorption survivors](../theory-mediated-self-improvement-series/absorption-survivors.md);
-- [grounding-sweep narrowing check](../theory-mediated-self-improvement-series/grounding-sweep-narrowing-check.md);
-- [accepted baseline](../theory-mediated-self-improvement-series/accepted/README.md); and
-- [rejected-draft quarantine](../theory-mediated-self-improvement-series/rejected-drafts/README.md).
+Keep the source captures and evidence limits:
 
-Keep their source restrictions in force. A re-foundation changes dependency and
-exposition; it does not convert rejected prose into an accepted baseline or
-erase the provenance of recovered claims.
+- [Greenfield and Short 2003](../../sources/greenfield-short-software-factories-oopsla-2003.ingest.md);
+- [Greenfield 2007](../../sources/greenfield-mass-customizing-software-factories-2007.ingest.md);
+- [Software Factories book preview](../../sources/greenfield-short-software-factories-book-preview.ingest.md);
+- [Tool Factory](../../sources/cook-kent-tool-factory-2003.ingest.md); and
+- [MDSoFa](../../sources/langlois-exertier-mdsofa-software-factory-factory-2004.ingest.md).
 
-Before closing the old workshop, each record must be classified as consumed by
-durable outputs, still needed as retained evidence, recoverable from git history
-without loss, or transferred to a new live owner.
+Their classifications, source summaries, extracts, and limitations remain useful. After the durable notes settle, revise only interpretive fields that point to retired successor, closure, or domain-extensibility formulations. The partial book preview must remain a bibliographic and framing source rather than authority for detailed ontology claims.
 
-## Companion material
+## Research-program article
 
-- [The decisions that stay human, and what would move
-  them](../../articles/the-decisions-that-stay-human-and-what-would-move-them.md)
-  remains a companion on transfer, closure, and warrant. Those are not the
-  minimal learning-factory premise.
-- [The Bitter Lesson does not require everything to live in
-  weights](../../articles/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md)
-  remains a scaling and production-method companion. It should not establish
-  theory mediation by exclusion of alternatives.
-- The [explanatory-theories deployment-time-learning
-  workshop](../explanatory-theories-deployment-time-learning/README.md) owns
-  comparative experimental work on whether explicit theory improves search and
-  evidence acquisition. Coordinate its experiments rather than duplicating
-  them here.
+Preserve these downstream contributions:
+
+- Naur's bearer question;
+- coherent modification across delayed consequences;
+- the theory-mediated causal path and evidence ladder;
+- theory withholding, replacement, and wrong-theory controls;
+- the distinction between claim warrant and fit in a working theory;
+- Commonplace and programming agents as complementary testbeds; and
+- the current human/computational actor allocation.
+
+The article should eventually follow this dependency order:
+
+1. import the agentic computational substrate;
+2. map it to a configured family-specific software factory;
+3. motivate agentic factory development under broad demands;
+4. define factory-level continual learning;
+5. compare alternative learning mechanisms;
+6. introduce theory mediation as the positive research bet;
+7. develop Naur, coherent modification, experiments, evidence, and bootstrapping.
+
+The article need not reproduce every supporting derivation. It must make the order visible and avoid reopening closure, recursion, or universal-factory claims before they are needed.
+
+## Companion articles
+
+- [The Bitter Lesson does not require everything to live in weights](../../articles/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md): carry the production-method-versus-representational-form argument. Replace domain-extensible-factory terminology with the more general requirement that task-specific production knowledge increasingly be computationally found rather than rebuilt by people for each new case.
+- [The decisions that stay human, and what would move them](../../articles/the-decisions-that-stay-human-and-what-would-move-them.md): carry as a companion on warrant, transfer, closure, and residual human decisions. Do not make it part of the minimal learning definition.
+- [Continual learning outside the weights](../../articles/continual-learning-outside-the-weights.md): keep withdrawn. Recover claims only through durable notes, not by reviving the rejected article body.
+
+## Old workshop records
+
+The old workshop's README, shared model, target problems, article roles, ledgers, accepted baseline, rejected-draft quarantine, review residua, and closure/capability maps remain governed by their existing source and disposition rules.
+
+Carry theory-specific experiment design and evidence downstream. Do not rewrite historical commissions as though the refoundation had governed them. Before closing the old workshop, classify each artifact as consumed by durable outputs, retained as evidence, transferred to a new owner, or safely recoverable from history.
 
 ## Migration gate
 
-No article restructuring or old-workshop closure begins until supporting notes
-can answer all of these questions:
+The main article restructure begins only when durable notes answer:
 
-1. What is the minimum agentic architecture being assumed, and which scheduler
-   details are optional?
-2. What empirical or practical breadth premise creates the need for constructed
-   machinery?
-3. What distinguishes a target work product from task-local production
-   machinery, and what additional retention makes that machinery part of
-   cross-task learning?
-4. What is the minimal cross-task learning relation, and when do stronger
-   improvement or self-improvement claims begin?
-5. What makes retained machinery part of a learning factory?
-6. When does higher-order construction become operationally recursive, and
-   when does it meet the stricter reflection criterion?
-7. Which alternative learning mechanisms perform the same causal job?
-8. What comparative result would support, narrow, or defeat the theory-
-   versatility hypothesis?
+1. What turns a general agentic substrate into a Greenfield-style software factory?
+2. How do task families differ from software product or solution families?
+3. What practical breadth premise motivates agentic factory development without denying a fixed universal substrate in principle?
+4. What is the minimal causal relation for factory-level continual learning?
+5. Which mechanisms perform the same experience-to-retained-change job?
+6. What comparative result would support, narrow, or defeat the theory-versatility hypothesis?
 
-Once these are carried by durable notes, update this map with concrete
-`carry`, `revise`, `split`, or `retire-after-replacement` dispositions and only
-then edit the article.
+After those notes merge, update this map from planned dispositions to completed ones, restructure the article, and only then decide whether to delete, withdraw, or retain the premature extension files.


### PR DESCRIPTION
## Intent

Rebase the refoundation workshop on the imported distinction between a general agentic substrate, a configured family-specific software factory, factory development, and factory-level continual learning.

## Changes

- import the existing computational-model cluster rather than proposing another bounded-call architecture note;
- stop treating task-local generated software as sufficient for the Greenfield factory boundary;
- distinguish task families from software product or solution families;
- shorten the conceptual spine to factory configuration, agentic factory development, continual learning, mechanism comparison, and theory mediation;
- move recursion, reflection, closure, self-improvement, compounding, and breadth into optional extensions;
- record concrete carry/revise/split/park/retire-after-replacement dispositions for the premature notes and articles.

## Dependency

This is a draft stacked on PR 148. Its base is the ontology branch, so the diff contains only the three workshop files. After PR 148 merges, retarget this PR to `main` before merging.