### PR TITLE
Refoundation 4/5: add the agentic factory-learning bridge

### DIFF
--- a/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
+++ b/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
@@ -1,0 +1,113 @@
+---
+description: "Minimal factory-level continual learning requires production experience to causally determine a retained change to reusable family machinery that affects later production"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, learning-theory, self-improving-systems]
+---
+
+# A software factory learns when production experience changes reusable machinery used later
+
+A [software factory](./definitions/software-factory.md) undergoes **factory-level continual learning** when experience from production causally determines a retained change to its reusable family-level production machinery and later production depends on that change.
+
+The minimal path is:
+
+```text
+production under current factory machinery
+  -> experience bearing on that machinery
+  -> change to reusable family-level production machinery
+  -> retention
+  -> changed later production
+```
+
+Each link excludes a nearby but weaker event.
+
+- Experience without a factory change is observation or feedback.
+- Product repair without a reusable change is solution development.
+- A generated but rejected or discarded asset is a candidate, not retained learning.
+- Stored machinery that later production does not consume has no demonstrated behavioral effect.
+- A later process that differs only because the task differs does not show dependence on earlier experience.
+
+## The learning target is factory development
+
+[Factory development](./definitions/factory-development.md) constructs or revises reusable production machinery for a declared product or solution family. The learning claim therefore concerns changes such as:
+
+- revised family scope, commonality, variability, or configuration knowledge;
+- new or changed schemas, viewpoints, and representations;
+- decomposition, aggregation, retrieval, or context-management strategies;
+- processes, guidance, prompts, and methods;
+- tools, generators, libraries, frameworks, and interfaces;
+- tests, evaluators, validation rules, monitors, and recovery procedures; or
+- reusable lifecycle content for requirements, architecture, deployment, operation, maintenance, or migration.
+
+The same production event can have both product-level and factory-level effects. A failed test may trigger a patch to the current product and also reveal that a reusable test generator or release gate should change. Only the latter change is factory-level learning relative to the producing factory.
+
+## Learning is boundary-relative
+
+The causal determination must occur inside the learner boundary being claimed. At a human-inclusive boundary, a person and computational tools may jointly interpret experience and revise the factory. At a boundary that excludes the operator, a human-selected schema, evaluator, decomposition, promotion decision, or recovery step remains an external intervention rather than learning by the technical subsystem.
+
+This distinction is about causal responsibility, not who typed the final bytes. An LLM can author a file while a person supplies the decisive change. Conversely, a person can provide an observation or acceptance response while the system determines how reusable machinery should change.
+
+The permitted evidence and interaction protocol should therefore be declared separately from the update decisions assigned to the learner.
+
+## Retention means later behavioral dependence
+
+Retention is stronger than storage. The changed machinery must enter a path through which it can affect later production. Depending on the factory, this may mean that a revised schema is loaded, a workflow is selected by default, a validator gates later changes, a tool becomes available, or a natural-language rule is retrieved into later model calls.
+
+Permanent installation is not required. A change can be operative for a declared horizon and later be rolled back. What matters is that later production actually depended on it during the interval for which learning is claimed.
+
+Later use can occur on another family member or on a later lifecycle episode for the same member, provided the changed item is genuinely reusable family machinery rather than a disguised product-local patch. Evidence from a distinct admitted variation is stronger because it tests the reuse claim directly.
+
+## Minimal learning does not imply improvement
+
+A retained factory change can degrade later production. The causal sequence still establishes learning in the minimal sense that experience changed future capacity or behavior. Calling it **improvement** additionally requires a declared objective, an assessment relation, and evidence that the change helped relative to an appropriate comparison.
+
+The minimal definition also does not require:
+
+- explicit competing candidates or a proposal-selection loop;
+- a complete independent evaluator;
+- computational closure;
+- reflection or a self-model;
+- recursive factory construction;
+- broad domain reach;
+- repeatability after the change; or
+- compounding improvement.
+
+Those are separately testable extensions.
+
+## Direct updates and search both qualify
+
+Some learning paths expose proposals, reject candidates, select one, and install it. Others directly update a retained rule, policy, model, or schema in response to evidence. Both can satisfy the minimal path when the causal and later-use relations are established.
+
+The [proposal-selection loop](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) remains important for architectures that expose rejectable candidates. It should not be imported as the definition of all factory learning.
+
+Likewise, [continual-learning governance](./continual-learning-requires-governing-behaviour-changing-writes.md) adds selection, validation, authorization, coordination, and regression control for safe deployment. Those requirements govern learning well; they are stronger than the minimal occurrence condition.
+
+## Evidence
+
+A persuasive record should identify:
+
+1. the factory machinery before the episode;
+2. the production experience that bore on it;
+3. the update decision and the declared learner boundary;
+4. the retained change;
+5. the later production path that consumed it; and
+6. the behavioral difference attributable to the retained change.
+
+Withholding, reverting, or replacing the change strengthens causal attribution. A mere chronology—experience occurred, a file changed, later work improved—does not establish that the same learning path connects the events.
+
+## Scope
+
+- The definition is relative to a declared factory and product-family boundary.
+- Accumulating product facts or traces can be continual learning at the deployed-system level without being factory-level learning.
+- Human maintenance can improve a factory without demonstrating learning by a narrower technical subsystem.
+- Factory-level learning can occur in natural-language, symbolic, parametric, or mixed representational forms.
+- One occurrence does not establish indefinite learning capacity or recursive self-improvement.
+
+---
+
+Relevant Notes:
+
+- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — grounds: places all behavior-determining factory machinery inside the candidate learning surface
+- [Continual learning requires governing behaviour-changing writes, not just storing content](./continual-learning-requires-governing-behaviour-changing-writes.md) — extends: adds governance requirements for safe and coordinated deployment
+- [Operative change](./definitions/operative-change.md) — extends: supplies the stronger persistence and behavioral-authority account for retained system changes
+- [Task families and product families classify different things](./task-families-and-product-families-classify-different-things.md) — grounds: clarifies what later transfer establishes at task and family levels

--- a/kb/notes/an-agentic-substrate-becomes-a-software-factory-through-family-specific-production-machinery.md
+++ b/kb/notes/an-agentic-substrate-becomes-a-software-factory-through-family-specific-production-machinery.md
@@ -1,0 +1,76 @@
+---
+description: "Maps the bounded-call agentic substrate to Greenfield's software-factory ontology without calling every generic harness or generated program a factory"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# An agentic substrate becomes a software factory through family-specific production machinery
+
+A general agentic substrate is not automatically a software factory. It becomes a Greenfield-style [software factory](./definitions/software-factory.md) for a declared software product or solution family when it is configured with reusable family-specific production knowledge that guides and supports the creation and sustainment of family members.
+
+The mapping can be written schematically as:
+
+\[
+F_{\mathcal P}=\operatorname{configure}(G,K_{\mathcal P})
+\]
+
+where \(G\) is general agentic machinery, \(\mathcal P\) is a declared product or solution family, and \(K_{\mathcal P}\) is reusable production knowledge for that family. \(F_{\mathcal P}\) is the configured factory.
+
+The general substrate may include bounded LLM calls, persistent state, context assembly, scheduling, tool dispatch, permissions, code execution, aggregation, validation, recovery, and storage. The [bounded-context orchestration model](./bounded-context-orchestration-model.md) supplies one computational form for this substrate, and [scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) explains why exact progression and bookkeeping often belong in its software part.
+
+The family-specific production knowledge may include:
+
+- the family scope, commonality, variability, variants, and constraints;
+- schemas, viewpoints, and intermediate representations;
+- domain-specific decomposition and coordination strategies;
+- processes, guidance, prompts, and methods;
+- tools, generators, frameworks, libraries, and interfaces;
+- tests, evaluators, validation rules, and recovery procedures; and
+- reusable lifecycle content for requirements, design, implementation, deployment, operation, maintenance, or migration.
+
+This list extends the historical ontology into current agentic machinery while preserving its boundary: the relevant items are reusable production knowledge for a declared family, not merely any software artifact present in the system.
+
+## The substrate and the factory have different scopes
+
+One substrate can host, select, compose, or help construct several factories. A generic LLM runtime may remain the same while different family schemas, tools, workflows, tests, and guidance configure it for web applications, data pipelines, embedded controllers, or another declared family.
+
+Calling the general substrate one universal software factory would hide this distinction. Its generic capabilities may make many factories realizable, but a configured factory additionally embodies the specialization needed for a particular family. The ability to execute or generate any supplied program does not establish that the appropriate family specialization is already present or can be acquired from task evidence.
+
+## Task-local software is not sufficient
+
+An agent may write a script, parser, orchestrator, or evaluator for one task. That artifact can be real production machinery within the episode, but it is not yet Greenfield-style factory machinery merely because it is software written by the agent.
+
+The additional boundary is reusable family scope. The artifact becomes part of factory machinery when it carries production knowledge intended to govern later work across a declared family or admitted variation space. Retention alone is not enough: a stored tool that is never used, or is used only as copied product-local code, has not been shown to participate in the configured factory.
+
+This separates three cases:
+
+| Case | Classification |
+|---|---|
+| The agent writes code that is the requested product | Solution or product work |
+| The agent writes an episode-local program that helps produce the requested product | Task-local production machinery, not yet established as factory machinery |
+| The agent retains a schema, workflow, tool, evaluator, or other asset that governs later production across a declared family | Reusable software-factory machinery |
+
+## The mapping does not fix who develops the factory
+
+Greenfield's accounts primarily assign [factory development](./definitions/factory-development.md) to human factory or product-line developers. The configured factory may then support human solution developers with varying amounts of automation.
+
+An agentic system can occupy either side of that inherited division. It may use an already configured factory to develop family members. It may also participate in constructing or revising the family machinery. The latter is agentic factory development, an additional capability rather than part of the software-factory definition.
+
+Likewise, the mapping does not imply learning. A complete family template can be supplied by people and installed computationally. The resulting agentic arrangement is a software factory even if its production knowledge never changes.
+
+## Scope
+
+- The mapping is functional, not a claim that a modern agent harness is identical to Greenfield's Microsoft IDE architecture.
+- The general substrate may contain fixed components that apply across families.
+- The configured factory can include human activities; actor allocation and autonomy must be declared separately.
+- A family-valued product can itself be another factory, but recursive output does not establish acquisition, learning, reflection, or self-improvement.
+- The product-family boundary must be declared independently; it cannot be inferred post hoc from whatever artifacts the system happened to produce.
+
+---
+
+Relevant Notes:
+
+- [A software factory is family-scoped lifecycle production machinery](./a-software-factory-is-family-scoped-lifecycle-production-machinery.md) — grounds: supplies the imported family, schema, template, configured-environment, and member boundaries
+- [A software factory can produce another factory without learning its specialization](./a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) — contrasts: shows that general construction machinery can realize supplied specialization without acquiring it
+- [The deployed system, not the model alone, is the unit of learning](./the-deployed-system-not-the-model-is-the-unit-of-learning.md) — extends: places the configured model, artifacts, tools, and runtime inside the behavior-producing system boundary

--- a/kb/notes/broad-software-demands-create-pressure-for-agentic-factory-development.md
+++ b/kb/notes/broad-software-demands-create-pressure-for-agentic-factory-development.md
@@ -1,0 +1,91 @@
+---
+description: "Broad software demands make exhaustive predefinition of useful family-specific production machinery practically implausible, motivating agentic factory development without ruling out a fixed universal substrate in principle"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# Broad software demands create pressure for agentic factory development
+
+A sufficiently broad class of software demands creates practical pressure for an agentic system to construct or revise reusable production machinery instead of relying only on family specializations supplied in advance. This is a claim about engineering adequacy and scaling, not an impossibility theorem.
+
+In principle, a fixed universal substrate could interpret every needed program. A large catalog could contain every useful schema, workflow, evaluator, representation, tool, and decomposition. The premise here is weaker: as the covered demands widen, exhaustively anticipating and maintaining all useful family-specific production knowledge becomes increasingly implausible and expensive.
+
+The relevant response is agentic [factory development](./definitions/factory-development.md): the system participates in constructing or revising reusable machinery that later production can use.
+
+## Why breadth exposes missing production knowledge
+
+Different software demands can require different:
+
+- decompositions and aggregation strategies;
+- intermediate representations and schemas;
+- retrieval, context-selection, and memory policies;
+- algorithms and data structures;
+- tests, evaluators, simulators, and acceptance procedures;
+- tools, interfaces, libraries, frameworks, and deployment machinery;
+- recovery, rollback, monitoring, and maintenance processes; and
+- relations among requirements, architecture, code, tests, runtime state, and operational evidence.
+
+These are not all object-level product decisions. When they are retained and reused across a declared product or solution family, they become part of the [software factory](./definitions/software-factory.md) for that family.
+
+A fixed substrate can remain general while the installed specialization changes. Write the configured factory schematically as:
+
+\[
+F_{\mathcal P,t}=\operatorname{configure}(G,K_{\mathcal P,t})
+\]
+
+where \(G\) is general machinery and \(K_{\mathcal P,t}\) is the current family-specific production knowledge. Agentic factory development can update \(K_{\mathcal P,t}\) without requiring every component of \(G\) to be self-modifying.
+
+## Bounded model calls make the pressure visible
+
+The [bounded-context orchestration model](./bounded-context-orchestration-model.md) shows how a larger computation can be organized around bounded LLM calls. Difficult tasks may require decomposition, persistent intermediate state, code execution, map-reduce aggregation, or external verification.
+
+But the right orchestration is not determined by task size alone. It depends on the task's dependency structure, the solver's effective capabilities, what information must survive between calls, which operations need exact execution, and how partial results can be checked and combined.
+
+A generic scheduler can provide recursion or iteration without knowing the useful decomposition for every domain. The family-specific strategy may still need to be constructed. The [scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) therefore supports both a fixed software substrate and the possibility that schemas, invariants, and control strategies become later development targets.
+
+## Configuration, construction, and acquisition must stay separate
+
+Three increasingly strong cases are easy to conflate:
+
+1. **Configuration:** select and bind anticipated options inside already supplied family machinery.
+2. **Construction:** realize a factory or asset from a supplied schema, metamodel, mapping, or complete description.
+3. **Acquisition:** use task or production evidence to determine what reusable production knowledge is required and construct or revise it.
+
+The first two can cover substantial work. Greenfield, Tool Factory, and MDSoFa already establish recursive construction from supplied specialization. The [construction-versus-acquisition note](./a-software-factory-can-produce-another-factory-without-learning-its-specialization.md) marks the remaining boundary.
+
+The practical generality claim concerns the third case. A system does not meet it by hiding a target-indexed catalog of handcrafted factories inside its supposedly general substrate.
+
+## What would support the claim
+
+The pressure claim earns evidence when a fixed supplied repertoire repeatedly encounters demands for which:
+
+- ordinary product configuration cannot express the needed solution process;
+- human experts introduce new schemas, decompositions, tools, evaluators, or workflows;
+- those additions become reusable across later products or episodes; and
+- systems that can construct such machinery from evidence transfer with less new human specialization.
+
+A stronger test declares the task and product-family frames before outcomes are known, withholds target-specific production machinery, and compares a fixed-repertoire condition against one allowed to construct and retain new machinery. The comparison should count human interventions, failed attempts, total compute, and later reuse rather than only successful product outputs.
+
+## What would weaken or defeat it
+
+The claim should narrow where a small fixed substrate and stable general policies cover the declared demands at comparable or lower total cost. It also weakens when generated machinery is mostly disposable glue, when the same few tools suffice across domains, or when constructing new machinery adds more error and maintenance burden than it removes.
+
+A universal fixed substrate is therefore a live counterhypothesis, not a contradiction. The empirical question is how much task- or family-specific production knowledge can be economically absorbed into fixed general machinery and how much must still be acquired or revised as demands change.
+
+## Scope
+
+- The note does not claim that every task needs new software or that every agentic system is a software factory.
+- Broad demand coverage is not itself learning. The system may construct machinery from a complete human-supplied description.
+- Fixed objectives, interfaces, runtimes, model providers, resource controls, and trusted kernels may remain.
+- The relevant burden is recurring human construction of specialization required by the claimed reach, not the mere existence of handcrafted general components.
+- One novel tool does not establish broad extensibility; later reuse and repeated transfer are separate evidence requirements.
+
+---
+
+Relevant Notes:
+
+- [An agentic substrate becomes a software factory through family-specific production machinery](./an-agentic-substrate-becomes-a-software-factory-through-family-specific-production-machinery.md) — grounds: separates fixed general machinery from installed family specialization
+- [Learning inside a fixed decomposition inherits its mistakes](./learning-inside-a-fixed-decomposition-inherits-its-mistakes.md) — grounds: shows why learning confined to supplied production structure may preserve its errors
+- [Orchestration strategies and run-state have opposite persistence economics](./orchestration-strategies-and-run-state-have-opposite-persistence.md) — exemplifies: reusable control strategy may merit promotion while task-specific state remains ephemeral
+- [Machinery persists by warrant, not position, in a reflective loop](./machinery-persists-by-warrant-not-position-in-a-reflective-loop.md) — extends: explains why the pressure does not require universal self-modification

--- a/kb/notes/factory-learning-mechanisms-should-be-compared-on-the-same-causal-job.md
+++ b/kb/notes/factory-learning-mechanisms-should-be-compared-on-the-same-causal-job.md
@@ -1,0 +1,104 @@
+---
+description: "Compares learning mechanisms by how they turn production experience into retained factory changes that affect later production, rather than by representational form or readability"
+type: kb/types/note.md
+traits: [title-as-claim, has-comparison]
+tags: [foundations, learning-theory, self-improving-systems]
+---
+
+# Factory-learning mechanisms should be compared on the same causal job
+
+A fair comparison among factory-learning mechanisms asks how each turns production experience into a retained change to reusable production machinery that affects later production. Comparing natural language with code or weights, or readability with end-to-end optimization, mixes representational form with the causal job being performed.
+
+The shared job is:
+
+```text
+production experience
+  -> allocation of search or update effort
+  -> candidate or direct factory change
+  -> evaluation or other update control
+  -> retention and later behavioral effect
+```
+
+Not every mechanism exposes all of these steps as separate components. A direct optimizer may combine proposal and selection in one update. A trajectory-reuse system may retrieve an earlier procedure without constructing a new artifact. A theory-mediated process may guide search before a candidate exists. The comparison should preserve these architectural differences while asking whether the same downstream transition was achieved.
+
+## Live mechanism families
+
+| Mechanism | Typical retained state | Characteristic strength | Characteristic risk |
+|---|---|---|---|
+| Trial-and-error retention | A tool, workflow, policy, prompt, or configuration associated with observed success | Makes few assumptions about why a change works | Weak transfer and expensive search when feedback is sparse or delayed |
+| Trajectory or episode reuse | Stored traces, summaries, plans, demonstrations, or retrieved procedures | Reuses concrete experience with low abstraction cost | Copies incidental details, can fail under shift, and may not expose which part should be revised |
+| Program search | Symbolic programs, schemas, workflows, evaluators, or tool compositions | Produces executable and testable machinery | Search spaces and evaluators can encode decisive human specialization |
+| Learned construction or selection policy | Parametric or artifact-based policy for choosing or building machinery | Amortizes repeated decisions and can improve with scale | Hidden credit assignment, distribution shift, and limited inspectability |
+| Direct optimization | Weights, adapters, continuous policies, scores, or other directly updated state | Can integrate large amounts of feedback without explicit hand decomposition | Update cost, catastrophic interference, weak localization, and difficulty coordinating heterogeneous artifacts |
+| Theory mediation | Addressable natural-language claims about tasks, solvers, failures, interventions, evidence, and scope | Can coordinate search and revision across several artifact kinds through one interpretable medium | Plausible rationalization, interpretation error, maintenance cost, and dependence on model reading and application |
+| Mixed mechanisms | Different forms and update methods at different layers or timescales | Matches mechanisms to the structure and verifiability of each subproblem | Cross-layer inconsistency and opaque responsibility for failures |
+
+The table is a working comparison, not an exhaustive taxonomy. A concrete system can instantiate several rows at once.
+
+## Comparison dimensions
+
+Mechanisms should be evaluated on at least these dimensions:
+
+- **Evidence use:** What observations, tests, corrections, telemetry, examples, or interactions can affect the update?
+- **Search allocation:** How does the mechanism decide which production machinery to examine or change before decisive evaluation is available?
+- **Reach:** Which schemas, tools, workflows, evaluators, representations, prompts, code, or parametric state can it alter?
+- **Credit assignment:** How does later success or failure bear on earlier factory decisions?
+- **Operative retention:** How does the selected or updated state enter later production, and can it be rolled back?
+- **Transfer:** Does the retained change help a distinct task, product variation, or family without new target-specific human design?
+- **Negative transfer:** How are overgeneralized or harmful lessons detected and revised?
+- **Total cost:** Count model calls, environment interaction, compute, human judgment, artifact maintenance, validation, and recovery.
+- **Warrant:** What independent checks or accepted error bounds support consequential use?
+
+No single dimension settles the comparison. A mechanism can be cheap but narrow, broad but poorly warranted, interpretable but ineffective, or powerful but expensive to update.
+
+## Representation and production method are orthogonal
+
+The same representational form can be produced by different learning mechanisms. A person can write a prompt; an optimizer can search for one; a theory-mediated agent can derive one from an explanation. All three results are natural-language artifacts, but the production methods and evidence paths differ.
+
+Likewise, symbolic software can be handcrafted, generated from a supplied schema, selected through search, learned from trajectories, or revised through theory. Parametric state can encode either general machinery or target-specific specialization. The [Bitter Lesson production-method distinction](./the-bitter-lesson-selects-production-methods-not-representational.md) therefore applies directly: the carrier does not determine whether useful structure was found by a scalable computational method.
+
+## Proposal selection is one architecture, not the universal definition
+
+When a system exposes rejectable candidates, a complete proposal-selection path needs search, evaluation, and operative retention. The [proposal-selection loop](./a-proposal-selection-loop-requires-search-evaluation-and-retention.md) states that requirement.
+
+But some mechanisms update state directly or retrieve previously retained machinery without presenting explicit alternatives. They should be judged by causal controls appropriate to their architecture rather than forced into candidate terminology. The common requirement is that production experience determine a retained factory change used later, as defined by [factory-level continual learning](./a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md).
+
+## Fair experimental contrasts
+
+A useful comparison holds constant, as far as possible:
+
+- model and tool access;
+- task and product-family selection;
+- permitted evidence and interaction;
+- total compute and wall-clock budget;
+- human interventions and supplied specialization;
+- acceptance conditions and later-use horizon; and
+- accounting for failures, abstentions, retries, and recovery.
+
+Information matching is especially important. A theory condition should not receive extra facts hidden in its theory artifact. A trajectory condition should not receive more worked examples. A direct optimizer should not be credited with human-designed target-specific reward shaping that other conditions must infer.
+
+The strongest comparisons intervene on the mechanism while preserving the information available to it. Theory can be withheld, flattened into an information-matched record, or deliberately made wrong. Trajectories can be shuffled or stripped of outcomes. Search policies can be replaced while keeping the candidate language fixed. The experiment identifies only the contrast it actually runs.
+
+## What a result can establish
+
+- Better immediate product output shows task performance, not factory learning.
+- A retained change used later supports the learning path, but not necessarily improvement.
+- Transfer to a distinct admitted product variation supports family-level reuse.
+- Repeated transfer across families with falling target-specific human work supports broader acquisition reach.
+- A mechanism winning in one feedback regime does not establish universal superiority; sparse delayed feedback, dense automated feedback, and safety-critical deployment may favor different mechanisms.
+
+## Scope
+
+- The note compares mechanisms, not complete systems; system architecture and evaluator quality can dominate results.
+- Readability, addressability, exact execution, and parametric compression are properties with costs and benefits, not rankings.
+- Mixed mechanisms are the default serious alternative to any single-method claim.
+- Theory mediation earns support only through comparative causal and outcome evidence, not because the research program is described in theoretical language.
+
+---
+
+Relevant Notes:
+
+- [A software factory learns when production experience changes reusable machinery used later](./a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md) — grounds: supplies the shared causal job
+- [The bitter lesson selects production methods, not representational forms](./the-bitter-lesson-selects-production-methods-not-representational.md) — grounds: separates how useful state is produced from where it is stored
+- [An experiment identifies only the contrast it actually runs](./an-experiment-identifies-only-the-contrast-it-actually-runs.md) — grounds: bounds conclusions from mechanism comparisons
+- [Open-ended improvement allocates search before evaluation](./open-ended-improvement-allocates-search-before-evaluation.md) — extends: identifies search allocation as a central comparison dimension under weak feedback

--- a/kb/notes/task-families-and-product-families-classify-different-things.md
+++ b/kb/notes/task-families-and-product-families-classify-different-things.md
@@ -1,0 +1,69 @@
+---
+description: "Task families group obligations or evaluations; software product families group products through declared commonality, variability, and reusable production scope"
+type: kb/types/note.md
+traits: [title-as-claim, has-comparison]
+tags: [foundations, computational-model, self-improving-systems]
+---
+
+# Task families and product families classify different things
+
+A **task family** groups tasks because they share some relation relevant to solving, learning, or evaluation. A **software product or solution family** groups software products because they share declared commonality and variability that justify reusable family-level production machinery. The two classifications can overlap, but neither implies the other.
+
+The distinction matters because Greenfield's [software-factory](./definitions/software-factory.md) identity depends on a product or solution family. A benchmark task grouping does not become a software-product family merely because one agent or evaluator handles all of its members.
+
+## Different classification questions
+
+| Classification | Primary members | Grouping relation | Why the relation matters |
+|---|---|---|---|
+| Task family | Requests, obligations, episodes, or problem instances | Shared skill, domain, input form, objective, operation, difficulty, evidence regime, or evaluation protocol | Supports comparison, curriculum design, coverage claims, or reuse of solving strategies |
+| Product or solution family | Software systems or solutions | Declared commonality, variability, variants, constraints, architecture, and lifecycle production knowledge | Supports systematic reuse of schemas, assets, processes, tools, tests, and other production machinery |
+
+A task family is often solver-relative. “Tasks requiring map-reduce over intermediate results” can group many domains and products because they stress the same computational strategy. A product family is producer-relative. “Tenant-configurable accounting services on one platform” groups products because a declared factory can reuse production knowledge across their anticipated variation.
+
+## The axes cross in several ways
+
+One product can generate many tasks. A long-lived repository may receive a sequence of bug fixes, feature additions, migrations, performance work, security reviews, and deployment changes. These are distinct software-production tasks or episodes, while the evolving repository may remain one family member.
+
+One task family can range across many product families. “Add audit logging,” “upgrade a dependency,” or “repair a race condition” can be evaluated across unrelated repositories whose product-family machinery differs substantially.
+
+One product family can require many task families. Requirements work, architecture design, code generation, testing, deployment, operation, maintenance, and migration have different task structures even when they contribute to members of the same product family.
+
+A collection can satisfy both classifications. Repeated requests to configure and deploy variants of one declared service family may be both a task family and product-family work. That conjunction must be shown rather than assumed.
+
+## Why the distinction is load-bearing
+
+First, it prevents a post-hoc singleton factory. Solving one task and then declaring its output to be a one-member family does not demonstrate reusable family production knowledge. The family and the variation or reuse relation should be declared before the result is used as evidence for factory capability.
+
+Second, it separates evaluation reach from factory scope. A system may perform well across a broad task family by using different manually supplied factories for each domain. That shows broad task performance, not acquisition of product-family specialization. Conversely, a factory may support a rich product family while being evaluated on only a narrow set of tasks.
+
+Third, it clarifies what is retained. A general task-solving heuristic may transfer across product families without becoming part of any one family's specialization. A family-specific schema or test suite may transfer across members of one product family while being useless elsewhere. Both are reusable, but their reuse scopes differ.
+
+Fourth, it prevents decomposition from being smuggled into the benchmark. If tasks are grouped only after observing which decomposition worked, the grouping can hide failures outside the selected method's reach. Task-family selection and product-family definition should be independently inspectable.
+
+## Mapping between the axes
+
+A study that uses both concepts should declare:
+
+1. the task-family membership or sampling rule;
+2. the product-family commonality and variability being assumed;
+3. which reusable machinery is general across task families, which is family-specific, and which is product-local;
+4. whether evidence comes from repeated work on one product, multiple members of one product family, or products from several families; and
+5. what transfer result would show reuse at the claimed level.
+
+A held-out task can test task-family transfer. A distinct held-out product variant can test reuse of family production machinery. These are complementary controls, not substitutes.
+
+## Scope
+
+- Neither family concept requires a formal mathematical partition; both require an explicit enough membership relation to support the claim being made.
+- Product families can evolve. A later factory revision may widen, narrow, or reorganize the admitted variation, but the change should not be hidden by relabeling products after evaluation.
+- Task families may be defined by empirical similarity, institutional workflow, or benchmark construction. That does not make their relation identical to software-product-line commonality and variability.
+- The distinction classifies scope. It does not by itself establish learning, improvement, or generality.
+
+---
+
+Relevant Notes:
+
+- [Software factory](./definitions/software-factory.md) — grounds: makes a declared product or solution family part of factory identity
+- [Factory development](./definitions/factory-development.md) — extends: changes reusable machinery for a product family rather than merely solving another task
+- [An agentic substrate becomes a software factory through family-specific production machinery](./an-agentic-substrate-becomes-a-software-factory-through-family-specific-production-machinery.md) — extends: uses the product-family boundary when mapping generic agentic machinery to a configured factory
+- [Learning inside a fixed decomposition inherits its mistakes](./learning-inside-a-fixed-decomposition-inherits-its-mistakes.md) — compares: shows why a task grouping should not protect the decomposition used to define it

--- a/kb/notes/theory-mediation-can-coordinate-heterogeneous-factory-development.md
+++ b/kb/notes/theory-mediation-can-coordinate-heterogeneous-factory-development.md
@@ -1,0 +1,128 @@
+---
+description: "Natural-language theory may be a versatile factory-learning mechanism because one LLM-interpretable account can connect tasks, solver limits, failures, evidence, and changes across heterogeneous production machinery"
+type: kb/types/note.md
+traits: [title-as-claim, has-comparison]
+tags: [foundations, learning-theory, self-improving-systems]
+---
+
+# Theory mediation can coordinate heterogeneous factory development
+
+Natural-language theory may be a particularly versatile mechanism for [factory development](./definitions/factory-development.md) because one LLM-interpretable account can connect task structure, relevant solver limitations, observed failures, proposed interventions, scope conditions, and evidence, then guide changes across heterogeneous production machinery.
+
+This is a comparative hypothesis, not a definition of learning and not a claim that theory is necessary. A software factory can learn through trial and error, trajectory reuse, program search, learned policies, direct optimization, or mixtures. The question is whether theory mediation provides useful leverage when a change must coordinate several artifact kinds or when decisive feedback is sparse, delayed, or arrives under a structured shift.
+
+## The coordination problem
+
+A failure in software production may not identify the artifact that should change. The same symptom can arise from:
+
+- a mistaken understanding of the task or product family;
+- a decomposition that drops necessary dependencies;
+- context selection that omits relevant evidence;
+- an intermediate representation that cannot express required distinctions;
+- a tool or algorithm that performs the wrong transformation;
+- an evaluator that rewards a proxy;
+- a workflow that stops before delayed consequences arrive; or
+- conflicting schemas, prompts, tests, and runtime assumptions.
+
+The remedy can therefore span natural-language guidance, symbolic software, schemas, tests, workflows, retrieval policy, and model-facing context. A fixed update operator for one artifact kind may repair the local symptom while leaving the shared explanation inconsistent elsewhere.
+
+A retained theory can instead state a cross-artifact commitment such as:
+
+> The final decision depends on relations among evidence units, so independent summaries are insufficient; extraction may be parallelized, but the representation and aggregation path must preserve cross-unit relations for a later reconciliation pass.
+
+An LLM can interpret that claim into changes to decomposition, intermediate schemas, map-reduce code, prompts, aggregation logic, and tests. The theory is useful only if it actually changes those decisions and remains revisable when later outcomes contradict it.
+
+## What theory can represent in one medium
+
+A factory-relevant theory may include:
+
+- **task or domain claims** — what distinctions, dependencies, invariants, and variations matter;
+- **solver claims** — which operations are reliable, bounded, expensive, or prone to a known failure mode;
+- **production claims** — why a decomposition, workflow, representation, or tool should work;
+- **evaluation claims** — which observations would support or defeat the proposed organization;
+- **scope claims** — where the account applies and where it should not transfer; and
+- **revision claims** — which parts should change when a prediction fails.
+
+The relevant self-knowledge is therefore not a complete theory of the model's internals. It is a task-relevant theory of the relation among the task, the current solver, and interventions that can make the task tractable.
+
+## Theory guides search; it does not replace it
+
+Theory mediation does not require deductively deriving every factory change. The theory can shape a generate-and-verify process by controlling:
+
+- which failure explanations are plausible;
+- which machinery is worth inspecting;
+- which candidate decompositions or tools to try;
+- which experiments are informative;
+- which checks should reject a proposal; and
+- how an observed result should revise the retained account.
+
+Blind or stochastic exploration can remain inside the process. A learned policy can propose candidates. Code can execute exact transformations and tests. The theory-mediated claim is that addressable theory causally changes search, diagnosis, evaluation, recovery, or revision.
+
+The [scheduler–LLM separation](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) gives the complementary implementation principle: semantic interpretation can remain model-mediated while exact progression, bookkeeping, and stabilized invariants move into software. Theory can guide which invariants should be codified without requiring the LLM to execute them unreliably on every run.
+
+## Why versatility is plausible
+
+Theory mediation has four potential advantages for heterogeneous factory learning.
+
+### Cross-artifact reach
+
+The same explanation can guide coordinated edits to prompts, schemas, workflows, tests, code, tools, and documentation. This can reduce the need for one separately trained update policy per artifact class.
+
+### Selective revision
+
+Addressable claims can be revised or rescaled without discarding the whole retained state. A failed prediction may defeat one scope condition or mechanism claim while preserving unrelated parts of the factory theory.
+
+### Delayed credit assignment
+
+A theory records why an earlier production decision was made and what consequences it predicted. When a later requirement exposes damage, the retained joins can connect the consequence to the earlier decomposition or representation choice.
+
+### Transfer under structured shifts
+
+A mechanism-level claim may apply to a new product variation even when surface details differ. This could improve sample efficiency relative to replaying only concrete trajectories, provided the theory captures real structure rather than a plausible story.
+
+These are hypotheses. Natural language also introduces ambiguity, retrieval cost, contradiction, interpretation error, and rationalization. A theory can coordinate several artifacts into the same mistake.
+
+## Comparative predictions
+
+Against information- and budget-matched alternatives, theory mediation should earn support when it:
+
+1. transfers one retained explanation into several causally coherent machinery changes;
+2. predicts where a decomposition, representation, evaluator, or tool will fail before exhaustive trial;
+3. improves recovery after delayed feedback by identifying the earlier commitment that should change;
+4. supports targeted rescoping instead of copying or discarding an entire trajectory;
+5. reduces new human specialization when a related but unanticipated family variation appears; or
+6. leaves an intervention-sensitive trace: withholding, replacing, or corrupting the theory changes consequential factory-development choices.
+
+It should narrow or lose when:
+
+- the retained theory is ignored or reconstructed post hoc;
+- direct search or optimization reaches better machinery at comparable total cost;
+- trajectory reuse transfers as well with less maintenance;
+- theories become self-confirming because their evaluators share the same assumptions;
+- cross-artifact coordination increases correlated error;
+- human judgment required to maintain theory grows with the system; or
+- each new domain still requires people to supply the decisive decomposition and evaluator.
+
+## Theory content and factory machinery are different roles
+
+A natural-language artifact can be consumed as evidence, advice, an instruction, a constraint, or a generator input. Merely storing a theory beside the factory does not make production theory-mediated. The causal path must show how the theory changes model calls or executable machinery and how later evidence revises the same retained surface.
+
+Conversely, theory need not remain in natural language forever. Stable claims can be codified into validators, schemas, tools, or workflows. A brittle symbolic rule can be relaxed back into an interpretable hypothesis. Theory mediation describes the learning relation, not a requirement that every useful result remain prose.
+
+## Scope
+
+- The claim concerns versatility across factory-development decisions, not universal superiority on every task.
+- Natural-language theory is one representational surface inside the deployed system; model weights and symbolic machinery remain essential.
+- A theory of the task alone may be insufficient when decomposition depends on solver limits. A theory of the solver alone may be insufficient when task dependencies determine what must be preserved.
+- Theory mediation can coexist with fixed general machinery and with non-theoretical search at lower levels.
+- Reflection is not required for every theory-mediated factory change. It is claimed only when a causally connected representation of selected aspects of the same system participates in operation or revision.
+
+---
+
+Relevant Notes:
+
+- [Factory-learning mechanisms should be compared on the same causal job](./factory-learning-mechanisms-should-be-compared-on-the-same-causal-job.md) — grounds: supplies the neutral comparison frame and failure conditions
+- [Program theory sustains search under delayed feedback](./program-theory-sustains-search-under-delayed-feedback.md) — grounds: explains how retained rationale connects later consequences to earlier choices
+- [Theory-mediated self-improvement needs interpretation and retention](./theory-mediated-self-improvement-needs-interpretation-and-retention.md) — grounds: supplies the causal mediation and retained-revision requirements
+- [Theory-mediated learning may improve sample efficiency under shifts](./theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md) — extends: states the structured-transfer conjecture
+- [Natural-language project state specializes search heuristics](./natural-language-project-state-specializes-search-heuristics.md) — mechanism: explains one way explicit theory can alter an LLM's proposal distribution


### PR DESCRIPTION
## Intent

Add the durable claims that connect the existing agentic computational model and the imported Greenfield ontology to factory-level continual learning, then position theory mediation against credible alternatives.

## New notes

- an agentic substrate becomes a software factory only through declared family-specific reusable production machinery;
- task families and product families classify different things;
- broad software demands create practical pressure for agentic factory development without ruling out a fixed universal substrate;
- a factory learns when production experience changes reusable machinery used later;
- factory-learning mechanisms should be compared on the same causal job;
- theory mediation may coordinate heterogeneous factory development and is stated as a defeasible comparative hypothesis.

## Dependency

This draft is stacked on PR 148. Its base is the ontology branch, so the diff contains only the six bridge notes. After PR 148 merges, retarget this PR to `main` before merging.