### PR TITLE
Clarify the software-house topology boundary

### DIFF
--- a/kb/articles/nearest-existing-constructions-to-a-reachability-witness.md
+++ b/kb/articles/nearest-existing-constructions-to-a-reachability-witness.md
@@ -69,7 +69,8 @@ scopes differ, and the evidence differs. The table is not a ranking.
 The comparison runs on six questions, which are narrower and more directly
 checkable than the obligations:
 
-1. **House.** Does the system keep changing software for external users,
+1. **Software-house topology.** Does the construction include the complete
+   persistent system responsible for changing software for external users
    across demands that are not a fixed benchmark list?
 2. **Fixed parametric state.** Can the documented learning happen without
    changing foundation-model weights or other distributed-parametric internal
@@ -84,6 +85,17 @@ checkable than the obligations:
    explicit theory or reconstructed from records?
 6. **Continuation.** Is the loop sustained with no person in an internal
    production, theory-holding, generalization, selection, or admission role?
+
+The first question is a boundary test, not an automation test. A coding harness
+may repeatedly change software across benchmark or repository tasks while
+remaining only one component used by a larger producer. It has software-house
+topology only when the reviewed construction includes the complete persistent
+system responsible for evolving a user product across requirements, feedback,
+and operating consequences. Direct conversation with end users is unnecessary;
+those inputs may arrive through tickets, product management, telemetry, or
+other interfaces. Human independence is assessed separately under
+**Continuation**. A construction meeting both questions would be an automated
+software house over its stated scope and horizon.
 
 ## How the questions relate to the four obligations
 
@@ -103,24 +115,24 @@ acquisition must alter later production. **Successor acquisition** asks the same
 of understanding that later evidence makes inadequate. A complete witness must
 eventually demonstrate both **Software learning** and **Note learning** across
 its sequence, but one acquisition episode need not change both forms.
-**Automated continuation** is bounded by **House**, **Fixed parametric state**,
-and **Continuation**, and it requires the holding and acquisition capacities to
-keep working across that boundary.
+**Automated continuation** is bounded by **Software-house topology**, **Fixed
+parametric state**, and **Continuation**, and it requires the holding and
+acquisition capacities to keep working across that boundary.
 
-One warning governs every use of the table. **House** and **Fixed parametric
-state** are cross-cutting controls on a whole witness, not acquisition stages.
-**Software learning** and **Note learning** report which retained forms changed,
-and neither alone establishes **Program theory**. A partial cell is therefore
-not partial completion of an obligation. Storing, retrieving, or paraphrasing a
-rationale does not show that it governed a later decision; a software or note
-update does not by itself show that adequate project understanding was
-acquired; a reject-capable gate does not show that the admitted successor was
-adequate; and scheduling or restart does not show continued software-house
-operation.
+One warning governs every use of the table. **Software-house topology** and
+**Fixed parametric state** are cross-cutting controls on a whole witness, not
+acquisition stages. **Software learning** and **Note learning** report which
+retained forms changed, and neither alone establishes **Program theory**. A
+partial cell is therefore not partial completion of an obligation. Storing,
+retrieving, or paraphrasing a rationale does not show that it governed a later
+decision; a software or note update does not by itself show that adequate
+project understanding was acquired; a reject-capable gate does not show that
+the admitted successor was adequate; and scheduling or restart does not show
+continued software-house operation.
 
 ## Comparison table
 
-| Construction | House | Fixed parametric state | Software learning | Note learning | Program theory | Continuation | Evidence basis | Decisive shortfall |
+| Construction | Software-house topology | Fixed parametric state | Software learning | Note learning | Program theory | Continuation | Evidence basis | Decisive shortfall |
 |---|---|---|---|---|---|---|---|---|
 | Fluent | Meets stated scope | Not demonstrated; model lineage and auxiliary parametric state not pinned | Meets stated scope; human-inclusive | Meets stated scope; human-inclusive | Partial; rationale is supplied, while acquisition and faithful reuse are not demonstrated | Human-dependent | Product documentation and practitioner report; implementation and outcomes not independently inspected | Humans confirm behaviour, technical approach, and unresolved decisions; theory acquisition is not tested |
 | Wheelhouse | Not demonstrated | Not demonstrated | Partial; human-inclusive | Partial; human-inclusive | Not demonstrated | Human-dependent | Practitioner report; implementation and outcomes not independently inspected | Human rulings and verdicts produce the doctrine; the consolidating agent's theory-holding role is only a hypothesis |

--- a/kb/articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md
+++ b/kb/articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md
@@ -257,10 +257,7 @@ Computational training of localized state is a condition on obligations 2 and
 3, not a further stage. A partial mechanism for one of them is not partial
 completion of it: storing or paraphrasing a rationale does not show that it
 governed a decision, and a gate that can reject does not show that the
-admitted successor was adequate. The [companion
-map](./nearest-existing-constructions-to-a-reachability-witness.md) separates
-what a carrier-neutral witness must demonstrate from the stronger test of
-explicit retained theory.
+admitted successor was adequate.
 
 ## Nearest existing constructions
 
@@ -307,8 +304,8 @@ addressable rationale improves coherent modification, diagnosis, or recovery
 relative to raw records or direct artifact search. Both routes require retained
 evidence to reach the relevant decision with enough behavioural force. Only
 the explicit route additionally requires selecting, retaining, and revising
-the synthesized theory object. The companion map treats that as a mechanism
-test rather than a condition of reachability.
+the synthesized theory object. That additional requirement tests the mechanism,
+not reachability.
 
 An [open-domain theory builder may itself become a software
 house](../notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md)


### PR DESCRIPTION
## Summary

- rename the companion's `House` criterion to `Software-house topology`;
- explain that a self-editing coding harness can repeatedly change software while remaining only one component of a larger producer, and therefore does not itself meet the software-house boundary;
- clarify that direct end-user conversation is unnecessary: requirements and consequences may arrive through tickets, product management, telemetry, or other interfaces;
- keep automation separate under `Continuation`, so satisfying both columns identifies an automated software house over the stated scope and horizon;
- introduce the companion only once in the main article, in the nearest-constructions section, and remove the two redundant references around the obligations and explicit-theory paragraph.

This is a focused follow-up to #177.