### PR TITLE
Separate the reachability witness from the explicit-theory mechanism test

### DIFF
--- a/kb/articles/nearest-existing-constructions-to-a-reachability-witness.md
+++ b/kb/articles/nearest-existing-constructions-to-a-reachability-witness.md
@@ -1,10 +1,12 @@
 ---
-description: "Comparison of reviewed self-improving systems against the reachability conjecture's four witness obligations: six endpoint questions, one table of criterion results, evidence bases and decisive shortfalls, and seven witness-test conditions"
+description: "Comparison of reviewed self-improving systems against the reachability conjecture's carrier-neutral obligations, with a separate stronger protocol for explicit retained theory"
 type: kb/articles/types/article.md
 status: draft
 byline: Zbigniew Lukasiak
 source_notes:
+  - kb/notes/definitions/representational-form.md
   - kb/notes/definitions/software-house.md
+  - kb/notes/program-theory-sustains-search-under-delayed-feedback.md
   - kb/sources/darwin-godel-machine-open-ended-evolution-self-improving-agents.ingest.md
   - kb/sources/fluent-self-improving-software-factory-2081823472016335059.ingest.md
   - kb/sources/harness-continual-learning-adaptation-beyond-model-parameters.ingest.md
@@ -31,14 +33,15 @@ source_notes:
 The reachability conjecture holds that an automated [software
 house](../notes/definitions/software-house.md), one that keeps developing
 software for its users across demands nobody listed in advance, can be built
-with the LLMs available in 2026 by holding the model fixed and training the
-software and notes around it. It states four obligations that one constructive
-witness must eventually discharge. This article does not argue for the
-conjecture. It compares the systems reviewed for this program against those
-obligations, so that a researcher with a system of their own can find the
-nearest row and read what would still be missing. Only the rows resting on
-inspected code are placements of an implementation; the rest are comparisons of
-designs as their sources describe them.
+with the LLMs available in 2026 while its distributed-parametric internal state
+stays fixed and its localized natural-language and symbolic state learns. It
+states four carrier-neutral obligations that one constructive witness must
+eventually discharge. This article does not argue for the conjecture. It
+compares the systems reviewed for this program against those obligations, so
+that a researcher with a system of their own can find the nearest row and read
+what would still be missing. Only the rows resting on inspected code are
+placements of an implementation; the rest are comparisons of designs as their
+sources describe them.
 
 The table below runs two separate vocabularies, and neither upgrades the other.
 The six criterion columns say what the reviewed record presents. **Meets stated
@@ -68,15 +71,17 @@ checkable than the obligations:
 
 1. **House.** Does the system keep changing software for external users,
    across demands that are not a fixed benchmark list?
-2. **Fixed model.** Can the documented learning happen without changing
-   foundation-model weights, and is that condition actually held or pinned?
+2. **Fixed parametric state.** Can the documented learning happen without
+   changing foundation-model weights or other distributed-parametric internal
+   state, and are those components actually held or pinned?
 3. **Software learning.** Does experience cause a retained executable or
    codified change that affects later production?
 4. **Note learning.** Does experience cause a retained natural-language change
    that is read back into later production?
-5. **Program theory.** Is rationale-bearing project understanding acquired and
-   applied, rather than supplied, logged, or paraphrased, and is an inadequate
-   rationale later replaced from consequences?
+5. **Program theory.** Is project-specific understanding acquired and applied,
+   rather than supplied, logged, or paraphrased, and is inadequate
+   understanding later replaced from consequences, whether it is retained as
+   explicit theory or reconstructed from records?
 6. **Continuation.** Is the loop sustained with no person in an internal
    production, theory-holding, generalization, selection, or admission role?
 
@@ -85,52 +90,51 @@ checkable than the obligations:
 The obligations describe a progression. The questions decompose properties,
 and one property can serve more than one obligation.
 
-**Holding and application** starts with an adequate rationale already present
-and asks whether the system retains and applies it. **Program theory** asks
-that directly. Its witness conditions below are the later-load half of
-condition 3, then conditions 4 and 7: load the rationale at the decision where
-it matters, preserve coherence when a locally valid change conflicts with it,
-and show causal use on untouched changes and under perturbation.
+**Holding and application** asks whether the system realizes a program-theory
+function across novel changes. **Program theory** asks that directly. The broad
+witness conditions below require an implication not stated verbatim, causal use
+of the relevant retained state or consumption path, and a modification path
+that changes under withholding or replacement.
 
-**Initial acquisition** needs **Program theory**, **Software learning**, and
-**Note learning** together, because it asks whether the system built an
-explanation it was not given and changed both legible forms accordingly. Its
-conditions are 2, the writing and first-read-back portions of 3, and 7.
-**Successor acquisition** needs the same three questions, asked of a rationale
-that later evidence made false; its conditions are 5, 6, and 7. **Automated
-continuation** is bounded by **House**, **Fixed model**, and **Continuation**,
-and it requires holding, acquisition, and both learning questions to keep
-working across that boundary; its conditions are 1 plus repeated coverage of 3
-through 7.
+**Initial acquisition** needs **Program theory** plus an operative retained
+change in at least one localized form: the system must acquire the
+project-specific understanding rather than receive it from a person, and that
+acquisition must alter later production. **Successor acquisition** asks the same
+of understanding that later evidence makes inadequate. A complete witness must
+eventually demonstrate both **Software learning** and **Note learning** across
+its sequence, but one acquisition episode need not change both forms.
+**Automated continuation** is bounded by **House**, **Fixed parametric state**,
+and **Continuation**, and it requires the holding and acquisition capacities to
+keep working across that boundary.
 
-One warning governs every use of the table. **House** and **Fixed model** are
-cross-cutting controls on a whole witness, not acquisition stages.
-**Software learning** and **Note learning** report which retained forms
-changed, and neither alone establishes **Program theory**. A partial cell is
-therefore not partial completion of an obligation. Storing, retrieving, or
-paraphrasing a rationale does not show that it governed a later decision; a
-software or note update does not by itself show that an adequate theory was
+One warning governs every use of the table. **House** and **Fixed parametric
+state** are cross-cutting controls on a whole witness, not acquisition stages.
+**Software learning** and **Note learning** report which retained forms changed,
+and neither alone establishes **Program theory**. A partial cell is therefore
+not partial completion of an obligation. Storing, retrieving, or paraphrasing a
+rationale does not show that it governed a later decision; a software or note
+update does not by itself show that adequate project understanding was
 acquired; a reject-capable gate does not show that the admitted successor was
 adequate; and scheduling or restart does not show continued software-house
 operation.
 
 ## Comparison table
 
-| Construction | House | Fixed model | Software learning | Note learning | Program theory | Continuation | Evidence basis | Decisive shortfall |
+| Construction | House | Fixed parametric state | Software learning | Note learning | Program theory | Continuation | Evidence basis | Decisive shortfall |
 |---|---|---|---|---|---|---|---|---|
-| Fluent | Meets stated scope | Not demonstrated; model lineage not pinned | Meets stated scope; human-inclusive | Meets stated scope; human-inclusive | Partial; rationale is supplied, while acquisition and faithful reuse are not demonstrated | Human-dependent | Product documentation and practitioner report; implementation and outcomes not independently inspected | Humans confirm behaviour, technical approach, and unresolved decisions; theory acquisition is not tested |
+| Fluent | Meets stated scope | Not demonstrated; model lineage and auxiliary parametric state not pinned | Meets stated scope; human-inclusive | Meets stated scope; human-inclusive | Partial; rationale is supplied, while acquisition and faithful reuse are not demonstrated | Human-dependent | Product documentation and practitioner report; implementation and outcomes not independently inspected | Humans confirm behaviour, technical approach, and unresolved decisions; theory acquisition is not tested |
 | Wheelhouse | Not demonstrated | Not demonstrated | Partial; human-inclusive | Partial; human-inclusive | Not demonstrated | Human-dependent | Practitioner report; implementation and outcomes not independently inspected | Human rulings and verdicts produce the doctrine; the consolidating agent's theory-holding role is only a hypothesis |
 | Ona Memo factory | Partial; bounded trial | Not demonstrated | Partial; human-inclusive | Partial; human-inclusive | Not demonstrated | Human-dependent | Product report; implementation and outcomes not independently inspected | Humans built the harness, specified taste and intent, and retained product direction |
-| OpenAI agent-first product | Meets stated scope | Not demonstrated; model lineage not pinned | Partial; human-inclusive | Partial; human-inclusive | Partial; supplied rationale, acquisition not tested | Human-dependent | Practitioner report; no pinned model lineage or independent comparative evaluation | Humans made the repository legible and turned failures into tools, rules, and checks |
+| OpenAI agent-first product | Meets stated scope | Not demonstrated; model lineage and auxiliary parametric state not pinned | Partial; human-inclusive | Partial; human-inclusive | Partial; supplied rationale, acquisition not tested | Human-dependent | Practitioner report; no pinned model lineage or independent comparative evaluation | Humans made the repository legible and turned failures into tools, rules, and checks |
 | Warp skill improver | Not in scope | Not demonstrated | Not in scope | Partial; human-inclusive | Not in scope | Human-dependent | Practitioner report; linked demonstration not independently inspected | Human feedback supplies the evidence and human review admits every skill update |
 | Darwin Gödel Machine | Not in scope | Meets stated scope for the evolving agents; a separate fixed diagnostician sits outside them | Meets stated scope | Not in scope | Not in scope | Meets stated scope; bounded benchmark loop | Paper-reported mechanism and outcomes; implementation not independently inspected | Admission is compile-and-edit viability, the benchmark score only weights parent sampling, and no rationale is retained |
 | Huxley-Gödel Machine | Not in scope | Meets stated scope | Meets stated scope | Not in scope | Not in scope | Meets stated scope; bounded benchmark loop | Paper-reported mechanism and outcomes; implementation not independently inspected | Its contribution is a lineage-level parent-selection signal; benchmark-style scoring is an explicit assumption and no rationale is retained |
-| HyperAgents | Not in scope | Partial; no weight-update path in the reviewed commit, but no pinned model lineage | Meets stated scope | Not demonstrated | Not in scope | Meets stated scope; bounded generation loop | Code-inspected mechanism at a pinned commit; no run or outcome reproduced | Replayed patches change later behaviour but carry no reason, and no test isolates a replayed patch's causal effect |
-| Autogenesis | Not in scope | Partial; inspected update surface excludes weight change | Partial | Partial | Not in scope | Partial | Code-inspected mutation paths; outcomes paper-reported and not reproduced | Benchmarks and a weak semantic gate; the public implementations are transitional or incomplete |
+| HyperAgents | Not in scope | Partial; no parametric-update path in the reviewed commit, but model lineage is not pinned | Meets stated scope | Not demonstrated | Not in scope | Meets stated scope; bounded generation loop | Code-inspected mechanism at a pinned commit; no run or outcome reproduced | Replayed patches change later behaviour but carry no reason, and no test isolates a replayed patch's causal effect |
+| Autogenesis | Not in scope | Partial; the inspected mutation surface excludes parametric updates, but model lineage is not pinned | Partial | Partial | Not in scope | Partial | Code-inspected mutation paths; outcomes paper-reported and not reproduced | Benchmarks and a weak semantic gate; the public implementations are transitional or incomplete |
 | Exo harness | Not in scope | Not demonstrated; no learning process reviewed | Not demonstrated; the broad self-edit path is distinct from learning | Not demonstrated; the deliberate authoring path is distinct from learning | Not in scope | Partial; scheduling and restart paths, no automatic improvement | Code-inspected mechanism; no live instance run | It rewrites a personal-agent executor, not a user product, and build and test results do not judge program theory |
 | Prime Agent | Not demonstrated | Meets stated scope | Partial | Meets stated scope | Not in scope | Meets stated scope; bounded goals | Code-inspected mechanism; paper-reported cases and outcomes | The paper reports direct adoption of persistent refinement and a retained specification exploit; it does not test product theory |
-| Memento-Skills | Not in scope | Meets stated scope for the foundation LLM; the router is trained | Meets stated scope | Meets stated scope | Not in scope | Meets stated scope; bounded task loop | Paper-reported mechanism and outcomes; implementation not independently inspected | Mixed-form skills learn under answer oracles, not under delayed software-maintenance consequences |
-| Recuris | Not in scope | Meets stated scope | Partial | Meets stated scope | Not in scope | Meets stated scope; fixed gate and benchmark loop | Code-inspected mechanism; fixed-model condition and outcomes paper-reported | Four predeclared memory coordinates and benchmark tasks; no project rationale and no product demand stream |
+| Memento-Skills | Not in scope | Partial; the foundation LLM is fixed, but the router is trained | Meets stated scope | Meets stated scope | Not in scope | Meets stated scope; bounded task loop | Paper-reported mechanism and outcomes; implementation not independently inspected | Mixed-form skills learn under answer oracles, not under delayed software-maintenance consequences |
+| Recuris | Not in scope | Meets stated scope | Partial | Meets stated scope | Not in scope | Meets stated scope; fixed gate and benchmark loop | Code-inspected mechanism; fixed-parametric-state condition and outcomes paper-reported | Four predeclared memory coordinates and benchmark tasks; no project rationale and no product demand stream |
 | Harness Continual Learning | Not in scope | Meets stated scope | Partial | Meets stated scope | Not in scope | Meets stated scope; bounded task loop | Paper-reported mechanism and outcomes; implementation not independently inspected | Finite benchmark streams and a fixed four-part harness partition; held-out forgetting remains |
 | Dynamic Cheatsheet | Not in scope | Meets stated scope | Not in scope | Meets stated scope | Not in scope | Meets stated scope; bounded sequential benchmark run | Code-inspected mechanism at a pinned commit; outcomes not independently reproduced | A curator prompt is the only gate, correctness never gates a retained entry, and entries carry no provenance |
 | Voyager | Not in scope | Meets stated scope | Meets stated scope | Partial; descriptions and the question cache guide retrieval and task choice | Not in scope | Meets stated scope; bounded game curriculum | Code-inspected mechanism at a pinned commit; aggregate outcomes repository-reported and not reproduced | A critic's success report admits a skill, and a same-named program overwrites the old one instead of being revised |
@@ -140,16 +144,18 @@ operation.
 
 The **Program theory** column has three values and one gap, and that
 distribution is the table's main result. Fifteen rows read *not in scope*
-because their objective never required a theory: a benchmark loop has no
-activity beyond the task and no user, so there is nothing for a theory to
-relate the software to. PROJECTMEM logs decisions, which is more than not
-setting out to hold one and less than applying one. Fluent and the OpenAI
-account, the two rows with a product and users, hold a theory that people
-wrote: expertise files and repository documents that make the domain legible.
-Wheelhouse's people supply rulings rather than explanations, which is why it
-reads *not demonstrated* beside them. So the column runs absent, logged,
-supplied, and the fourth value, acquired, is empty. Users and theory arrive
-together in this set, and so far only with people inside.
+because their objective does not ask them to acquire project understanding that
+relates a maintained user product to the activity it supports and guides later
+modification. A benchmark agent could still need a theory of its own
+organization; these records do not test that function. PROJECTMEM logs
+decisions, which is more than not setting out to hold a theory and less than
+applying one. Fluent and the OpenAI account, the two rows with a product and
+users, carry theory that people wrote: expertise files and repository documents
+that make the domain legible. Wheelhouse's people supply rulings rather than
+explanations, which is why it reads *not demonstrated* beside them. So the
+column runs absent, logged, supplied, and the fourth value, acquired, is empty.
+Users and project theory arrive together in this set, and so far only with
+people inside.
 
 ## Reading the rows
 
@@ -157,41 +163,40 @@ together in this set, and so far only with people inside.
 [Fluent](../sources/fluent-self-improving-software-factory-2081823472016335059.ingest.md)
 is the strongest reviewed match to the software-house topology, because the
 architecture described in its product documentation and its builder's
-practitioner report includes external stakeholders, product
-code, deployment evidence, natural-language expertise, a scheduler, rejection,
-retention, and later reuse; people and the system jointly shape and confirm the
-brief, the behaviour specifications, and the technical approach. The
-product-reported [Ona Memo
-factory](https://ona.com/stories/software-factory-what-we-learned) trial took
-an empty repository to a deployed product in ten days with software, notes,
-schedulers, and production signals in one loop, and people spent the early days
-writing the automations, conventions, and review paths that made it run. Steve
-Yegge's practitioner-reported account describes rulings progressing from custom
-to warning to written doctrine to programs that refuse an action, with his own
-judgments producing the rulings, and it also reports the maintenance cost of that path in
-a corpus that retained "old rulings that were obsolete or had changed"
-([Wheelhouse](../sources/steve-yegge-fences-not-sandboxes.ingest.md),
-verbatim).
+practitioner report includes external stakeholders, product code, deployment
+evidence, natural-language expertise, a scheduler, rejection, retention, and
+later reuse; people and the system jointly shape and confirm the brief, the
+behaviour specifications, and the technical approach. The product-reported
+[Ona Memo factory](https://ona.com/stories/software-factory-what-we-learned)
+trial took an empty repository to a deployed product in ten days with software,
+notes, schedulers, and production signals in one loop, and people spent the
+early days writing the automations, conventions, and review paths that made it
+run. Steve Yegge's practitioner-reported account describes rulings progressing
+from custom to warning to written doctrine to programs that refuse an action,
+with his own judgments producing the rulings, and it also reports the
+maintenance cost of that path in a corpus that retained "old rulings that were
+obsolete or had changed"
+([Wheelhouse](../sources/steve-yegge-fences-not-sandboxes.ingest.md), verbatim).
 
 **Production scale reports and rule accumulation.** [Warp's scheduled skill
 improver](../sources/how-warp-builds-self-improving-agents-on-claude.ingest.md)
 is practitioner-reported on the note side only: people write the feedback and a
-human review admits every skill update. OpenAI's five-month practitioner-reported
-account is the largest substrate case in the set, with agents generating the
-product code, repository-local documents making the business domain legible,
-and recurring agents repairing stale documentation, and it assigns the
-generalization work to people. When agents struggled, engineers asked "what
-capability is missing? What constraint is unenforced?" and then built the tool,
-wrote the linter, or added the structural test ([agent-first
+human review admits every skill update. OpenAI's five-month
+practitioner-reported account is the largest substrate case in the set, with
+agents generating the product code, repository-local documents making the
+business domain legible, and recurring agents repairing stale documentation,
+and it assigns the generalization work to people. When agents struggled,
+engineers asked "what capability is missing? What constraint is unenforced?"
+and then built the tool, wrote the linter, or added the structural test
+([agent-first
 product](../sources/harness-engineering-leveraging-codex-agent-first-world.ingest.md),
 verbatim).
 
 **Self-rewriting agent lineages around frozen models.** The Darwin Gödel
 Machine paper reports an evolutionary loop over coding agents around frozen
 foundation models, in which a child is admitted on viability rather than on
-score, because "Only agents that compile
-successfully and retain the ability to edit a given codebase are added to the
-DGM archive" ([Darwin Gödel
+score, because "Only agents that compile successfully and retain the ability to
+edit a given codebase are added to the DGM archive" ([Darwin Gödel
 Machine](../sources/darwin-godel-machine-open-ended-evolution-self-improving-agents.ingest.md),
 verbatim).
 
@@ -217,21 +222,21 @@ update, and its most informative reported case is adverse: an agent found a
 specification exploit and "preserved it as a reusable skill", which shows that
 persistence, versioning, and rollback do not by themselves supply semantic
 admission ([Prime
-Agent](../sources/prime-agent-a-self-improving-rlm-harness.ingest.md),
-verbatim).
+Agent](../sources/prime-agent-a-self-improving-rlm-harness.ingest.md), verbatim).
 
-**Fixed-model learning under benchmark oracles.** The paper-reported [Harness
-Continual
+**Fixed-parametric-state learning under benchmark oracles.** The
+paper-reported [Harness Continual
 Learning](../sources/harness-continual-learning-adaptation-beyond-model-parameters.ingest.md)
 work commits an edit only when it improves the current task, respects sampled
 historical anchors, and passes validity checks, and it reports held-out
 forgetting even at zero loss on the retained anchors, which is negative
 evidence for any easy continuation claim. The Memento-Skills paper reports
 learning through one mixed-form unit of declarative instructions plus
-executable code under an answerable-benchmark oracle, and its ablation isolates
-that mechanism by removing the optimisation step, leaving "no failure attribution,
-no skill rewriting, and no skill discovery"
-([Memento-Skills](../sources/memento-skills-let-agents-design-agents.ingest.md),
+executable code under an answerable-benchmark oracle, but also trains a router,
+so it is not a witness to the stronger fixed-parametric-state condition. Its
+ablation isolates the mixed-form optimization mechanism by removing the
+optimisation step, leaving "no failure attribution, no skill rewriting, and no
+skill discovery" ([Memento-Skills](../sources/memento-skills-let-agents-design-agents.ingest.md),
 verbatim).
 
 **A reject-capable gate on a fixed surface.** Recuris forms component-scoped
@@ -241,8 +246,7 @@ four memory coordinates, its gate, and its benchmark partitions are all
 supplied in advance and the work does not ask whether the agent acquires a
 rationale for why a user product is organized as it is. Its reported retirement
 behaviour is the weakest part of the design, because "The memory only grows,
-and it can afford to."
-([Recuris](../sources/recursive-experiential-working-memory-evolution.ingest.md),
+and it can afford to." ([Recuris](../sources/recursive-experiential-working-memory-evolution.ingest.md),
 verbatim).
 
 **Single-form retention under a thin gate.** The code-inspected [Dynamic
@@ -261,8 +265,9 @@ fixes, and decisions and warns before repeated failed fixes, which gives
 project memory a path into later action without testing acquisition or
 revision. The Knowledge-Centric Self-Improvement preprint reports a protocol
 that isolates external knowledge as the learned object, holding software and
-solver state fixed and letting benchmark answers supply the oracle, so that "The only object that
-changes is the curated knowledge base." ([Knowledge-Centric
+solver state fixed and letting benchmark answers supply the oracle, so that
+"The only object that changes is the curated knowledge base."
+([Knowledge-Centric
 Self-Improvement](../sources/knowledge-centric-self-improvement-2607.19592.ingest.md),
 verbatim).
 
@@ -274,42 +279,83 @@ operators, and strategies are all designer-supplied and fixed. It locates the
 boundary precisely: a model can drive adaptation without the system learning
 the theory that governs adaptation.
 
-## What a witness test would have to do
+## What a carrier-neutral reachability witness would have to do
 
-No row above is a witness. The endpoint needs a more demanding conjunction,
-and these seven conditions state it:
+No row above is a witness. A test of the broad conjecture needs the following
+conjunction:
 
-1. A pinned fixed-model system maintains one user product over a declared
-   horizon of incrementally revealed requirements and production events.
-2. The seed withholds at least one decisive project rationale while retaining
-   the records from which it can be acquired.
-3. The system writes both the product or production machinery and a
-   rationale-bearing natural-language artifact, then demonstrably loads the
-   latter at the later decision where it matters.
-4. A later change is locally valid under tests but conflicts with the acquired
+1. A system with every distributed-parametric internal component pinned
+   maintains one user product over a declared horizon and prospectively
+   specified demand process of incrementally revealed requirements and
+   production events.
+2. The seed withholds at least one decisive piece of project-specific
+   understanding while retaining the permitted records and interactions from
+   which the theory-holding function can be acquired.
+3. The system later handles an implication not stated verbatim in those records,
+   and withholding or replacing the relevant retained state or consumption path
+   changes proposal, evaluation, diagnosis, or recovery in a predicted way.
+4. A later dependency or operating consequence makes part of the earlier
+   understanding inadequate. The system attributes the evidence and reaches an
+   adequate successor state rather than preserving the old account blindly or
+   rewriting it without grounds.
+5. Across the sequence, experience causes operative learning in both
+   natural-language and symbolic state, though the two forms need not change in
+   the same acquisition episode.
+6. Candidate admission, rollback, conflict resolution, and continuation operate
+   without a person supplying the decisive understanding or choosing the
+   successor. Users may supply product requirements, facts, observed outcomes,
+   and acceptance judgments about visible behaviour; internal diagnosis,
+   candidate comparison, theory editing, or successor selection remains an
+   internal role whatever the participant is called.
+7. Evaluation covers untouched later changes and repeated runs or another
+   justified estimate of usable success within the declared resource envelope,
+   so one lucky path does not establish practical reachability.
+
+This protocol does not require the acquired understanding to persist as a
+separate theory object. Reliable reconstruction from retained records or a mixed
+carrier can satisfy it if the composite passes the same causal and longitudinal
+tests.
+
+## The stronger explicit-theory mechanism test
+
+To establish that separately retained addressable theory contributes more than
+the carrier-neutral witness requires, add these conditions:
+
+1. The seed withholds a decisive project rationale while retaining the records
+   from which it can be synthesized.
+2. The system writes a rationale-bearing natural-language artifact and
+   demonstrably loads it at later decisions where its unstated implications
+   matter.
+3. A later change is locally valid under tests but conflicts with the acquired
    rationale. The system preserves coherence without receiving the answer from
    a person.
-5. A later dependency or operating consequence makes the old rationale false.
-   The system attributes the evidence, admits a successor rationale and code
-   change, and avoids both blind preservation and ungrounded rewrite.
-6. Candidate admission, rollback, retirement, and conflict resolution operate
+4. A later dependency or operating consequence makes the old rationale false.
+   The system attributes the evidence, admits a successor rationale and the
+   corresponding software or machinery change, and avoids both blind
+   preservation and ungrounded rewrite.
+5. Candidate admission, rollback, retirement, and conflict resolution operate
    without a person supplying the decisive theory or choosing the successor.
-7. Evaluation includes untouched later changes and counterfactual removal or
-   perturbation of the retained rationale, so that success shows causal use
-   rather than storage, retrieval, or benchmark selection alone.
+6. Evaluation includes untouched later changes, counterfactual removal or
+   replacement of the retained rationale, and raw-record or direct-artifact
+   baselines under the same model, source evidence, demand sequence, and
+   inference budget.
+
+These conditions identify the stronger mechanism claim. Storing or citing a
+rationale is insufficient; success must show causal use, revision, and an
+advantage over the routes that reconstruct understanding when needed.
 
 ## What the set shows together
 
 Read as a whole, the comparison is evidence about parts. Separate component
 mechanisms are inspected in code or reported by their sources: trace-derived
-candidates, scheduled consolidation, retention in both legible forms,
+candidates, scheduled consolidation, retention in both localized forms,
 reject-capable gates, broad self-revision, rollback that preserves
-failed-attempt evidence, and continuing product operation with human
-authority. What no reviewed source supplies is
-the conjunction. None tests both initial acquisition of a withheld project
-rationale and its later replacement from delayed product consequences, with
-causal read-back into software decisions and no person supplying the
-generalization or the admission verdict. The set therefore supports claims
-about available components and missing tests. It does not show that the
-components compose, and it does not show that the conjectured endpoint is
-reachable.
+failed-attempt evidence, and continuing product operation with human authority.
+What no reviewed source supplies is the carrier-neutral conjunction: acquired
+project understanding, causal use on unstated implications, successor
+acquisition from delayed product consequences, learning in both localized
+forms, user-facing operation, and continuation without an internal human. None
+also supplies the stronger explicit-theory test against matched raw-record or
+direct-search baselines. The set therefore supports claims about available
+components and missing tests. It does not show that the components compose, and
+it does not show that the conjectured endpoint is reachable.

--- a/kb/articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md
+++ b/kb/articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md
@@ -1,10 +1,11 @@
 ---
-description: "Conjecture that an automated software house capable of open-ended coherent change is reachable with fixed current LLMs by training the surrounding software and notes; the program-theory argument, training path, and witness obligations"
+description: "Conjecture that an automated software house capable of open-ended coherent change is reachable with 2026 LLMs while distributed-parametric state stays fixed and localized natural-language and symbolic state learns; the program-theory argument, training path, and witness obligations"
 type: kb/articles/types/article.md
 status: draft
 byline: Zbigniew Lukasiak
 source_notes:
   - kb/notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md
+  - kb/notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md
   - kb/notes/axes-of-artifact-analysis.md
   - kb/notes/code-complements-weight-prompt-with-symbolic-operations.md
   - kb/notes/continual-learning-requires-governing-behaviour-changing-writes.md
@@ -12,6 +13,7 @@ source_notes:
   - kb/notes/definitions/software-house.md
   - kb/notes/goedel-machines-are-a-proof-governed-case-of-self-modification.md
   - kb/notes/naur-equates-machine-execution-with-formulated-criteria.md
+  - kb/notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md
   - kb/notes/opacity-is-a-scale-threshold.md
   - kb/notes/program-theory-sustains-search-under-delayed-feedback.md
   - kb/notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md
@@ -29,15 +31,14 @@ source_notes:
 for its users, as they ask for things and as the software is used. The
 conjecture is that such a house can run with no human in a production role,
 on models that already exist, and handle requests nobody listed in advance.
-**The model never changes. Everything around it does:** the code the house
-runs on, and the notes that say what the software is for, why it is built
-the way it is, and what earlier changes taught. People write the first
-versions of both. The house then revises them as requests and their
-consequences arrive, and people correct it at first. **The bet** is that
-each round needs less correction, until the house keeps its own notes and
-code adequate without people. Whether the house does better by writing this
-understanding down as addressable notes than by rebuilding it from raw
-records each time is a separate, stronger hypothesis.
+**The models stay fixed; learning happens in the software and project state
+around them:** code, notes, and the machinery that makes both affect later
+work. People write the first versions. The house then revises them as requests
+and their consequences arrive, and people correct it at first. **The bet** is
+that the correction required falls over training until the house keeps its own
+state and software adequate without people. Whether it does better by writing
+its understanding down as addressable theory than by rebuilding it from raw
+records is a separate, stronger hypothesis.
 
 ## Claim
 
@@ -45,14 +46,17 @@ records each time is a separate, stronger hypothesis.
 house](../notes/definitions/software-house.md) capable of open-ended coherent
 software change is practically reachable with LLMs available by 2026-09-02.
 
-The LLMs stay fixed. What gets trained is the house, through computationally
-produced and retained changes to two legible [representational
-forms](../notes/definitions/representational-form.md): executable software
-and persistent natural-language notes. *Practically reachable* means success
+The eligible model versions and other distributed-parametric internal state
+stay fixed. What gets trained is the house, through computationally produced
+and retained changes to localized [natural-language and symbolic
+state](../notes/definitions/representational-form.md): notes, code, schemas,
+tests, tools, and production policy. Derived indexes may be regenerated from
+that canonical state under pinned machinery, but they are not independently
+trained or treated as learned state. *Practically reachable* means success
 within a declared product scope, operating horizon, and resource envelope of
 compute, time, and cost. Within those bounds, training must discover and
-maintain the decisive project-specific structures until no human is needed
-in an internal production or theory-holding role.
+maintain the decisive project-specific structures until no human is needed in
+an internal production or theory-holding role.
 
 ## Why the substrate could suffice
 
@@ -64,49 +68,47 @@ only some preserve the assumptions the rest of the code silently relies on.
 Choosing among them needs what the computer scientist Peter Naur called a
 program theory: the capacity to relate the software to the activity it
 supports, explain why it is organized as it is, and relate a new demand to
-that organization. [Holding a program
-theory means sustaining coherent search under delayed
-feedback](../notes/program-theory-sustains-search-under-delayed-feedback.md):
+that organization. [Holding a program theory means sustaining coherent search
+under delayed feedback](../notes/program-theory-sustains-search-under-delayed-feedback.md):
 the multi-tenant choice may not show its consequences until the next three
 demands arrive.
 
-[Naur's evidence](../sources/programming-as-theory-building.ingest.md) was a
-compiler whose original team could extend it cleanly while a second team,
-working from the same code and documentation, produced patches that fit
-badly. He concluded that the theory lives in people because its judgments
-cannot be reduced to a finite set of formulated criteria. An LLM is still
-formal computation. What has changed is that a machine can now take a
-paragraph explaining why the retry logic lives in the caller as input to a
-decision, without first translating it into a complete symbolic decision
-procedure. Naur's second team had such paragraphs too, so more prose of the
-same kind is not an answer. But the case tested one package and one way of
-consuming it: text, annotations, design discussion, personal advice, and
-the reading practices that team had. It did not test rationale linked to
-the decisions it affects, ADR-like records, machine-maintained indexes,
-semantic retrieval, dependency-aware context assembly, or loading the
-relevant record at the decision point. Whether such a system transfers more
-of the capacity, to people or to an LLM-based composite, remains open.
-Holding the theory means the paragraph is loaded at the decision it
-concerns and changes the outcome, which is what obligation 1 below tests. A house that passes it
-would meet Naur's functional criterion while leaving intact his claim that
-the theory cannot be written as rules. It would refute only his unproved
-step from "not rules" to "only people". [The distinction is between formal execution and explicitly
-formulated criteria](../notes/naur-equates-machine-execution-with-formulated-criteria.md).
-His evidence is bounded by the technology of its day on both sides: what
-machines could execute and what documentation practice could deliver.
+[Naur's compiler case](../sources/programming-as-theory-building.ingest.md)
+showed that full code, annotations, extensive design discussion, and personal
+advice did not give a successor team enough program-specific understanding;
+more prose of the same kind is not an answer. But it tested [one historically
+bounded documentation-and-consumption
+system](../notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md),
+not linked rationale, machine-maintained indexes, semantic retrieval,
+dependency-aware context assembly, or decision-point activation. Whether a
+newer representation-plus-consumption system transfers more of the required
+capacity, to people or to an LLM-based composite, remains empirical.
+
+Naur's human-only conclusion also relied on identifying machine execution with
+execution of formulated criteria. An LLM is still formal computation, but it
+can interpret a paragraph explaining why retry logic belongs in the caller
+without that judgment first being translated into a complete symbolic decision
+procedure. A successful house would falsify Naur's human-only conclusion while
+leaving intact his claim that the relevant judgment cannot be reduced to a
+finite formulable rubric. [The distinction is between formal execution and
+explicitly formulated
+criteria](../notes/naur-equates-machine-execution-with-formulated-criteria.md).
+Whether a composite meets his functional criterion is a longitudinal question:
+project-specific state must shape proposal, evaluation, diagnosis, or recovery
+on implications not stated verbatim, and interventions on that state must
+change the modification path.
 
 The conjecture assigns each component a role:
 
 - Fixed current LLMs supply the general linguistic, programming, and reasoning
   capacity that interprets project state and produces candidate changes.
-- Natural-language notes supply the persistent project-specific state:
-  purposes, commitments, explanations, evidence, and prior search. For
-  example: "installs must be a single file, so the store is SQLite; do not add
-  a server dependency." Architecture decision records are the familiar
-  candidate carrier closest to this. The notes generalize them, and Naur's
-  theory is what a decision record tries to write down.
-- Executable software supplies exact behaviour and continuity. This includes
-  the product, tools, context assembly, schedulers, validators and tests,
+- Natural-language notes supply persistent project-specific purposes,
+  commitments, explanations, evidence, and prior search. For example:
+  "installs must be a single file, so the store is SQLite; do not add a server
+  dependency." Architecture decision records are a familiar partial carrier
+  of such rationale.
+- Symbolic software supplies exact behaviour and continuity. This includes the
+  product, tools, schemas, context assembly, schedulers, validators and tests,
   version-control rollback, and retention rules.
 
 None of these holds the theory alone. A note nobody loads is inert. A fixed
@@ -127,20 +129,20 @@ that scale with computation because [the lesson selects how behavior-shaping
 structure is produced, not the form in which it is
 retained](../notes/the-bitter-lesson-selects-production-methods-not-representational.md).
 Learned software and notes are not disqualified merely because they are
-localized and legible. A hand-crafted seed is compatible only if [learning outgrows the
-task-specific knowledge the seed
+localized and legible. A hand-crafted seed is compatible only if [learning
+outgrows the task-specific knowledge the seed
 supplies](../notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md).
 Those two points answer the categorical objection; whether training over
 legible structures scales is what the program has to demonstrate.
 
-Current LLMs can produce both forms. Software can make a proposed change
-operative and feed later consequences into another update. The process is a
-schematic loop, not a formal model:
+Current LLMs can produce both localized forms. Software can make a proposed
+change operative and feed later consequences into another update. The process
+is a schematic loop, not a formal model:
 
 ```text
-production evidence + fixed LLMs + present software and notes
-  -> computational update of software and/or notes
-  -> retained successor software and notes
+production evidence + fixed LLMs + present localized state
+  -> computational update of natural-language and/or symbolic state
+  -> retained successor state
   -> later production
 ```
 
@@ -160,16 +162,17 @@ chooses the successor is doing the house's credit assignment and fills the
 excluded internal role.
 
 The update mechanism is otherwise open. It may produce a successor directly
-or separate proposal, evaluation, and selection, and it may edit the prior
-notes, rebuild them from the evidence, or both. Whatever the mechanism, a
-retained change counts as learning by the house only when experience causes
-it and it changes how a later, not-yet-specified production episode is
-conducted. Carrying forward the product state an earlier request asked for is
-not enough, since the next episode starts from the changed product either
-way. Adding a validator because a bug class recurred, so that the validator
-later blocks that class, qualifies; so does a product abstraction, invariant,
-or test that demonstrably shapes later changes beyond that continuity. A
-note never loaded by context assembly does not.
+or separate proposal, evaluation, and selection, and it may edit prior notes,
+rebuild working understanding from retained records, revise software, or
+combine these operations. A retained change counts as learning by the house
+only when experience causes it and it changes how a later,
+not-yet-specified production episode is conducted. Carrying forward the
+product state an earlier request asked for is not enough, since the next
+episode starts from the changed product either way. Adding a validator because
+a bug class recurred, so that the validator later blocks that class, qualifies;
+so does a product abstraction, invariant, or test that demonstrably shapes
+later changes beyond that continuity. A note never loaded by context assembly
+does not.
 
 Hand-crafted tools, stores, interfaces, safety boundaries, and provisional
 notes may start the loop. They are seed engineering, not evidence of
@@ -211,7 +214,8 @@ retained change to a note, test, tool, or policy, and that change can affect
 the next round of work without a training run.
 
 A further payoff is possible but not required by the conjecture. When
-retained program theory captures structure that survives a change, the house [may need fewer new observations to
+retained program theory captures structure that survives a change, the house
+[may need fewer new observations to
 adapt](../notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md).
 It can revise one premise and derive several consequences instead of
 relearning them separately. This advantage depends on the theory being both
@@ -224,27 +228,39 @@ cost once theory search, validation, retrieval, and maintenance are counted.
 One construction must eventually demonstrate the whole progression:
 
 1. **Holding and application.** Given adequate project-specific state, the
-   composite uses a program theory across novel changes. The test is a change
-   that violates a recorded rationale without violating any stated rule: a
-   house that holds the theory adapts or declines; one that only paraphrases
-   makes the change and cites the note.
+   composite sustains theory-guided proposal, evaluation, diagnosis, or
+   recovery across novel changes, including cases whose correct handling is
+   not stated verbatim in that state. Under matched conditions, withholding
+   or replacing the relevant state changes the modification path in a
+   predicted way.
 2. **Initial acquisition.** From permitted records, interaction, and
-   participation in the work, it builds an adequate theory instead of receiving
-   the decisive theory from a human.
+   participation in the work, it acquires an adequate project-theory function
+   instead of receiving the decisive project-specific understanding from a
+   human. The function may be carried by explicit theory, reliable
+   reconstruction from records, or mixed state.
 3. **Successor acquisition.** When experience exposes an inadequacy, such as a
-   dependency change that makes a recorded design reason false, it comes to
-   hold an adequate successor, by editing, rebuilding, or both.
+   dependency change that makes an earlier design reason false, it reaches a
+   successor state that supports coherent later modification, by revising
+   explicit theory, records, software, production machinery, or a combination.
 4. **Automated continuation.** It sustains these capacities across the declared
-   scope and horizon with no human in an internal role. Users may still supply
-   requirements, feedback, domain knowledge, and acceptance judgments.
+   scope and horizon with no human in an internal role.
 
-Computational training of the legible state is a condition on obligations 2
-and 3, not a further stage. A partial mechanism for one of them is not partial
+These obligations are carrier-neutral. A complete witness must demonstrate
+evidence-responsive learning in both natural-language and symbolic state
+somewhere across the sequence, but no single acquisition episode must change
+both forms. Users may supply product-level requirements, facts, observed
+outcomes, and acceptance judgments about visible behaviour. Implementation
+diagnosis, internal candidate comparison, theory editing, or successor
+selection counts as an internal role regardless of who supplies it.
+
+Computational training of localized state is a condition on obligations 2 and
+3, not a further stage. A partial mechanism for one of them is not partial
 completion of it: storing or paraphrasing a rationale does not show that it
 governed a decision, and a gate that can reject does not show that the
-admitted successor was adequate. What a test of the whole progression would
-have to do is stated in [the companion
-map](./nearest-existing-constructions-to-a-reachability-witness.md).
+admitted successor was adequate. The [companion
+map](./nearest-existing-constructions-to-a-reachability-witness.md) separates
+what a carrier-neutral witness must demonstrate from the stronger test of
+explicit retained theory.
 
 ## Nearest existing constructions
 
@@ -272,137 +288,76 @@ derive. The house admits what a fallible gate accepts on production
 consequences, and a consequence can contradict the current theory where a
 proof cannot contradict its axioms. The house pays with fallibility instead.
 
-No reviewed system is an empirical witness, but several hold one piece, and
-comparing them shows what the obligations exclude. The papers describing the
-[Darwin Gödel
-Machine](../sources/darwin-godel-machine-open-ended-evolution-self-improving-agents.ingest.md)
-and the [Huxley-Gödel
-Machine](../sources/huxley-godel-machine-human-level-coding-agent-development.ingest.md)
-report coding agents rewritten around frozen foundation models, with a child
-admitted on viability or on estimated lineage productivity. The reviewed code
-of [HyperAgents](../agent-memory-systems/reviews/hyperagents.md) replays
-benchmark-selected patches into the code its next generation edits. All
-three train software with the model fixed. What they retain is code, not the
-reasons a later change must respect. [Dynamic
-Cheatsheet](../agent-memory-systems/reviews/dynamic-cheatsheet.md) retains
-the other form: a natural-language cheatsheet curated from solver traces and
-read back into later prompts, with no gate beyond the curator and no change
-to software. [Voyager](../agent-memory-systems/reviews/voyager.md) admits an
-executable skill when a critic reports success and replaces a skill rather
-than revising it. None of the five serves users. Their demand streams are
-benchmarks or a game environment, which the open-endedness rule excludes.
-Each answers part of obligation 1's question about the substrate. Obligations
-2 and 3 concern acquiring and revising a program theory, and none of the five
-is set up to test that: what they retain and revise is judged by score or
-viability, not by whether it explains why the software is organized as it
-is. A wider comparison, with fourteen further constructions including
-human-inclusive software factories and the evidence behind every cell, is in
-[the companion
-map](./nearest-existing-constructions-to-a-reachability-witness.md).
+No reviewed system is an empirical witness. Human-inclusive factories such as
+Fluent and the OpenAI agent-first account are closest to the user-facing house
+topology and supplied project rationale, but people retain theory-building,
+generalization, or admission roles. Darwin and Huxley Gödel Machines and
+HyperAgents train software around frozen foundation models; Dynamic Cheatsheet
+and Voyager retain natural-language or executable artifacts. None combines
+user-facing open-ended operation, acquisition and revision of program theory,
+and continuation without an internal human. The [companion
+map](./nearest-existing-constructions-to-a-reachability-witness.md) compares
+nineteen constructions and records the evidence behind each placement.
 
-The simplest rival to explicit retained theory is that obligations 2 and 3
-need no separate theory object: an LLM given the record of what happened
-will reconstruct the theory whenever a decision needs it. The broad
-conjecture does not exclude this. It concerns the composite's functional
-capacity to acquire and maintain a program theory, and a house that reliably
-rebuilds an adequate theory from retained records at each decision holds
-one. The explicit route is a stronger mechanism hypothesis: with the model,
-source evidence, demand sequence, and inference budget held fixed,
-synthesizing, retaining, retrieving, revising, and activating addressable
-rationale-bearing theory improves coherent modification, diagnosis, or
-recovery relative to raw episodic records or direct search of the
-artifacts. The raw-record route is that hypothesis's baseline, not a denial
-of reachability. Both routes depend on a consumption path: something must
-load the record into the right call, with enough force to change the
-decision, at the moment it is made. A failure log left in a directory is
-advice nobody reads. Either way the admission and credit-assignment
-decisions above must be made, and the result retained in a form later calls
-consume with enough authority to matter. This program's method is to map
-the design space of that machinery: how each retained artifact acts,
-recorded by [its storage, representational form, lineage, and behavioural
-authority](../notes/axes-of-artifact-analysis.md); where current LLMs fail;
-what context limits force; and which computational models the loop admits.
-The comparisons above come from the first of these.
-What the map adds is a finding: separate component mechanisms exist in
-reviewed systems, but no reviewed system demonstrates the conjunction the
-obligations require.
+The broad conjecture does not require a separately retained theory object: a
+house may reliably reconstruct the understanding it needs from retained
+records. The stronger explicit-theory hypothesis predicts that, with model,
+source evidence, demand sequence, and inference budget held fixed, an
+addressable rationale improves coherent modification, diagnosis, or recovery
+relative to raw records or direct artifact search. Both routes require retained
+evidence to reach the relevant decision with enough behavioural force. Only
+the explicit route additionally requires selecting, retaining, and revising
+the synthesized theory object. The companion map treats that as a mechanism
+test rather than a condition of reachability.
 
-## A related conjecture about general theory builders
-
-The same components appear when the target is a persistent automated system
-that builds, tests, and revises natural-language theories for external users
-across domains not fixed in advance, such as [this knowledge
-base](../index.md) operated without its maintainers. At present an LLM is the only generally available
-computational interpreter for semantic operations over theories of that
-breadth. Symbolic systems perform such operations only over domains someone
-has already formalized. The corpus, exact state transitions,
-scheduling, checks, and rollback need software outside model interpretation:
-[code complements the weight–prompt pair with independently executed symbolic
-operations](../notes/code-complements-weight-prompt-with-symbolic-operations.md),
-and [symbolic scheduling avoids using an LLM for unreliable
-bookkeeping](../notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md).
-
-We conjecture that such a builder is itself a software house. New domains
-bring new manipulation requirements as well as new content. A domain whose
-claims must be compared across versions of a source needs snapshot pins in the
-note schema and a validator for them, which the earlier domains never needed.
-A harness fixed in advance can anticipate only requirements someone has
-already formulated, and a genuinely new domain brings some that nobody has.
-So either the builder revises its own supporting software or a person does.
-Whoever repeatedly supplies those demand-specific changes fills an internal
-role in the complete builder, so an automated builder brings that role
-inside. It then keeps developing software for its external users, which is
-the software-house [definition](../notes/definitions/software-house.md).
-
-This link is a conjecture, and the reachability conjecture does not depend on
-it. A fixed harness that sustained a general theory builder across genuinely
-new domains would refute the link without affecting the forward argument. [The
-decisions that stay human, and what would move
-them](./the-decisions-that-stay-human-and-what-would-move-them.md) develops
-this boundary.
+An [open-domain theory builder may itself become a software
+house](../notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md)
+when new domains require changes to its production machinery. That separate
+conjecture is not needed for the reachability claim.
 
 ## Boundaries and epistemic status
 
-The conjecture is existential: some current LLM, some arrangement of software
+The conjecture is existential: some eligible LLM, some arrangement of software
 and notes, some product scope. Two ways of saving the conjecture after a
-failure are ruled out in advance. The witness pins the model versions it
-admits before testing, so that a newer model cannot quietly do the work. And
-it declares product scope, horizon, and resource envelope before testing, so that the scope cannot shrink until fixed
-machinery suffices. Open-ended means the declared demand stream admits
-relevant novelty: one web application whose users keep asking for things
-nobody listed qualifies; a fixed set of fifty tasks does not. The declared
-stream is part of what the claim is about, since the reachable states depend
-on the demands received. Bare reachability is cheap: a gate that
-admits anything makes every state reachable. The claim is that adequate
-states are reached with usable probability inside the declared envelope.
+failure are ruled out in advance. The witness pins every eligible model and
+other distributed-parametric component before testing, so that a newer model
+or learned auxiliary component cannot quietly do the work. It also declares
+product scope, horizon, and resource envelope before testing, so that the scope
+cannot shrink until fixed machinery suffices. Open-ended means the declared
+demand stream admits relevant novelty: one web application whose users keep
+asking for things nobody listed qualifies; a fixed set of fifty tasks does not.
+The declared stream is part of what the claim is about, since the reachable
+states depend on the demands received. Bare reachability is cheap: a gate that
+admits anything makes every state reachable. The claim is that adequate states
+are reached with usable probability inside the declared envelope.
 
-The cutoff and model pinning bind a claim-establishing witness run, not
-ordinary development. The project may build and deploy with newer models,
-and doing so can show that accumulated state and machinery let a prepared
-project exploit a newer model better than an unprepared one. That is
-evidence about the state's value, not of reachability with models available
-by 2026-09-02. In a claim-establishing run, a newer model must not supply
-trial-specific theory, diagnose the trial's internal failures, select
-successors, or fill any other excluded internal role.
+The cutoff and pinning bind a claim-establishing witness run, not ordinary
+development. The project may build and deploy with newer models, and doing so
+can show that accumulated state and machinery let a prepared project exploit a
+newer model better than an unprepared one. That is evidence about the state's
+value, not of reachability with models available by 2026-09-02. In a
+claim-establishing run, a newer model must not supply trial-specific theory,
+diagnose the trial's internal failures, select successors, or fill any other
+excluded internal role. Derived indexes may change only as mechanical views of
+localized canonical state under the pinned algorithms declared by the witness.
 
-Software and notes are the trainable internal state. Products, demands, tool
-outputs, and operating consequences are its evidence. Holding, acquisition,
-training, learning, and automation are requirements of this witness, not of
-the base software-house definition.
+Localized natural-language and symbolic artifacts are the trainable internal
+state. Products, demands, tool outputs, and operating consequences are its
+evidence. Holding, acquisition, training, learning, and automation are
+requirements of this witness, not of the base software-house definition.
 
-The need for a program-theory function is a theoretical argument, not a
-proved theorem. Current-LLM sufficiency and the practical training path are
+The need for a program-theory function is a theoretical argument, not a proved
+theorem. Current-LLM sufficiency and the practical training path are
 conjectures. The program is constructive: a working system establishes
 reachability over its declared scope, horizon, and envelope. Failure of one
 architecture eliminates that path; it cannot refute the existential claim
 unless the search has first been bounded.
 
-Three outcomes differ: the full constructive conjecture; a human-inclusive
-house that materially reduces programmer work; and evidence that the method
-has outgrown human construction of the required task-specific
-specialization. The second is a positive engineering and research result
-even if the first is never reached. But while decisive task-specific
-theory, decomposition, evaluation, or selection stays repeatedly
-human-produced, the result has not met the Bitter Lesson compatibility
-condition above. It may stay useful; what is missing is a warrant for its
-durability and scaling advantage, not a proof of failure.
+Practical usefulness, automated continuation, and Bitter-Lesson-compatible
+computational acquisition are separate achievements. A human-inclusive house
+that materially reduces programmer work is a positive engineering and research
+result even if it never satisfies the full conjecture. If decisive
+task-specific theory, decomposition, evaluation, or selection remains
+repeatedly human-produced, however, the project has not established its Bitter
+Lesson durability argument. The system may remain useful; what is missing is a
+warrant for its durability and scaling advantage, not a proof of failure.

--- a/kb/notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md
+++ b/kb/notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md
@@ -1,0 +1,25 @@
+---
+description: "A persistent automated theory builder for external users becomes a software house when genuinely new domains require it to revise the software that performs theory production rather than only the theories produced"
+type: kb/types/note.md
+traits: [title-as-claim]
+tags: [foundations, self-improving-systems, learning-theory]
+---
+
+# An open-domain theory builder becomes a software house when new domains require production-machinery changes
+
+Consider a persistent automated system that builds, tests, and revises natural-language theories for external users across domains not fixed in advance. Language models currently supply the broadly applicable semantic operations: interpreting claims, comparing explanations, proposing counterexamples, and revising scope. Software outside model interpretation supplies the corpus, exact state transitions, scheduling, checks, indexes, and rollback.
+
+New domains can bring new manipulation requirements as well as new content. A domain whose claims must be compared across changing versions of a source may require snapshot pins in the note schema and a validator for them, even if no earlier domain needed either. Other domains may require new evidence models, dependency representations, retrieval paths, evaluators, or workflows.
+
+When such requirements arise, either the builder revises its own supporting software or a person repeatedly supplies the required changes. In the second case that person fills an internal production role in the complete theory-building system. An automated builder must bring the role inside its computational boundary. It then persistently develops software in response to demands and operating consequences for external users, which meets the definition of a [software house](./definitions/software-house.md).
+
+The claim is conditional, not an impossibility theorem about fixed harnesses. A sufficiently general fixed harness might sustain theory building across genuinely new domains without requiring demand-specific machinery changes. Such a construction would refute this link while leaving open the broader question of whether automated software houses are reachable. The empirical issue is whether new domains repeatedly expose production requirements that were not economically or practically anticipated in the fixed substrate.
+
+---
+
+Relevant Notes:
+
+- [Software house](./definitions/software-house.md) — defines: the complete persistent producer whose boundary follows internal production roles
+- [Code complements the weight–prompt pair with independently executed symbolic operations](./code-complements-weight-prompt-with-symbolic-operations.md) — grounds: the division between open-ended semantic operations and exact installed transitions
+- [Scheduler-LLM separation exploits an error-correction asymmetry](./scheduler-llm-separation-exploits-an-error-correction-asymmetry.md) — grounds: why exact state, checks, and bookkeeping remain software responsibilities
+- [Broad software demands create pressure for agentic factory development](./broad-software-demands-create-pressure-for-agentic-factory-development.md) — parallels: broad demand classes create practical pressure to acquire new production machinery without proving that a fixed universal substrate is impossible

--- a/kb/notes/naur-equates-machine-execution-with-formulated-criteria.md
+++ b/kb/notes/naur-equates-machine-execution-with-formulated-criteria.md
@@ -1,5 +1,5 @@
 ---
-description: "Naur argues program theory cannot be expressed as criteria, then concludes it is human-only; the bridge equates machine execution with formulated criteria, true in his day; his compiler evidence is likewise bounded by its day's documentation practice"
+description: "Naur argues program theory cannot be expressed as criteria, then concludes it is human-only; the bridge equates machine execution with formulated criteria, true for the programs of his day and separated since by trained recognizers"
 type: kb/types/note.md
 traits: [title-as-claim, has-external-sources]
 tags: [foundations, context-engineering]
@@ -39,7 +39,7 @@ None of this shows that any program holds a program's theory. Breaking the bridg
 
 Naur's compiler case is a bounded transfer failure. A motivated successor group had the full program text, annotated sources, extensive written design discussion, and personal advice, and still proposed extensions the original group recognized as patches destroying the structure; the original group could propose simple changes framed within it. The case shows that the supplied package did not convey enough program-specific understanding to that group. It does not test other rationale packages or other interpreters.
 
-The bound on this evidence is technology-relative in the same way as the bridge. The package was the documentation and knowledge-consumption machinery of its time: text, annotations, written discussion, advice, and whatever organization and reading practice the group brought to them. It did not test structured rationale linked to the decisions it affects, ADR-like records, machine-maintained indexes, semantic retrieval, dependency-aware context assembly, or automatic loading of the relevant record at the decision point. Whether a different representation-plus-consumption system transfers more of the capacity, to people or to an LLM-based composite, is therefore an open empirical question. The negative result keeps its force: the successor group already had extensive documentation, so adding more prose of the same kind is not an answer, and none of the newer carriers holds a theory by itself.
+The case tested one historically bounded documentation-and-consumption system. [A separate note](./naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md) states what the negative result establishes, which newer representation, indexing, retrieval, and activation paths it did not test, and why those mechanisms still do not hold a theory by themselves.
 
 Read with Naur's account of theory possession, the case gives three necessary tests for any claim that an interpreter-plus-artifact composite is a bearer of a program's theory:
 
@@ -56,6 +56,7 @@ The third test is longitudinal rather than a demand for a correct first change. 
 Relevant Notes:
 
 - [Programming as Theory Building](../sources/programming-as-theory-building.ingest.md) — abstracted-from: supplies the Ryle regress, the inexpressibility and human-binding claims, the program-as-formal-symbol-manipulation and rule-following passages, the program-life passage, and the compiler case; the identification of the bridge as an equation is this note's reading
+- [Naur's compiler case tests one historically bounded documentation-and-consumption system](./naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md) — extends: separates the technology-relative bound on the transfer evidence from the machine-execution bridge
 - [Attempted recovery identifies informational gaps, not provenance or authority](./documentation-generates-the-system-rather-than-describing-it.md) — grounds: why Naur's failed transfers show that content was missing from the supplied artifacts, not that program theory is inexpressible in principle
 - [Holding a program theory means sustaining coherent search under delayed feedback](./program-theory-sustains-search-under-delayed-feedback.md) — extends: develops Naur's third bearer test as a longitudinal search-and-recovery capacity rather than one-shot correctness
 - [Theory-mediated self-improvement needs interpretation, retention, and independent read-back](./theory-mediated-self-improvement-needs-interpretation-and-retention.md) — extends: the interpreter/retention division of labour that the three tests condition

--- a/kb/notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md
+++ b/kb/notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md
@@ -1,0 +1,25 @@
+---
+description: "Naur's compiler transfer failure rules out more documentation of the same kind, but tested one historically bounded package and consumption process rather than every possible rationale, indexing, retrieval, and activation system"
+type: kb/types/note.md
+traits: [title-as-claim, has-external-sources]
+tags: [foundations, context-engineering]
+---
+
+# Naur's compiler case tests one historically bounded documentation-and-consumption system
+
+Peter Naur's compiler case reports a strong transfer failure. A motivated successor group received the full program text, annotated sources, extensive written design discussion, and personal advice, yet proposed extensions that the original group judged to be patches damaging the compiler's structure. The case therefore rules out a simple answer in which more prose of the same kind automatically transfers the program theory.
+
+It does not test every possible artifact-and-interpreter arrangement. The supplied package and its use belonged to the documentation and knowledge-consumption technology of its time: people had to organize, find, select, and activate the relevant material through their own reading and work practices. The case did not test rationale linked to the decisions it affects, ADR-like records with explicit scope and status, machine-maintained indexes, semantic retrieval, dependency-aware context assembly, or automatic loading of the relevant record at the decision point.
+
+These later mechanisms create an empirical possibility, not a rebuttal by definition. They may make previously supplied premises easier to find, preserve rejected alternatives and applicability conditions, or place relevant rationale where a person or LLM can use it. None holds a program theory by itself. The theory-holding claim belongs to the interpreter-plus-artifact composite and requires causal evidence that the retained state shapes coherent modification across novel demands, including implications not stated verbatim and recovery after delayed contradiction.
+
+The appropriate comparison therefore varies both representation and consumption while holding source evidence and task demands fixed. Ordinary documentation, structured rationale with indexing and context assembly, and raw records from which an interpreter reconstructs a theory are different transfer pathways. Naur's case establishes failure of one historically important pathway. Whether a newer pathway transfers more of the required capacity, to people or to an LLM-based composite, remains an experimental question.
+
+---
+
+Relevant Notes:
+
+- [Programming as Theory Building](../sources/programming-as-theory-building.ingest.md) — abstracted-from: supplies the compiler case, the package given to the successor group, and Naur's interpretation of its failure
+- [Naur binds program theory to humans by equating machine execution with formulated criteria](./naur-equates-machine-execution-with-formulated-criteria.md) — parallels: the human-only inference and the transfer evidence are both bounded by the computational and documentary technology being considered
+- [Holding a program theory means sustaining coherent search under delayed feedback](./program-theory-sustains-search-under-delayed-feedback.md) — supplies: the longitudinal bearer test that newer transfer machinery must pass
+- [Design rationale must preserve decision premises its interpreter cannot regenerate](./design-rationale-must-preserve-unregenerable-decision-premises.md) — sharpens: what a rationale package must add beyond implementation and generic competence


### PR DESCRIPTION
## Summary

- make the four constructive-witness obligations carrier-neutral while strengthening holding with unstated implications and causal intervention;
- split the companion protocol into a broad reachability witness and a stronger explicit-theory mechanism test;
- define the fixed surface as all distributed-parametric internal state, with learning restricted to localized natural-language and symbolic state;
- extract the technology-relative bound on Naur's compiler case and the separate software-house conjecture for open-domain theory builders;
- compress the main article's Naur, nearest-constructions, explicit-theory, and theory-builder passages;
- keep the user-input boundary brief and functional: product-level evidence remains external, while diagnosis, candidate comparison, theory editing, and successor selection are internal roles.

## Scope

This PR does not revise the closure supplement's formal treatment or fully operationalize the demand process and probability measurements. Those remain separate follow-up work.

## Result

The main article is 45 lines shorter than `main`, despite adding the stronger witness distinctions. The nearest-constructions supplement is longer because it now carries the two protocols that the main article only summarizes.