### PR TITLE
Frame factory learning as producing a theory-bearing factory

### DIFF
--- a/kb/articles/a-research-program-for-learning-software-factories.md
+++ b/kb/articles/a-research-program-for-learning-software-factories.md
@@ -184,11 +184,12 @@ project-specific theory: an understanding of how the program maps onto the
 activity it supports, why it is organized as it is, and how new demands relate
 to that organization.
 
-Naur's compiler case has the transition above. The original group retained the
-theory built while producing compiler A and could use it in later modification,
-while another group did not acquire the same capacity from source,
-documentation, discussion, and advice. The computational analogue is a new
-factory that retains and can apply the theory built during earlier production.
+Naur's compiler case has the transition above. Group A retained the theory built
+while producing the compiler and could use it to evaluate and propose later
+modifications. Group B received the source, documentation, design discussion,
+and advice but did not acquire the same capacity. The computational analogue is
+a new factory that retains and can apply the theory built during earlier
+production.
 
 For this target, the program adopts Naur's functional constraint: some
 project-specific state or capacity must perform those mapping, justification,

--- a/kb/articles/a-research-program-for-learning-software-factories.md
+++ b/kb/articles/a-research-program-for-learning-software-factories.md
@@ -42,7 +42,7 @@ source_notes:
 
 > **Draft.** Comments and counterexamples are welcome through the repository's issue tracker.
 
-> **TL;DR.** An agentic system is more than an LLM call: bounded model calls operate inside persistent software machinery. For software production, configuring that machinery with reusable knowledge for a declared product family yields a software factory. When production experience changes reusable factory machinery and later work depends on the change, the factory learns. Several mechanisms could drive that learning. Open-ended coherent modification is harder: following Naur, it requires some form of project theory. This program tests whether fallible natural-language theory gives an LLM-based system a useful, revisable way to coordinate changes across prompts, schemas, workflows, tools, evaluators, and code.
+> **TL;DR.** An agentic system is more than an LLM call: bounded model calls operate inside persistent software machinery. For software production, configuring that machinery with reusable knowledge for a declared product family yields a software factory. When producing one product leaves a new factory with retained state that changes later production, the factory learns. Several mechanisms could drive that learning. Open-ended coherent modification is harder: following Naur, it requires some form of project theory. This program tests whether fallible natural-language theory gives an LLM-based system a useful, revisable way to coordinate changes across prompts, schemas, workflows, tools, evaluators, and code.
 
 ## From agentic systems to learning software factories
 
@@ -127,23 +127,30 @@ target. [Constructing a factory from supplied family-specific production
 knowledge is not acquiring that
 knowledge](../notes/a-software-factory-can-produce-another-factory-without-acquiring-its-family-specific-production-knowledge.md).
 
-### Continual learning changes later production
+### Factory learning produces a new factory
 
 Software production and factory development do not by themselves imply
-learning. The minimal factory-level learning path is:
+learning. In a complete factory-learning episode, producing one product changes
+the factory available for later production:
 
 ```text
-production under current factory machinery
-  -> experience bearing on that machinery
-  -> system-determined change to reusable family machinery
-  -> retention
-  -> changed later production
+production of product A under factory F
+  -> experience bearing on reusable machinery
+  -> system-determined retention in new factory F'
+  -> production of later product B under F'
+  -> retained state changes how B is produced
 ```
 
-Experience without a reusable change is feedback. Repairing only the current
+`F'` is the new factory produced by the episode; it may remain scoped to the
+same declared product family. Its retained state may include project theory
+together with revised prompts, schemas, workflows, tools, evaluators, tests, or
+code.
+
+Experience without a retained change is feedback. Repairing only the current
 product is solution development. A generated candidate that is discarded does
-not persist. Stored machinery that later production never consumes has no
-demonstrated learning effect.
+not persist. Producing a factory from production knowledge supplied
+independently of the experience is construction, not learning. Retained state
+that later production never consumes has no demonstrated learning effect.
 
 When the whole path is present, [the software factory
 learns](../notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md)
@@ -177,11 +184,27 @@ project-specific theory: an understanding of how the program maps onto the
 activity it supports, why it is organized as it is, and how new demands relate
 to that organization.
 
+Naur's compiler case has the transition above. The original group retained the
+theory built while producing compiler A and could use it in later modification,
+while another group did not acquire the same capacity from source,
+documentation, discussion, and advice. The computational analogue is a new
+factory that retains and can apply the theory built during earlier production.
+
 For this target, the program adopts Naur's functional constraint: some
 project-specific state or capacity must perform those mapping, justification,
 and integration roles. A process that merely retains successful changes may
 learn in the minimal sense while still failing coherent modification when a
 later demand exposes a conflict that its local tests did not represent.
+
+Retaining a theory artifact is not yet holding the theory. In the current
+agentic realization, it must be activated by retrieval into a call-specific
+context, interpreted with the model's learned competence, and causally change
+search or modification; surrounding software must retain the consequences and
+reactivate the revised state later. This [interpretation, retention, and
+continuation
+path](../notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md)
+is the theory-bearing machinery; a theory merely stored or read without
+changing operation is inert.
 
 The necessity claim is about a function, not a carrier. Program theory may be
 distributed across model weights, retained artifacts, tools, and participants.
@@ -326,10 +349,10 @@ The **programming-agent testbed** will place a persistent, fallible theory insid
 an agentic software-production system and give it a sequence of modifications
 whose later demands can expose earlier mistakes. It directly tests whether
 theory changes coherent modification and factory-development choices. A run
-supports a factory-learning claim only if experience changes reusable family
-machinery that later production consumes; otherwise it tests theory-mediated
-solution modification. Matched runs will vary the theory while holding
-specified starting components fixed.
+supports a factory-learning claim only if producing one product leaves a new
+factory with retained state that changes later production; otherwise it tests
+theory-mediated solution modification. Matched runs will vary the theory while
+holding specified starting components fixed.
 
 ## What counts as theory-mediated learning
 
@@ -430,9 +453,9 @@ to expose mistakes introduced by earlier modifications.
 The test asks whether theory changes search and recovery, whether consequences
 revise the retained theory and later work, and whether this improves coherent
 modification at comparable total cost. A factory-learning claim additionally
-requires changed reusable machinery to affect later production; otherwise the
-result concerns theory-mediated solution modification. [Any conclusion is
-limited to the contrasts actually
+requires the first production episode to leave a new factory whose retained
+state affects later production; otherwise the result concerns theory-mediated
+solution modification. [Any conclusion is limited to the contrasts actually
 run](../notes/an-experiment-identifies-only-the-contrast-it-actually-runs.md).
 
 ### Longitudinal Commonplace study

--- a/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
+++ b/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
@@ -7,14 +7,14 @@ tags: [foundations, learning-theory, self-improving-systems]
 
 # A software factory learns when production experience changes reusable machinery used later
 
-A [software factory](./definitions/software-factory.md) undergoes **factory-level continual learning** when experience from producing one product causally determines retained state in a new factory and later production under that factory depends on the retained state.
+A [software factory](./definitions/software-factory.md) undergoes **factory-level continual learning** when experience from producing one product causally determines a retained change to the reusable family-level production machinery of a new factory and later production under that factory depends on the change.
 
 The minimal path is:
 
 ```text
 production of product A under factory F
   -> experience bearing on reusable machinery
-  -> retained change in new factory F'
+  -> retained change to reusable machinery in new factory F'
   -> later production under F' depends on the change
 ```
 

--- a/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
+++ b/kb/notes/a-software-factory-learns-when-production-experience-changes-reusable-machinery-used-later.md
@@ -7,23 +7,25 @@ tags: [foundations, learning-theory, self-improving-systems]
 
 # A software factory learns when production experience changes reusable machinery used later
 
-A [software factory](./definitions/software-factory.md) undergoes **factory-level continual learning** when experience from production causally determines a retained change to its reusable family-level production machinery and later production depends on that change.
+A [software factory](./definitions/software-factory.md) undergoes **factory-level continual learning** when experience from producing one product causally determines retained state in a new factory and later production under that factory depends on the retained state.
 
 The minimal path is:
 
 ```text
-production under current factory machinery
-  -> experience bearing on that machinery
-  -> change to reusable family-level production machinery
-  -> retention
-  -> changed later production
+production of product A under factory F
+  -> experience bearing on reusable machinery
+  -> retained change in new factory F'
+  -> later production under F' depends on the change
 ```
+
+`F'` is the new factory produced by the learning episode. It may be a revised version of the same family-scoped factory; it need not define a new product family.
 
 Each link excludes a nearby but weaker event.
 
 - Experience without a factory change is observation or feedback.
 - Product repair without a reusable change is solution development.
 - A generated but rejected or discarded asset is a candidate, not retained learning.
+- A factory produced from knowledge supplied independently of the experience is construction, not learning.
 - Stored machinery that later production does not consume has no demonstrated behavioral effect.
 - A later process that differs only because the task differs does not show dependence on earlier experience.
 
@@ -52,6 +54,8 @@ The permitted evidence and interaction protocol should therefore be declared sep
 ## Retention means later behavioral dependence
 
 Retention is stronger than storage. The changed machinery must enter a path through which it can affect later production. Depending on the factory, this may mean that a revised schema is loaded, a workflow is selected by default, a validator gates later changes, a tool becomes available, or a natural-language rule is retrieved into later model calls.
+
+For retained theory, this requires activation rather than storage alone: the theory must be selected into a call-specific context, interpreted, and change a later operation. [Theory-mediated self-improvement needs interpretation, retention, and independent read-back](./theory-mediated-self-improvement-needs-interpretation-and-retention.md) separates these functions.
 
 Permanent installation is not required. A change can be operative for a declared horizon and later be rolled back. What matters is that later production actually depended on it during the interval for which learning is claimed.
 
@@ -90,8 +94,9 @@ A persuasive record should identify:
 2. the production experience that bore on it;
 3. the update decision and the declared learner boundary;
 4. the retained change;
-5. the later production path that consumed it; and
-6. the behavioral difference attributable to the retained change.
+5. the new factory containing that change;
+6. the later production path that consumed it; and
+7. the behavioral difference attributable to the retained change.
 
 Withholding, reverting, or replacing the change strengthens causal attribution. A mere chronology—experience occurred, a file changed, later work improved—does not establish that the same learning path connects the events.
 


### PR DESCRIPTION
## Summary

- frame the complete learning episode as producing a new factory whose retained state changes later production
- use Naur's compiler case to connect project theory built during production with the factory available for subsequent work
- distinguish a stored theory artifact from theory holding through context activation, interpretation, operative use, retention, and later reactivation
- align the canonical factory-learning note and the programming-agent test criteria

This does not introduce a new formal successor-factory type: `F'` may be a revised factory for the same declared product family.