### PR TITLE
Create the reachability working-paper publication workshop

### DIFF
--- a/kb/work/README.md
+++ b/kb/work/README.md
@@ -6,6 +6,7 @@ Each workshop is a directory exploring a specific workflow end-to-end: from ques
 
 ## Active Workshops
 
+- [reachability-working-paper-publication](./reachability-working-paper-publication/README.md) — staging the reachability conjecture as a versioned working-paper package with frozen authoritative appendices, live successor links, a dependency audit, and the remaining definitions, protocols, references, and probability criteria filled before publication approval
 - [commonplace-nearest-constructions](./commonplace-nearest-constructions/README.md) — characterizing Commonplace through the systems nearest its current human-inclusive theory builder, its path toward less task-specific human input, and its conjectured software-house endpoint
 - [agent-operability-second-slice](./agent-operability-second-slice/README.md) — making installed-project provenance and scaffold skew inspectable, then exercising a non-mutating three-way upgrade plan while preserving compact status and keeping review state opt-in
 - [cognitive-architecture-transfer-scan](./cognitive-architecture-transfer-scan/README.md) — breadth-first conjecture scan whose promising cross-architecture candidates still require deduplication, selective grounding, and extraction

--- a/kb/work/reachability-working-paper-publication/README.md
+++ b/kb/work/reachability-working-paper-publication/README.md
@@ -1,0 +1,123 @@
+# Workshop: Stage the reachability conjecture as a working paper
+
+## Goal
+
+Prepare a self-standing, versioned working-paper package for [The reachability
+conjecture](../../articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md)
+without collapsing its live supporting knowledge base into one permanently
+copied document.
+
+The intended publication architecture has three layers:
+
+1. the main paper states the conjecture, short argument, mechanism, evidence,
+   limits, and experimental obligations;
+2. frozen appendices preserve the load-bearing definitions, arguments,
+   protocols, and evidence used by that paper version; and
+3. links from each appendix lead to the live notes where the project can revise
+   the argument after publication.
+
+The authority rule is:
+
+> The frozen appendix is authoritative for what that working-paper version
+> argues. The linked live note is authoritative only for the project's current
+> position.
+
+This workshop stages and completes the package. It does not authorize
+publication or change the article's lifecycle status. Promotion still requires
+explicit approval naming `working-paper` and must follow [Publish an
+article](../../instructions/publish-an-article.md).
+
+## Inputs
+
+- [Main draft](../../articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md)
+- [Nearest-constructions supplement](../../articles/nearest-existing-constructions-to-a-reachability-witness.md)
+- [Transition-reachability supplement](../../articles/reachability-as-closure-under-the-seed-gate.md) — its formal correction is staged separately in [PR #179](https://github.com/zby/commonplace/pull/179) and must land before the publication snapshot is frozen
+- the definitions, theory notes, and source captures classified in [dependency-audit.md](./dependency-audit.md)
+
+## Working artifacts
+
+- [artifact-manifest.md](./artifact-manifest.md) — planned paper components,
+  snapshot/adaptation mode, live source, target destination, and readiness
+- [dependency-audit.md](./dependency-audit.md) — which current dependencies are
+  load-bearing enough to enter the versioned package and which remain live links
+- [appendix-plan.md](./appendix-plan.md) — paper-native appendix structure,
+  provenance headers, missing content, and assembly rules
+- [staging/README.md](./staging/README.md) — boundary and naming rules for the
+  actual copied or adapted appendix drafts once the source cohort is selected
+
+## Work sequence
+
+1. **Audit the dependency closure.** For every definition, premise, protocol,
+   material qualification, and evidence claim, decide whether a skeptical
+   reader needs it when links are unavailable.
+2. **Choose the publication mode.** Mark each included component as an exact
+   snapshot, a paper adaptation, or paper-native content. Do not call an edited
+   adaptation a snapshot.
+3. **Fill the remaining gaps.** In particular, settle the paper definitions of
+   open-ended demand generation, practical reachability, hitting probability,
+   continuation reliability, and the treatment of retries, abstentions,
+   rescues, and post-hoc demand removal.
+4. **Stage the appendices.** Copy exact snapshots from one declared source
+   commit; write adaptations in the staging area; add direct primary-source
+   references and provenance headers; keep live-note links for later
+   developments.
+5. **Assemble and test the paper package.** Verify that the main body remains
+   understandable with links disabled, that appendices discharge every
+   load-bearing dependency, and that the package contains no unresolved
+   placeholders.
+6. **Freeze a candidate.** Record paper version, source commit, source path and
+   source blob or commit for every frozen appendix, then review the complete
+   diff rather than regenerating a released version automatically from live
+   notes.
+7. **Publish only after approval.** Once the user explicitly approves the body
+   and target lifecycle, apply the repository publication procedure and record
+   the frozen package as the cited version.
+
+## Boundaries
+
+- Do not recursively copy every note reached by a link. Snapshot only the
+  load-bearing dependency closure; optional examples, neighboring theories,
+  implementation history, and later extensions remain live links.
+- Exact snapshots may receive only mechanical transformations such as heading
+  normalization, frontmatter removal, link rewriting, and provenance headers.
+  Substantive edits make the artifact a paper adaptation.
+- Appendices cite primary external sources directly. Commonplace ingest reports
+  remain provenance and analysis aids, not the paper's sole scholarly record.
+- A live-note revision does not silently revise an older paper. It may trigger a
+  new working-paper version, a visible correction, or no paper change after
+  explicit review.
+- The main article remains the public draft during staging. Workshop copies are
+  not alternative canonical versions of the paper.
+
+## Current gaps to close
+
+- final definitions for practical reachability and the prospective demand and
+  consequence process;
+- a reproducible witness protocol that separates one possible path from usable
+  hitting probability and sustained continuation;
+- the paper-native boundary between the carrier-neutral reachability witness
+  and the stronger explicit-theory mechanism experiment;
+- direct bibliographic references and source locations for the Naur and Gödel
+  arguments;
+- the final decision whether the large nearest-constructions material remains
+  an appendix inside one document or a versioned supplement released with it;
+- automated or at least checkable detection that a live note has changed since
+  the frozen source cohort.
+
+## What closes this workshop
+
+1. The dependency audit identifies every load-bearing component and no appendix
+   depends on an unversioned live note for its historical meaning.
+2. The manifest records one source commit and the exact mode and provenance of
+   every staged component.
+3. The definitions, witness protocol, transition treatment, comparison evidence,
+   and references are complete enough for an external technical reader to
+   assess without traversing the KB.
+4. Every frozen appendix links to its live successor, and each live source can
+   point back to the paper version that froze it.
+5. The assembled package validates and passes an external-reader review with
+   hyperlinks disabled.
+6. The user either approves promotion to `working-paper` and the publication
+   procedure lands it, or explicitly decides to keep the package as a draft.
+7. Durable process lessons are extracted to the article publication machinery;
+   temporary staging copies are then removed with the workshop.

--- a/kb/work/reachability-working-paper-publication/appendix-plan.md
+++ b/kb/work/reachability-working-paper-publication/appendix-plan.md
@@ -1,0 +1,196 @@
+# Reachability working-paper appendix plan
+
+## Package shape
+
+The default target is one working paper with paper-native appendices:
+
+```text
+Main paper
+Appendix A — Definitions and system boundary
+Appendix B — Program theory and the technology-relative reading of Naur
+Appendix C — Constructive-witness protocols
+Appendix D — Nearest existing constructions
+Appendix E — Transition reachability and seed descent
+References
+```
+
+Appendix D may instead become a separately paginated supplement if the complete
+comparison makes the paper unwieldy. That supplement must be released with the
+same paper version, source commit, and revision date; an independently mutable
+web page is not an adequate substitute.
+
+## Appendix A — Definitions and system boundary
+
+### Required content
+
+- software house;
+- automated software house;
+- external user and internal production role;
+- declared product scope and operating horizon;
+- natural-language, symbolic, and distributed-parametric state;
+- program-theory function;
+- learning by the house rather than ordinary product-state continuity;
+- admissible input histories, realized history, and selection process;
+- adequate state;
+- practical reachability;
+- hitting probability and continuation reliability.
+
+### Mode
+
+Paper adaptation. The source definitions are broader library artifacts; the
+appendix should select only the meanings used by this paper and make their
+relations explicit in one place.
+
+### Gap
+
+The live KB does not yet contain settled standalone definitions of practical
+reachability, adequate state, hitting probability, or continuation reliability.
+The workshop should formulate them in Appendix A and then decide which deserve
+promotion back into atomic notes.
+
+## Appendix B — Program theory and Naur
+
+### Required argument
+
+1. Naur's functional tests connect software to the activity it supports,
+   justify its organization, and assimilate new demands coherently.
+2. Extensive ordinary documentation failed to transfer enough of this capacity
+   in the compiler case.
+3. That case tested one historically bounded representation and consumption
+   path; more prose of the same kind is not the answer, but linked rationale,
+   indexing, retrieval, context assembly, and decision-point activation remain
+   empirical alternatives.
+4. Naur's human-only conclusion also relied on identifying machine judgment with
+   execution of explicitly formulated criteria.
+5. Trained recognizers and LLM interpretation reopen the bearer question without
+   proving that current systems pass it.
+6. Possession is tested longitudinally through theory-guided search, delayed
+   contradiction, recovery, successor acquisition, and causal interventions.
+
+### Mode
+
+Provisional combination:
+
+- B1 machine-execution bridge — exact snapshot unless compression materially
+  improves the paper;
+- B2 compiler-transfer bound — exact snapshot candidate;
+- B3 longitudinal bearer test — paper adaptation from the longer note.
+
+All three need direct citation to Naur's primary text. A snapshot may preserve
+internal source links, but the paper cannot make the ingest report its only
+source record.
+
+## Appendix C — Constructive-witness protocols
+
+### Carrier-neutral protocol
+
+Start from the current seven-condition protocol in the nearest-constructions
+supplement and complete:
+
+- prospective declaration of the demand and consequence process;
+- model, auxiliary parametric state, seed, and update machinery freeze;
+- hidden-future-demand and no-post-hoc-removal rules;
+- allowed user evidence versus internal production decisions;
+- unstated-implication and withholding/replacement interventions;
+- delayed contradiction and successor acquisition;
+- learning in both localized forms across the sequence;
+- retries, abstentions, timeouts, rollbacks, rescues, and human-intervention
+  accounting;
+- evidence for usable hitting probability;
+- evidence for continuation reliability across the autonomous horizon.
+
+### Explicit-theory mechanism protocol
+
+Add the stronger intervention and baseline conditions:
+
+- synthesize and retain an addressable rationale-bearing artifact;
+- load it at the decisions where unstated implications matter;
+- revise or retire it when later evidence defeats it;
+- compare against raw records and direct artifact search with model, source
+  evidence, demand sequence, and inference budget held fixed;
+- distinguish a mediation trace from a load-bearing causal effect.
+
+### Mode
+
+Paper-native. This appendix defines what the paper asks future constructions to
+demonstrate; it should not inherit its meaning from a changing comparison
+article.
+
+## Appendix D — Nearest existing constructions
+
+### Required content
+
+- evidence-basis vocabulary;
+- software-house topology separated from automated continuation;
+- fixed-parametric-state criterion;
+- software learning and note learning;
+- program-theory acquisition and successor acquisition;
+- the nineteen-row comparison or its final reviewed successor;
+- concise reading of the strongest neighboring clusters;
+- the missing-conjunction result.
+
+### Mode
+
+Paper adaptation from the current supplement, or a versioned supplement released
+as part of the same package.
+
+### Gap
+
+Before freeze, recheck every row affected by the stronger fixed-parametric-state
+criterion and preserve the exact source or commit behind code-inspected
+placements. The table is evidence about reviewed records, not a ranking or a
+claim that no unreviewed construction exists.
+
+## Appendix E — Transition reachability and seed descent
+
+### Required content
+
+- complete mutable state and pinned parameters;
+- state-dependent successor relation covering gated and direct updates;
+- transition closure from the seed over declared input histories;
+- self-revision admitted by predecessor machinery;
+- exogenous human transitions distinguished from warrant;
+- Gödel-machine proof-gated transition relation versus fallible empirical
+  relation;
+- machine-state reachability distinguished from deductive closure of theorems;
+- existential claim distinguished from nondeterminism;
+- admissible histories, realized history, and distribution distinguished;
+- hitting probability and continuation reliability;
+- seed-exclusion and negligible-mass failure modes.
+
+### Mode
+
+Paper adaptation or exact snapshot of the corrected supplement after PR #179 is
+reviewed. The appendix should be shorter than the supplement only when no
+load-bearing distinction is lost.
+
+## References
+
+The paper should carry a conventional reference list and source locations for
+material claims. At minimum:
+
+- Peter Naur, *Programming as Theory Building*;
+- Jürgen Schmidhuber, *Gödel Machines: Fully Self-Referential Optimal Universal
+  Self-Improvers* or the exact cited edition/title;
+- primary sources for every construction whose reported result bears load in
+  Appendix D;
+- Richard Sutton, *The Bitter Lesson*, for the narrow production-method claim.
+
+Repository notes and ingests may appear as reproducibility and provenance links,
+but external readers should be able to identify and inspect the primary sources
+without traversing Commonplace.
+
+## Assembly rules
+
+- The paper body points first to the frozen appendix, not directly to the live
+  note, when the appendix carries a load-bearing argument.
+- Each appendix links onward to the live note or article and states that the live
+  version may have changed.
+- Live notes should eventually link back to the paper version and appendix that
+  froze or adapted them.
+- Exact snapshots are generated from the declared source commit and not
+  hand-edited in staging.
+- Paper adaptations are reviewed against every source they claim to preserve.
+- No released paper is regenerated automatically when a live source changes.
+- No `TODO`, unresolved placeholder, mutable workshop link, or link into
+  `kb/work/` may remain in the public paper package.

--- a/kb/work/reachability-working-paper-publication/artifact-manifest.md
+++ b/kb/work/reachability-working-paper-publication/artifact-manifest.md
@@ -1,0 +1,90 @@
+# Reachability working-paper artifact manifest
+
+## Status
+
+Staging manifest. No paper version or source commit has been frozen, and no
+publication state is authorized.
+
+The eventual manifest must record one paper version and source cohort. An exact
+snapshot is historical evidence for that version; a live note is a successor,
+not a dependency that can silently redefine it.
+
+## Planned package
+
+| ID | Paper role | Live source | Mode | Planned staged artifact | Current state | Remaining work |
+|---|---|---|---|---|---|---|
+| M | Main paper | `kb/articles/reachability-conjecture-the-llm-stays-fixed-the-software-house-learns.md` | paper-native | published article path | substantial draft exists | complete dependency audit, paper invitation, references, final self-standing review, publication approval |
+| A | Definitions and boundary | `kb/notes/definitions/software-house.md`; `kb/notes/definitions/representational-form.md`; main-paper terms | paper adaptation | `staging/appendix-a-definitions-and-boundary.md` | outline only | define program-theory function, learning by the house, open-ended input process, adequate state, practical reachability, hitting probability, and continuation reliability in one paper vocabulary |
+| B1 | Naur's machine-execution bridge | `kb/notes/naur-equates-machine-execution-with-formulated-criteria.md` | snapshot candidate | `staging/appendix-b-program-theory-and-naur.md` | live note ready | decide exact snapshot versus compressed adaptation; add direct Naur references |
+| B2 | Technology-relative compiler-transfer evidence | `kb/notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md` | snapshot candidate | `staging/appendix-b-program-theory-and-naur.md` | live note ready | add direct case citation and distinguish what the case rules out from what newer retrieval and activation leave open |
+| B3 | Longitudinal theory-holding test | `kb/notes/program-theory-sustains-search-under-delayed-feedback.md` | paper adaptation | `staging/appendix-b-program-theory-and-naur.md` | long live argument exists | retain only the derivation and tests needed by this paper; preserve wrong-theory, withholding, delayed-feedback, and recovery predictions |
+| C | Constructive-witness protocols | main paper plus `kb/articles/nearest-existing-constructions-to-a-reachability-witness.md` | paper-native | `staging/appendix-c-witness-protocols.md` | carrier-neutral and explicit-theory cores exist | complete prospective demand process, run accounting, probability evidence, model and seed freeze, and intervention schedule |
+| D | Nearest existing constructions | `kb/articles/nearest-existing-constructions-to-a-reachability-witness.md` | paper adaptation or versioned supplement | `staging/appendix-d-nearest-constructions.md` | comparison exists | choose in-document appendix versus separately paginated supplement; freeze evidence basis and direct references |
+| E | Transition reachability and seed descent | `kb/articles/reachability-as-closure-under-the-seed-gate.md` | paper adaptation or snapshot after correction | `staging/appendix-e-transition-reachability.md` | formal correction proposed in PR #179 | merge and review the corrected relation, then decide whether to preserve the complete supplement or a shorter paper adaptation |
+| R | References and provenance | source ingests and primary sources cited by all components | paper-native | `staging/references.md` | source captures exist | produce conventional bibliography, page or section locations, and direct primary-source citations; keep ingest links only as optional provenance |
+
+## Publication modes
+
+**Exact snapshot.** The staged text reproduces the source artifact at the frozen
+commit. Allowed transformations are mechanical: remove frontmatter, lower or
+raise heading levels, rewrite links, normalize citation formatting, and add the
+provenance header. Any substantive wording change changes the mode to a paper
+adaptation.
+
+**Paper adaptation.** The appendix is edited for this paper: material may be
+selected, reorganized, compressed, or joined with another source. The appendix
+is authoritative paper text. Its source links record derivation and live
+successors; they do not imply textual identity.
+
+**Paper-native.** The content exists to make the paper complete and may combine
+several live artifacts. The witness protocol and reference list belong here
+because neither should be defined by whichever source note happens to be current
+later.
+
+## Fields to freeze for a release candidate
+
+```yaml
+paper: reachability-conjecture
+version: pending
+source_commit: pending
+frozen_at: pending
+components:
+  - id: A
+    mode: paper-adaptation
+    staged_path: pending
+    sources:
+      - path: kb/notes/definitions/software-house.md
+        source_commit: pending
+        source_blob: pending
+        live_path: kb/notes/definitions/software-house.md
+```
+
+Repeat the source path, source commit, source blob, live path, mode, and staged
+path for every component. The final build or review should fail when an exact
+snapshot's source content does not match its declared blob.
+
+## Provenance header
+
+Every appendix or independently released supplement should open with a compact
+header of this shape:
+
+> **Versioned argument snapshot.** This appendix is authoritative for *The
+> Reachability Conjecture*, version `<version>`. It is an `<exact snapshot / paper
+> adaptation>` of `<source paths>` at commit `<commit>`. The [live
+> version](<live link>) may contain later corrections or extensions and does not
+> silently change this paper version.
+
+For a multi-source adaptation, list all load-bearing live sources in a short
+source block rather than claiming one textual predecessor.
+
+## Live-successor status
+
+A future publication page or generated check may report one of:
+
+- unchanged since this paper version;
+- revised since this paper version;
+- materially revised;
+- superseded.
+
+This status is advisory navigation. The frozen appendix remains the historical
+authority until a new paper version is explicitly released.

--- a/kb/work/reachability-working-paper-publication/dependency-audit.md
+++ b/kb/work/reachability-working-paper-publication/dependency-audit.md
@@ -1,0 +1,83 @@
+# Reachability working-paper dependency audit
+
+## Test
+
+Read the candidate paper as if its hyperlinks were unavailable. For each
+linked artifact, ask whether a technically competent critic needs its contents
+to understand or assess a central definition, premise, derivation, protocol,
+qualification, or evidence claim.
+
+- **Package** means the necessary content must appear in the main body or a
+  versioned appendix.
+- **Summarize and link** means the body carries the load-bearing result and the
+  live artifact supplies fuller derivation or later development.
+- **Live link only** means the paper remains assessable without the artifact.
+- **Primary reference** means the paper should cite the external source
+  conventionally; the Commonplace ingest remains optional provenance.
+
+The current dispositions are staging decisions, not publication approval.
+
+## Current `source_notes` cohort
+
+| Source | Role in the paper | Initial disposition | Reason / required paper content |
+|---|---|---|---|
+| `kb/notes/definitions/software-house.md` | load-bearing definition and boundary | package in Appendix A | the paper's target and automated/human-inclusive distinction cannot be judged without the complete persistent producer, external-user, internal-role, scope, and horizon boundaries |
+| `kb/notes/definitions/representational-form.md` | load-bearing fixed/mutable-state distinction | package in Appendix A | the conjecture depends on distributed-parametric state staying fixed while natural-language and symbolic state can learn; only the needed form carve should be adapted |
+| `kb/notes/program-theory-sustains-search-under-delayed-feedback.md` | load-bearing bearer argument and causal test | summarize in body; adapt in Appendix B and C | the paper must carry theory-guided search, delayed contradiction, recovery, and withholding or wrong-theory interventions without requiring a click |
+| `kb/notes/naur-equates-machine-execution-with-formulated-criteria.md` | load-bearing reopening of Naur's human-only conclusion | package in Appendix B, snapshot or adaptation | the paper's theoretical possibility claim depends on separating formal execution from explicitly formulated criteria |
+| `kb/notes/naurs-compiler-case-tests-one-historically-bounded-documentation-and-consumption-system.md` | material evidence boundary | package in Appendix B, snapshot candidate | the paper must preserve both sides: ordinary extensive documentation failed, while newer representation and consumption paths were not tested |
+| `kb/notes/continual-learning-requires-governing-behaviour-changing-writes.md` | mechanism premise for semantic admission and credit assignment | summarize and link | the main body already states the required selection, validation, authorization, and coordination; the general continual-learning ontology need not be copied wholesale |
+| `kb/notes/a-bootstrap-fits-the-bitter-lesson-only-if-learning-outgrows-it.md` | material scaling qualification | summarize and link; keep fuller treatment outside this paper | the reachability paper needs the outgrowth condition and failure implication, while the dedicated Bitter Lesson paper owns the full argument |
+| `kb/notes/the-bitter-lesson-selects-production-methods-not-representational.md` | conceptual defense of learned localized state | summarize and link | the body must state production method versus representational form; the quadrant analysis and broader literature remain separate |
+| `kb/notes/theory-mediated-learning-may-improve-sample-efficiency-under-shifts.md` | stronger payoff and explicit-theory experiment | live link only after the body states the bounded hypothesis | sample efficiency is not required for the reachability conjecture; only the optional prediction and its costs belong in the paper |
+| `kb/notes/opacity-is-a-scale-threshold.md` | caveat to legibility | live link only after one body sentence | the paper already disclaims transparency; the full opacity argument is not needed to assess reachability |
+| `kb/notes/axes-of-artifact-analysis.md` | implementation and comparison ontology | summarize and link or omit from frozen package | useful for the research program's machinery map, but not necessary if the paper directly defines the mutable surfaces and causal consumption requirement |
+| `kb/notes/code-complements-weight-prompt-with-symbolic-operations.md` | implementation rationale for symbolic state | live link only | the main paper's core claim does not depend on the full weight–prompt versus runtime derivation |
+| `kb/notes/scheduler-llm-separation-exploits-an-error-correction-asymmetry.md` | implementation rationale for symbolic bookkeeping | live link only | a useful design argument, not a necessary premise of existential reachability |
+| `kb/notes/goedel-machines-are-a-proof-governed-case-of-self-modification.md` | formal comparison | summarize in body and Appendix E; cite primary source | the paper needs the proof-gated contrast and its limits, not the complete note's wider comparison portfolio |
+| `kb/notes/an-open-domain-theory-builder-becomes-a-software-house-when-new-domains-require-production-machinery-changes.md` | optional extension | live link only | the main paper explicitly does not depend on this separate conjecture |
+| `kb/sources/programming-as-theory-building.ingest.md` | source analysis and quote locations | primary reference; provenance link optional | Appendix B and the paper bibliography should cite Naur directly with page or section locations |
+| `kb/sources/goedel-machines-schmidhuber.ingest.md` | source analysis and quote locations | primary reference; provenance link optional | Appendix E and the paper bibliography should cite Schmidhuber directly rather than relying on the ingest as the scholarly endpoint |
+
+## Article and supplement dependencies outside `source_notes`
+
+| Source | Role | Initial disposition | Remaining decision |
+|---|---|---|---|
+| `kb/articles/nearest-existing-constructions-to-a-reachability-witness.md` | evidence map and full protocols | package as Appendix D or versioned supplement; protocol core becomes Appendix C | decide whether one-document length remains manageable and freeze every system placement against its evidence basis |
+| `kb/articles/reachability-as-closure-under-the-seed-gate.md` | transition-reachability derivation | package as Appendix E after PR #179 | confirm the corrected successor-relation treatment and settle probability evidence in Appendix C |
+| `kb/articles/the-bitter-lesson-does-not-require-everything-to-live-in-weights.md` | separate companion argument | cite as separate live or versioned paper, not appendix | decide whether it is promoted alongside the reachability paper or remains a draft dependency with the main paper carrying its own minimal qualification |
+| `kb/articles/the-decisions-that-stay-human-and-what-would-move-them.md` | separate boundary and transfer argument | optional companion link | the reachability paper already carries the internal-role boundary needed for its claim |
+
+## Main-body completeness checklist
+
+The main body, without following links, must let a reader state:
+
+1. the exact fixed-parametric-state reachability conjecture and its declared
+   scope, horizon, input process, and resource envelope;
+2. what a software house and an automated software house include and exclude;
+3. why open-ended coherent modification is argued to require a
+   project-theory function;
+4. why Naur's human-only inference and documentation evidence do not settle the
+   current computational question in advance;
+5. how fixed models, natural-language state, and symbolic state divide the
+   work;
+6. what counts as learning by the house rather than ordinary product
+   continuity;
+7. the four carrier-neutral witness obligations;
+8. why explicit retained theory is a stronger mechanism hypothesis with raw
+   records or direct artifact search as baselines;
+9. what the nearest-constructions review establishes and what it does not;
+10. why practical usefulness, automated continuation, and Bitter-Lesson-compatible
+    scaling remain separate achievements.
+
+## Appendix-closure rule
+
+An appendix may link to a live note for later developments without importing
+that note's full dependency graph. The appendix must carry every proposition
+needed for its own paper function. Links from a frozen appendix to optional
+examples, supporting derivations, or newer evidence remain navigation, not
+historical authority.
+
+A dependency is not discharged merely because the paper lists it in
+`source_notes`. Discharge requires the main body or frozen appendix to state the
+needed content at the scope and confidence the paper uses.

--- a/kb/work/reachability-working-paper-publication/staging/README.md
+++ b/kb/work/reachability-working-paper-publication/staging/README.md
@@ -1,0 +1,75 @@
+# Reachability working-paper staging area
+
+This directory will hold candidate paper appendices and assembly artifacts while
+the working-paper package is being prepared. Nothing here is authoritative or
+published merely because it has been copied into the workshop.
+
+## Planned files
+
+```text
+appendix-a-definitions-and-boundary.md
+appendix-b-program-theory-and-naur.md
+appendix-c-witness-protocols.md
+appendix-d-nearest-constructions.md
+appendix-e-transition-reachability.md
+references.md
+release-manifest.yml
+```
+
+Create these files only when their source cohort or paper-native role is clear.
+Do not copy every candidate note pre-emptively.
+
+## Staging rules
+
+1. **Select before copying.** The dependency audit must say why the component is
+   load-bearing and whether it is a snapshot, adaptation, or paper-native.
+2. **Freeze exact snapshots mechanically.** Generate them from the declared
+   source commit. Allowed transformations are frontmatter removal, heading
+   normalization, link rewriting, citation-format conversion, and insertion of
+   the provenance header. Do not edit their substantive text here.
+3. **Edit adaptations explicitly.** A paper adaptation names all load-bearing
+   source artifacts and is reviewed against them. It does not claim byte or
+   wording identity.
+4. **Keep historical and live authority separate.** The staged appendix is the
+   candidate historical argument; its live link is for later developments.
+5. **Use direct external references.** A source ingest may remain linked for
+   provenance, but the staged appendix cites the primary paper, essay,
+   practitioner account, or inspected repository directly.
+6. **No hidden recursive dependencies.** A staged appendix must contain the
+   propositions needed for its paper role. Its outbound live links may deepen or
+   update the argument but cannot be necessary to recover what the released
+   paper meant.
+7. **No workshop links at release.** The public package must not point into
+   `kb/work/`. Final appendix locations and stable links are chosen before
+   publication.
+
+## Candidate provenance block
+
+Use this while staging:
+
+```text
+Versioned argument snapshot for: The Reachability Conjecture
+Paper version: pending
+Mode: exact snapshot | paper adaptation | paper-native
+Frozen source commit: pending
+Source paths: ...
+Live successors: ...
+Status: staging — not published
+```
+
+At release, replace every `pending` value and convert this into the reader-facing
+header specified by the artifact manifest.
+
+## Assembly check
+
+Before a staged package can leave this workshop:
+
+- all source commits and modes are recorded;
+- exact snapshots reproduce their source blobs after allowed transformations;
+- adaptations have source-comparison review;
+- the main paper remains coherent with links disabled;
+- every load-bearing dependency is discharged by the body or appendices;
+- appendices contain direct scholarly references;
+- all placeholders and workshop-only links are gone;
+- the user has explicitly approved the complete body and the `working-paper`
+  lifecycle transition.


### PR DESCRIPTION
## Summary

Create `kb/work/reachability-working-paper-publication/` to stage the reachability conjecture as a versioned working-paper package.

The workshop establishes the publication rule that frozen appendices are authoritative for the paper version while linked live notes carry later project developments. It adds:

- an artifact manifest distinguishing exact snapshots, paper adaptations, and paper-native content;
- a dependency audit deciding which current notes must enter the versioned package and which remain live links;
- an appendix plan covering definitions, Naur and program theory, witness protocols, nearest constructions, transition reachability, and references;
- a staging boundary with provenance and release checks;
- explicit gaps for practical reachability, demand generation, hitting probability, continuation reliability, run accounting, direct citations, and live-note freshness.

The workshop does not promote the article or authorize publication. It requires explicit later approval naming `working-paper` and follows the existing publication instruction.

PR #179 supplies the corrected transition-reachability input and is tracked as a prerequisite to freezing the source cohort.