### PR TITLE
Clarify operative succession and theory acquisition

### DIFF
--- a/kb/articles/a-research-program-for-learning-software-factories.md
+++ b/kb/articles/a-research-program-for-learning-software-factories.md
@@ -1,5 +1,5 @@
 ---
-description: "Research program on whether a software factory configured to produce factories can directly build a better successor by acquiring, holding, and revising project theory"
+description: "Research program on whether a software factory configured to produce factories can construct and adopt a better successor by acquiring, holding, and revising project theory"
 type: kb/articles/types/article.md
 status: draft
 byline: Zbigniew Lukasiak
@@ -8,6 +8,7 @@ source_notes:
   - kb/notes/factory-construction-does-not-establish-knowledge-acquisition.md
   - kb/notes/theory-mediation-can-coordinate-heterogeneous-factory-development.md
   - kb/notes/program-theory-sustains-search-under-delayed-feedback.md
+  - kb/notes/project-theory-relates-new-demands-to-existing-organization.md
   - kb/notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md
   - kb/notes/theory-mediated-self-improvement-needs-interpretation-and-retention.md
   - kb/notes/knowledge-storage-does-not-imply-contextual-activation.md
@@ -23,7 +24,7 @@ source_notes:
 
 > **Draft.** Comments and counterexamples are welcome through the repository's issue tracker.
 
-> **TL;DR.** If a software factory can build a better software factory, improvement can happen through changes to software-production machinery without training new models. This program tests whether LLM-based factories can do this by acquiring, holding, using, and revising project theories.
+> **TL;DR.** If a software factory can construct and adopt a better successor, improvement can happen through changes to software-production machinery without training new models. This program tests whether LLM-based factories can do this by acquiring, holding, using, and revising project theories.
 
 ## Better software factories
 
@@ -36,14 +37,15 @@ The research target begins with a factory of this kind and gives it an explicit 
 ```text
 factory F configured to produce factories
   -> construct candidate successor F'
-  -> evaluate F' against the declared objective and prior scope
-  -> revise F'
-  -> accept F' only if it is better
+  -> evaluate F' under a fixed declared comparison
+  -> revise F' from the evaluation
+  -> adopt F' only if the evidence supports improvement
+  -> use F' in later production and factory development
 ```
 
-The accepted successor is the evidence of improvement; intermediate revisions are part of its construction.
+Comparative evaluation provides the evidence of improvement. Adoption and later use make F' the operative successor; intermediate revisions are part of its construction.
 
-A successor is better if it is at least as capable as its predecessor on the declared prior scope—including the ability to produce and improve further factories—and strictly better on at least one relevant dimension of software production. This preserves the capacity for further improvement rather than trading it away for a one-off gain.
+Under the declared comparison, F' must meet non-regression thresholds on the predecessor's prior scope—including an operative path for producing and improving further factories—and exceed a specified target on at least one relevant dimension of software production. This prevents a one-off gain that consumes the capacity for further improvement.
 
 The comparison is between [deployed systems rather than only model weights](../notes/the-deployed-system-not-the-model-is-the-unit-of-learning.md). The successor may improve through changes to any operative part of its production machinery.
 
@@ -54,6 +56,8 @@ The hard part is constructing a successor that changes software and reusable pro
 Peter Naur's [1985 essay *Programming as Theory Building*](../sources/programming-as-theory-building.ingest.md) argues that programmers do this by building and holding a project-specific theory: an understanding of how the program maps onto the activity it supports, why it is organized as it is, and how new demands relate to that organization.
 
 Naur's compiler example makes the last capacity especially important. The original group recognized that existing compiler facilities applied to novel modification requests. A later group, despite receiving the program and extensive documentation, proposed locally plausible additions that bypassed those facilities. Access to information was not enough; the relevant connection had to be recognized when the new demand appeared.
+
+The program treats this project-theory requirement as a functional hypothesis to be challenged experimentally, not as a necessity result established by Naur's cases.
 
 This gives a useful distinction. A **retained theory** persists in a recoverable form. A **held theory** is a capability of the theory-bearing system: it recognizes when retained project theory is relevant to a novel demand and brings it to bear without the task author naming the project-specific connection. Modern learned interpreters make Naur's formerly human-only bearer question [empirically open](../notes/naur-equates-machine-execution-with-formulated-criteria.md).
 
@@ -71,7 +75,9 @@ Such a theory can guide generate-and-verify, program search, and learned policie
 
 ## How to test the program
 
-The first experiment isolates Naurian theory-holding in ordinary software projects. Each project should contain a non-obvious reusable design idea, a novel requirement that can be met either by extending that idea or by adding a local special case, and a later demand that exposes whether the earlier modification preserved the program's organization.
+The first experiment isolates Naurian theory-holding in ordinary software projects. Each project should contain a non-obvious reusable design idea, a novel requirement that can be met either by extending that idea or by adding a local special case, and a later demand that exposes whether the earlier modification preserved the program's [existing organization](../notes/project-theory-relates-new-demands-to-existing-organization.md).
+
+The initial benchmark supplies the project theory to isolate holding and activation. A later acquisition condition starts without it and requires the system to construct and revise project theory from permitted project and production evidence.
 
 The diagnostic path is:
 
@@ -86,10 +92,10 @@ retained theory
 
 A direct probe tests whether the relevant theory is recoverable. An ordinary modification demand tests whether the system recognizes its relevance without a project-specific cue. A mechanism-specific hint then distinguishes failure to recognize relevance from failure to apply the theory. Withholding the theory or replacing it with a plausible but wrong alternative tests whether its content causally changes the modification rather than merely appearing in an explanation.
 
-A later experiment gives a factory the explicit task of building a successor factory. Candidate successors are evaluated against the predecessor's prior scope, the target improvement, and their ability to repeat the factory-development process. Evaluation must guide revision of the candidate. Success is measured by the successor factory itself: it must be better under the declared comparison. Holding model weights fixed isolates the proposed non-weight route.
+A later experiment gives a factory the explicit task of building a successor factory. Candidate successors are evaluated under the fixed comparison against the predecessor's prior scope, the target improvement, and their ability to repeat the factory-development process. Evaluation must guide revision of the candidate; an accepted candidate must then be adopted and used in later production and factory development. Holding model weights fixed isolates the proposed non-weight route.
 
 The program uses two complementary testbeds. **Commonplace** supplies a live, long-horizon human–LLM process for studying theory-holding and revision; the [recorded revision episode](../notes/evidence/commonplace-revision-used-theory-guided-computational-search.md) illustrates part of the mechanism but is not a controlled better-factory result. A controlled software-project testbed can run the interventions that Commonplace cannot. Current Commonplace evidence is human-inclusive, so progress also means reducing how often the operator must name the relevant theory, choose the decisive branch, or supply another task-specific learning decision.
 
 The theory-mediated approach loses support if changing or withholding project theory does not change construction decisions, if another learning mechanism performs better at comparable total cost, or if each new area still requires substantial human-built specialization. The bootstrap fits the Bitter Lesson only if it can [outgrow recurring human-supplied specialization](../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md).
 
-A successful transition would establish a bounded result: a software factory configured to produce factories can hold project theory strongly enough to construct, evaluate, and revise a successor that is better than itself without training a new model. Indefinite compounding and computational closure would remain open.
+A successful transition would establish a bounded result: a software factory configured to produce factories can acquire and hold project theory strongly enough to construct, revise, and adopt a successor that passes the declared better-than comparison and becomes operative, without training a new model. Indefinite compounding and computational closure would remain open.


### PR DESCRIPTION
This keeps the article's current spine and makes only the minimum corrections needed to complete the experimental claim.

- distinguish comparative evidence from adoption and later operative use
- define the better-than result under a fixed declared comparison with prior-scope non-regression
- separate the supplied-theory holding benchmark from a later acquisition condition
- state that the Naurian project-theory requirement is an experimental functional hypothesis
- connect the modification benchmark to the existing-organization note

The PR changes only the program article.